### PR TITLE
Use separate build directory for building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ qrc_*.cpp
 ui_*.h
 Makefile.*
 *~
-
+/build/

--- a/README.txt
+++ b/README.txt
@@ -17,14 +17,15 @@ Compilation on Ubuntu/Debian
 
 3 - compile
 
-   # cd trunk
-   # qmake CONFIG=debug
+   # mkdir build
+   # cd build
+   # qmake CONFIG=debug ../trunk
    # make
 
    => the executables produced will be 
 
-         trunk/retroshare-gui/src/Retroshare
-         trunk/retroshare-nogui/src/retroshare-nogui
+         build/retroshare-gui/src/Retroshare
+         build/retroshare-nogui/src/retroshare-nogui
 
 If libsqlcipher is not available as a package:
 =============================================
@@ -67,5 +68,3 @@ Using retroshare-nogui & webUI
       http://localhost:9090
 
    That also works with a retroshare GUI of course.
-
-


### PR DESCRIPTION
qmake supports out of directory builds. That way all generated files are contained in a single build directory and not mixed with the source code.

This also allows to have multiple build directories, e.g. buildDebug and buildRelease.
