### PR TITLE
Store lobby history on disk

### DIFF
--- a/libretroshare/src/pqi/p3historymgr.cc
+++ b/libretroshare/src/pqi/p3historymgr.cc
@@ -115,11 +115,6 @@ void p3HistoryMgr::addMessage(const ChatMessage& cm)
         item->sendTime = cm.sendTime;
         item->recvTime = cm.recvTime;
 
-        if (cm.chat_id.isLobbyId()) {
-			// disable save to disc for chat lobbies until they are saved
-			item->saveToDisc = false;
-		}
-
         item->message = cm.msg ;
 		//librs::util::ConvertUtf16ToUtf8(chatItem->message, item->message);
 

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -321,8 +321,21 @@ void ChatWidget::init(const ChatId &chat_id, const QString &title)
                 // it can happen that a message is first added to the message history
                 // and later the gui receives the message through notify
                 // avoid this by not adding history entries if their age is < 2secs
-                if((time(NULL)-2) > historyIt->recvTime)
-                    addChatMsg(historyIt->incoming, QString::fromUtf8(historyIt->peerName.c_str()), QDateTime::fromTime_t(historyIt->sendTime), QDateTime::fromTime_t(historyIt->recvTime), QString::fromUtf8(historyIt->message.c_str()), MSGTYPE_HISTORY);
+                if ((time(NULL)-2) <= historyIt->recvTime)
+                    continue;
+
+                QString name;
+                if (chatId.isLobbyId()) {
+                    RsIdentityDetails details;
+                    if (rsIdentity->getIdDetails(RsGxsId(historyIt->peerName), details))
+                        name = QString::fromUtf8(details.mNickname.c_str());
+                    else
+                        name = QString::fromUtf8(historyIt->peerName.c_str());
+                } else {
+                    name = QString::fromUtf8(historyIt->peerName.c_str());
+                }
+
+                addChatMsg(historyIt->incoming, name, QDateTime::fromTime_t(historyIt->sendTime), QDateTime::fromTime_t(historyIt->recvTime), QString::fromUtf8(historyIt->message.c_str()), MSGTYPE_HISTORY);
             }
 		}
 	}

--- a/retroshare-gui/src/gui/im_history/ImHistoryBrowser.cpp
+++ b/retroshare-gui/src/gui/im_history/ImHistoryBrowser.cpp
@@ -36,6 +36,7 @@
 
 #include "rshare.h"
 #include <retroshare/rshistory.h>
+#include <retroshare/rsidentity.h>
 #include "gui/settings/rsharesettings.h"
 #include "gui/notifyqt.h"
 
@@ -272,7 +273,19 @@ void ImHistoryBrowser::fillItem(QListWidgetItem *itemWidget, HistoryMsg& msg)
     }
 
     QString messageText = RsHtml().formatText(NULL, QString::fromUtf8(msg.message.c_str()), formatTextFlag);
-    QString formatMsg = style.formatMessage(type, QString::fromUtf8(msg.peerName.c_str()), QDateTime::fromTime_t(msg.sendTime), messageText);
+
+    QString name;
+    if (m_chatId.isLobbyId()) {
+        RsIdentityDetails details;
+        if (rsIdentity->getIdDetails(RsGxsId(msg.peerName), details))
+            name = QString::fromUtf8(details.mNickname.c_str());
+        else
+            name = QString::fromUtf8(msg.peerName.c_str());
+    } else {
+        name = QString::fromUtf8(msg.peerName.c_str());
+    }
+
+    QString formatMsg = style.formatMessage(type, name, QDateTime::fromTime_t(msg.sendTime), messageText);
 
     itemWidget->setData(Qt::DisplayRole, qVariantFromValue(IMHistoryItemPainter(formatMsg)));
     itemWidget->setData(ROLE_MSGID, msg.msgId);


### PR DESCRIPTION
RS didn't store the lobby history on disk, so it was unavailable after a restart.
This seems to have been intentional, however after removing the appropriate if clause, saving the history works without problems.
The only thing is that, the history can only be accessed after rereceiving the lobby id from another node and joining it. But that’s another issue, that lobbies are not saved.

The second commit adds resolving of nicks from the gxsid, when restoring the chat lobby history or viewing it in the history browser.
