### PR TITLE
enable customisation of columns in forum thread widget

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -206,6 +206,7 @@ GxsForumThreadWidget::GxsForumThreadWidget(const RsGxsGroupId &forumId, QWidget 
     ui->subscribeToolButton->setToolTip(tr("<p>Subscribing to the forum will gather \
                                            available posts from your subscribed friends, and make the \
                                            forum visible to all other friends.</p><p>Afterwards you can unsubscribe from the context menu of the forum list at left.</p>"));
+    ui->threadTreeWidget->enableColumnCustomize(true);
 }
 
 GxsForumThreadWidget::~GxsForumThreadWidget()


### PR DESCRIPTION
One line to allow hiding headers in forum. This is the first step towards voting in forums - making it easy to hide columns you are not interested in.
