### PR TITLE
Qmake improvements

### DIFF
--- a/RetroShare.pro
+++ b/RetroShare.pro
@@ -1,16 +1,35 @@
 TEMPLATE = subdirs
 
-CONFIG += ordered
-
 SUBDIRS += \
-        openpgpsdk/src/openpgpsdk.pro \
-        supportlibs/pegmarkdown/pegmarkdown.pro \
-        libbitdht/src/libbitdht.pro \
-        libretroshare/src/libretroshare.pro \
-		libresapi/src/libresapi.pro	\
-        retroshare-gui/src/retroshare-gui.pro \
-        retroshare-nogui/src/retroshare-nogui.pro \
-        plugins/plugins.pro
+        openpgpsdk \
+        libbitdht \
+        libretroshare \
+        libresapi \
+        pegmarkdown \
+        retroshare_gui \
+        retroshare_nogui \
+        plugins
+
+openpgpsdk.file = openpgpsdk/src/openpgpsdk.pro
+
+libbitdht.file = libbitdht/src/libbitdht.pro
+
+libretroshare.file = libretroshare/src/libretroshare.pro
+libretroshare.depends = openpgpsdk libbitdht
+
+libresapi.file = libresapi/src/libresapi.pro
+libresapi.depends = libretroshare
+
+pegmarkdown.file = supportlibs/pegmarkdown/pegmarkdown.pro
+
+retroshare_gui.file = retroshare-gui/src/retroshare-gui.pro
+retroshare_gui.depends = libretroshare libresapi pegmarkdown
+
+retroshare_nogui.file = retroshare-nogui/src/retroshare-nogui.pro
+retroshare_nogui.depends = libretroshare libresapi
+
+plugins.file = plugins/plugins.pro
+plugins.depends = retroshare_gui
 
 unix {
 	isEmpty(PREFIX)   { PREFIX = /usr }

--- a/plugins/Common/retroshare_plugin.pri
+++ b/plugins/Common/retroshare_plugin.pri
@@ -1,4 +1,5 @@
 TEMPLATE = lib
+CONFIG *= plugin
 
 DEPENDPATH += ../../libretroshare/src/ ../../retroshare-gui/src/
 INCLUDEPATH += ../../libretroshare/src/ ../../retroshare-gui/src/

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -122,7 +122,6 @@ win32 {
 	INCLUDEPATH += $$LIBS_DIR/include
 
 	gxs {
-		LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 		LIBS += -lsqlcipher
 	}
 }


### PR DESCRIPTION
This PR makes a few improvements to the qmake .pro files. The main one is the removal of CONFIG += ordered and replacing it with explicit dependencies. This makes inter-dependencies clearer and allows slightly faster builds on multi-core systems, by building independent parts (e.g.: libbitdht, openpgpsdk and pegmarkdown) in parallel.
For the other two changes see the commit messages.
