### PR TITLE
Qt5 fix

### DIFF
--- a/retroshare-gui/src/gui/AboutDialog.cpp
+++ b/retroshare-gui/src/gui/AboutDialog.cpp
@@ -761,13 +761,13 @@ void AboutDialog::on_copy_button_clicked()
 		verInfo+=QSysInfo::prettyProductName();
 	#endif
 #else
-	#ifdef Q_WS_X11
+	#ifdef Q_OS_LINUX
 	verInfo+="Linux";
 	#endif
-	#ifdef Q_WS_WIN
+	#ifdef Q_OS_WIN
 	verInfo+="Windows";
 	#endif
-	#ifdef Q_WS_MACX
+	#ifdef Q_OS_MAC
 	verInfo+="Mac";
 	#endif
 #endif

--- a/retroshare-gui/src/gui/GetStartedDialog.cpp
+++ b/retroshare-gui/src/gui/GetStartedDialog.cpp
@@ -189,7 +189,7 @@ void GetStartedDialog::tickFirewallChanged()
 static void sendMail(const QString &address, const QString &subject, QString body)
 {
 	/* Only under windows do we need to do this! */
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 	/* search and replace the end of lines with: "%0D%0A" */
 	body.replace("\n", "%0D%0A");
 #endif
@@ -343,7 +343,7 @@ void GetStartedDialog::emailSupport()
 
 #ifdef __APPLE__
 
-  #ifdef Q_WS_MAC
+  #ifdef Q_OS_MAC
 	switch(QSysInfo::MacintoshVersion)
 	{
 		case QSysInfo::MV_9: 
@@ -383,7 +383,7 @@ void GetStartedDialog::emailSupport()
 #else
   #if defined(_WIN32) || defined(__MINGW32__)
 	// Windows
-	#ifdef Q_WS_WIN
+	#ifdef Q_OS_WIN
 	switch(QSysInfo::windowsVersion())
 	{
 		case QSysInfo::WV_32s: 

--- a/retroshare-gui/src/gui/NetworkDialog.cpp
+++ b/retroshare-gui/src/gui/NetworkDialog.cpp
@@ -169,10 +169,6 @@ NetworkDialog::NetworkDialog(QWidget *parent)
     //updateNetworkStatus();
     //loadtabsettings();
     
-  /* Hide platform specific features */
-#ifdef Q_WS_WIN
-
-#endif
 }
 
 void NetworkDialog::changeEvent(QEvent *e)

--- a/retroshare-gui/src/gui/PhotoShare/PhotoDialog.cpp
+++ b/retroshare-gui/src/gui/PhotoShare/PhotoDialog.cpp
@@ -220,7 +220,7 @@ void PhotoDialog::setFullScreen()
   if (!isFullScreen()) {
     // hide menu & toolbars
 
-#ifdef Q_WS_X11
+#ifdef Q_OS_LINUX
     show();
     raise();
     setWindowState( windowState() | Qt::WindowFullScreen );

--- a/retroshare-gui/src/gui/PhotoShare/PhotoSlideShow.cpp
+++ b/retroshare-gui/src/gui/PhotoShare/PhotoSlideShow.cpp
@@ -299,7 +299,7 @@ void PhotoSlideShow::setFullScreen()
   if (!isFullScreen()) {
     // hide menu & toolbars
 
-#ifdef Q_WS_X11
+#ifdef Q_OS_LINUX
     show();
     raise();
     setWindowState( windowState() | Qt::WindowFullScreen );

--- a/retroshare-gui/src/gui/QuickStartWizard.cpp
+++ b/retroshare-gui/src/gui/QuickStartWizard.cpp
@@ -66,7 +66,7 @@ QuickStartWizard::QuickStartWizard(QWidget *parent) :
     ui.shareddirList->horizontalHeader()->setStretchLastSection(false);
 	  
   /* Hide platform specific features */
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
   ui.checkBoxRunRetroshareAtSystemStartup->setVisible(false);
   ui.chkRunRetroshareAtSystemStartupMinimized->setVisible(false);
 #endif
@@ -192,7 +192,7 @@ void QuickStartWizard::on_pushButtonSystemFinish_clicked()
 {
   Settings->setStartMinimized(ui.checkBoxStartMinimized->isChecked());
   Settings->setValue("doQuit", ui.checkBoxQuit->isChecked());
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   Settings->setRunRetroshareOnBoot(ui.checkBoxRunRetroshareAtSystemStartup->isChecked(), ui.chkRunRetroshareAtSystemStartupMinimized->isChecked());
 #endif
 
@@ -381,7 +381,7 @@ bool QuickStartWizard::messageBoxOk(QString msg)
 void
 QuickStartWizard::loadGeneral()
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   bool minimized;
   ui.checkBoxRunRetroshareAtSystemStartup->setChecked(Settings->runRetroshareOnBoot(minimized));
   ui.chkRunRetroshareAtSystemStartupMinimized->setChecked(minimized);

--- a/retroshare-gui/src/gui/SearchDialog.cpp
+++ b/retroshare-gui/src/gui/SearchDialog.cpp
@@ -213,10 +213,6 @@ SearchDialog::SearchDialog(QWidget *parent)
 
     checkText(ui.lineEdit->text());
 
-/* Hide platform specific features */
-#ifdef Q_WS_WIN
-
-#endif
 }
 
 SearchDialog::~SearchDialog()

--- a/retroshare-gui/src/gui/common/Emoticons.cpp
+++ b/retroshare-gui/src/gui/common/Emoticons.cpp
@@ -40,7 +40,7 @@ void Emoticons::load()
     QString sm_codes;
     bool internalEmoticons = true;
 
-#if defined(Q_OS_WIN32)
+#if defined(Q_OS_WIN)
     // first try external emoticons
     QFile sm_file(QApplication::applicationDirPath() + "/emoticons/emotes.acs");
     if(sm_file.open(QIODevice::ReadOnly))

--- a/retroshare-gui/src/gui/common/RSGraphWidget.cpp
+++ b/retroshare-gui/src/gui/common/RSGraphWidget.cpp
@@ -518,7 +518,7 @@ void RSGraphWidget::paintTotals()
   int x = SCALE_WIDTH*fact + FS, y = 0;
   int rowHeight = FS;
 
-#if !defined(Q_WS_MAC)
+#if !defined(Q_OS_MAC)
   /* On Mac, we don't need vertical spacing between the text rows. */
   rowHeight += 5;
 #endif

--- a/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
+++ b/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
@@ -77,7 +77,7 @@ ConnectFriendWizard::ConnectFriendWizard(QWidget *parent) :
 	mTitleFontWeight = 0; // Standard
 
 // this define comes from Qt example. I don't have mac, so it wasn't tested
-#ifndef Q_WS_MAC
+#ifndef Q_OS_MAC
 	setWizardStyle(ModernStyle);
 #endif
 
@@ -568,7 +568,7 @@ void ConnectFriendWizard::initializePage(int id)
 
 static void sendMail(QString sAddress, QString sSubject, QString sBody)
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 	/* search and replace the end of lines with: "%0D%0A" */
 	sBody.replace("\n", "%0D%0A");
 #endif

--- a/retroshare-gui/src/gui/help/browser/helpbrowser.cpp
+++ b/retroshare-gui/src/gui/help/browser/helpbrowser.cpp
@@ -58,10 +58,10 @@ HelpBrowser::HelpBrowser(QWidget *parent)
 {
   /* Invoke Qt Designer generated QObject setup routine */
   ui.setupUi(this);
-#if defined(Q_WS_MAC)
+#if defined(Q_OS_MAC)
   ui.actionHome->setShortcut(QString("Shift+Ctrl+H"));
 #endif
-#if !defined(Q_WS_WIN)
+#if !defined(Q_OS_WIN)
   ui.actionClose->setShortcut(QString("Ctrl+W"));
 #endif
 

--- a/retroshare-gui/src/gui/settings/GeneralPage.cpp
+++ b/retroshare-gui/src/gui/settings/GeneralPage.cpp
@@ -42,7 +42,7 @@ GeneralPage::GeneralPage(QWidget * parent, Qt::WindowFlags flags)
     connect(ui.runStartWizard_PB,SIGNAL(clicked()), this,SLOT(runStartWizard())) ;
 
     /* Hide platform specific features */
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 
 #ifdef QT_DEBUG
     ui.chkRunRetroshareAtSystemStartup->setEnabled(false);
@@ -79,7 +79,7 @@ bool GeneralPage::save(QString &/*errmsg*/)
   Settings->setValue("doQuit", ui.checkQuit->isChecked());
   Settings->setCloseToTray(ui.checkCloseToTray->isChecked());
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 
 #ifndef QT_DEBUG
   Settings->setRunRetroshareOnBoot(ui.chkRunRetroshareAtSystemStartup->isChecked(), ui.chkRunRetroshareAtSystemStartupMinimized->isChecked());
@@ -117,7 +117,7 @@ bool GeneralPage::save(QString &/*errmsg*/)
 /** Loads the settings for this page */
 void GeneralPage::load()
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   bool minimized;
   ui.chkRunRetroshareAtSystemStartup->setChecked(Settings->runRetroshareOnBoot(minimized));
   ui.chkRunRetroshareAtSystemStartupMinimized->setChecked(minimized);

--- a/retroshare-gui/src/gui/settings/rsharesettings.cpp
+++ b/retroshare-gui/src/gui/settings/rsharesettings.cpp
@@ -33,7 +33,7 @@
 #include <retroshare/rsnotify.h>
 #include <retroshare/rspeers.h>
 
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 #include <util/win32.h>
 #endif
 
@@ -60,7 +60,7 @@
 /* Default Retroshare Settings */
 #define DEFAULT_OPACITY             100
 
-#if defined(Q_OS_WIN32)
+#if defined(Q_OS_WIN)
 #define STARTUP_REG_KEY        "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
 #define RETROSHARE_REG_KEY         "RetroShare" 
 #endif
@@ -104,11 +104,11 @@ void RshareSettings::initSettings()
 	// use GTK as default style on ubuntu
 	setDefault(SETTING_STYLE, "GTK+");
 #else
-#if defined(Q_WS_MAC)
+#if defined(Q_OS_MAC)
 	setDefault(SETTING_STYLE, "macintosh (aqua)");
 #else
 	static QStringList styles = QStyleFactory::keys();
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 	if (styles.contains("windowsvista", Qt::CaseInsensitive))
 		setDefault(SETTING_STYLE, "windowsvista");
 	else if (styles.contains("windowsxp", Qt::CaseInsensitive))
@@ -710,7 +710,7 @@ RshareSettings::runRetroshareOnBoot(bool &minimized)
 {
 	minimized = false;
 
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 	QString value = win32_registry_get_key_value(STARTUP_REG_KEY, RETROSHARE_REG_KEY);
 
 	if (!value.isEmpty()) {
@@ -729,9 +729,9 @@ RshareSettings::runRetroshareOnBoot(bool &minimized)
 void
 RshareSettings::setRunRetroshareOnBoot(bool run, bool minimized)
 {
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 	if (run) {
-		QString value = "\"" + QDir::convertSeparators(QCoreApplication::applicationFilePath()) + "\"";
+		QString value = "\"" + QDir::toNativeSeparators(QCoreApplication::applicationFilePath()) + "\"";
 
 		if (minimized) {
 			value += " -m";
@@ -748,17 +748,17 @@ RshareSettings::setRunRetroshareOnBoot(bool run, bool minimized)
 #endif
 }
 
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 static QString getAppPathForProtocol()
 {
-	return "\"" + QDir::convertSeparators(QCoreApplication::applicationFilePath()) + "\" -r \"%1\"";
+	return "\"" + QDir::toNativeSeparators(QCoreApplication::applicationFilePath()) + "\" -r \"%1\"";
 }
 #endif
 
 /** Returns true if retroshare:// is registered as protocol */
 bool RshareSettings::getRetroShareProtocol()
 {
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 	/* Check key */
 	QSettings retroshare("HKEY_CLASSES_ROOT\\retroshare", QSettings::NativeFormat);
 	if (retroshare.contains("Default")) {
@@ -780,7 +780,7 @@ bool RshareSettings::getRetroShareProtocol()
 /** Returns true if the user can set retroshare as protocol */
 bool RshareSettings::canSetRetroShareProtocol()
 {
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 	QSettings retroshare("HKEY_CLASSES_ROOT\\retroshare", QSettings::NativeFormat);
 	return retroshare.isWritable();
 #else
@@ -791,7 +791,7 @@ bool RshareSettings::canSetRetroShareProtocol()
 /** Register retroshare:// as protocol */
 bool RshareSettings::setRetroShareProtocol(bool value)
 {
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 	if (value) {
 		QSettings retroshare("HKEY_CLASSES_ROOT\\retroshare", QSettings::NativeFormat);
 		retroshare.setValue("Default", "URL: RetroShare protocol");

--- a/retroshare-gui/src/gui/statistics/BandwidthGraphWindow.cpp
+++ b/retroshare-gui/src/gui/statistics/BandwidthGraphWindow.cpp
@@ -57,7 +57,7 @@ BandwidthGraph::BandwidthGraph(QWidget *parent, Qt::WindowFlags flags)
 {
   /* Invoke Qt Designer generated QObject setup routine */
   ui.setupUi(this);
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
   setShortcut("Esc", SLOT(close()));
 #else
   setShortcut("Ctrl+W", SLOT(close()));
@@ -78,13 +78,13 @@ BandwidthGraph::BandwidthGraph(QWidget *parent, Qt::WindowFlags flags)
   loadSettings();
 
    /* Turn off opacity group on unsupported platforms */
- #if defined(Q_WS_WIN)
+ #if defined(Q_OS_WIN)
    if(!(QSysInfo::WV_2000 <= QSysInfo::WindowsVersion && QSysInfo::WindowsVersion <= QSysInfo::WV_2003)) {
      ui.frmOpacity->setVisible(false);
    }
  #endif
 
- #if defined(Q_WS_X11)
+ #if defined(Q_OS_LINUX)
    ui.frmOpacity->setVisible(false);
  #endif
 }
@@ -236,10 +236,10 @@ void BandwidthGraph::setOpacity(int value)
   qreal newValue = value / 100.0;
   
   /* Opacity only supported by Mac and Win32 */
-#if defined(Q_WS_MAC)
+#if defined(Q_OS_MAC)
   this->setWindowOpacity(newValue);
   ui.lblPercentOpacity->setText(QString::number(value));
-#elif defined(Q_WS_WIN)
+#elif defined(Q_OS_WIN)
   if(QSysInfo::WV_2000 <= QSysInfo::WindowsVersion && QSysInfo::WindowsVersion <= QSysInfo::WV_2003) {
     this->setWindowOpacity(newValue);
     ui.lblPercentOpacity->setText(QString::number(value));

--- a/retroshare-gui/src/gui/statistics/BandwidthGraphWindow.cpp
+++ b/retroshare-gui/src/gui/statistics/BandwidthGraphWindow.cpp
@@ -79,7 +79,7 @@ BandwidthGraph::BandwidthGraph(QWidget *parent, Qt::WindowFlags flags)
 
    /* Turn off opacity group on unsupported platforms */
  #if defined(Q_OS_WIN)
-   if(!(QSysInfo::WV_2000 <= QSysInfo::WindowsVersion && QSysInfo::WindowsVersion <= QSysInfo::WV_2003)) {
+   if(!(QSysInfo::WV_2000 <= QSysInfo::WindowsVersion)) {
      ui.frmOpacity->setVisible(false);
    }
  #endif
@@ -240,7 +240,7 @@ void BandwidthGraph::setOpacity(int value)
   this->setWindowOpacity(newValue);
   ui.lblPercentOpacity->setText(QString::number(value));
 #elif defined(Q_OS_WIN)
-  if(QSysInfo::WV_2000 <= QSysInfo::WindowsVersion && QSysInfo::WindowsVersion <= QSysInfo::WV_2003) {
+  if(QSysInfo::WV_2000 <= QSysInfo::WindowsVersion) {
     this->setWindowOpacity(newValue);
     ui.lblPercentOpacity->setText(QString::number(value));
   }

--- a/retroshare-gui/src/rshare.cpp
+++ b/retroshare-gui/src/rshare.cpp
@@ -613,7 +613,7 @@ Rshare::dataDirectory()
 QString
 Rshare::defaultDataDirectory()
 {
-#if defined(Q_OS_WIN32)
+#if defined(Q_OS_WIN)
   return (win32_app_data_folder() + "\\RetroShare");
 #else
   return (QDir::homePath() + "/.RetroShare");

--- a/retroshare-gui/src/util/printpreview.cpp
+++ b/retroshare-gui/src/util/printpreview.cpp
@@ -54,7 +54,7 @@
 #include <QPageSetupDialog>
 #include <QStatusBar>
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
 const QString rsrcPath = ":/images/mac";
 #else
 const QString rsrcPath = ":/images/win";


### PR DESCRIPTION
Some functions were missing on Options-->General dialog under Windows with Qt5, because Q_WS_ macros are not supported. I replaced them with Q_OS_ macros that are supported by both Qt 4 and 5.

I replaced the macros for OSX and Linux too, but I could test it only on Windows.

Also I've found some unnecessary limitations on BandwidthGraphWindow.
