### PR TITLE
Remove lobby gui lag

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -671,7 +671,7 @@ void ChatLobbyDialog::displayLobbyEvent(int event_type, const RsGxsId& gxs_id, c
 
         ui.chatWidget->addChatMsg(true, tr("Lobby management"), QDateTime::currentDateTime(),
                                   QDateTime::currentDateTime(),
-                                  tr("%1 changed his name to: %2").arg(name).arg(newname),
+                                  tr("%1 changed his name to: %2").arg(RsHtml::plainText(name)).arg(RsHtml::plainText(newname)),
                                   ChatWidget::MSGTYPE_SYSTEM);
 
         // TODO if a user was muted and changed his name, update mute list, but only, when the muted peer, dont change his name to a other peer in your chat lobby

--- a/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
@@ -28,6 +28,7 @@
 #include "gui/settings/rsharesettings.h"
 #include "util/DateTime.h"
 #include <retroshare/rsidentity.h>
+#include <util/HandleRichText.h>
 
 ChatLobbyUserNotify::ChatLobbyUserNotify(QObject *parent) :
     UserNotify(parent)
@@ -258,7 +259,7 @@ void ChatLobbyUserNotify::chatLobbyNewMessage(ChatLobbyId lobby_id, QDateTime ti
 	if ((bGetNickName || bFoundTextToNotify || _bCountUnRead)){
 		QString strAnchor = time.toString(Qt::ISODate);
 		MsgData msgData;
-		msgData.text=senderName + ": " + msg;
+		msgData.text=RsHtml::plainText(senderName) + ": " + msg;
 		msgData.unread=!(bGetNickName || bFoundTextToNotify);
 
 		_listMsg[lobby_id][strAnchor]=msgData;

--- a/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
@@ -257,9 +257,8 @@ void ChatLobbyUserNotify::chatLobbyNewMessage(ChatLobbyId lobby_id, QDateTime ti
 
 	if ((bGetNickName || bFoundTextToNotify || _bCountUnRead)){
 		QString strAnchor = time.toString(Qt::ISODate);
-		strAnchor.append("_").append(senderName);
 		MsgData msgData;
-		msgData.text=msg;
+		msgData.text=senderName + ": " + msg;
 		msgData.unread=!(bGetNickName || bFoundTextToNotify);
 
 		_listMsg[lobby_id][strAnchor]=msgData;

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -902,7 +902,7 @@ void ChatWidget::addChatMsg(bool incoming, const QString &name, const QDateTime 
 	QString formatMsg = chatStyle.formatMessage(type, name, dtTimestamp, formattedMessage, formatFlag);
 	QString timeStamp = dtTimestamp.toString(Qt::ISODate);
 
-	formatMsg.prepend(QString("<a name=\"%1_%2\"/>").arg(timeStamp).arg(name));
+	formatMsg.prepend(QString("<a name=\"%1\"/>").arg(timeStamp));
 	//To call this anchor do:    ui->textBrowser->scrollToAnchor(QString("%1_%2").arg(timeStamp).arg(name));
 	QTextCursor textCursor = QTextCursor(ui->textBrowser->textCursor());
 	textCursor.movePosition(QTextCursor::End);

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -448,7 +448,7 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 			}
 		}
 
-		if (chatType() == CHATTYPE_LOBBY) {
+		if (notify && chatType() == CHATTYPE_LOBBY) {
 			if ((event->type() == QEvent::KeyPress)
 			    || (event->type() == QEvent::MouseMove)
 			    || (event->type() == QEvent::Enter)
@@ -460,9 +460,11 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 				QPoint bottom_right(ui->textBrowser->viewport()->width() - 1, ui->textBrowser->viewport()->height() - 1);
 				int end_pos = ui->textBrowser->cursorForPosition(bottom_right).position();
 				cursor.setPosition(end_pos, QTextCursor::KeepAnchor);
-
-				if (!cursor.selectedText().isEmpty()){
-					QRegExp rx("<a\\s+name\\s*=\\s*\"(.*)\"",Qt::CaseInsensitive, QRegExp::RegExp2);
+				if ((cursor.position() != lastUpdateCursorPos || cursor.selectionEnd() != lastUpdateCursorEnd) &&
+				   !cursor.selectedText().isEmpty()) {
+					lastUpdateCursorPos = cursor.position();
+					lastUpdateCursorEnd = cursor.selectionEnd();
+					QRegExp rx("<a name=\"(.*)\"",Qt::CaseSensitive, QRegExp::RegExp2);
 					rx.setMinimal(true);
 					QString sel=cursor.selection().toHtml();
 					QStringList anchors;
@@ -473,13 +475,9 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 					}
 					if (!anchors.isEmpty()){
 						for (QStringList::iterator it=anchors.begin();it!=anchors.end();++it) {
-							QByteArray bytArray=it->toUtf8();
-							std::string stdString=std::string(bytArray.begin(),bytArray.end());
-							if (notify) notify->chatLobbyCleared(chatId.toLobbyId()
-							                                     ,QString::fromUtf8(stdString.c_str())
-							                                     ,obj != ui->textBrowser && obj != ui->textBrowser->viewport());//, true);
+							notify->chatLobbyCleared(chatId.toLobbyId(), *it);
 						}
-	}
+					}
 				}
 			}
 		}
@@ -490,11 +488,11 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 
             QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
             if (keyEvent) {
-                if (keyEvent->key() == Qt::Key_Delete ) {
+                if (notify && keyEvent->key() == Qt::Key_Delete) {
 					// Delete key pressed
 					if (ui->textBrowser->textCursor().selectedText().length() > 0) {
 						if (chatType() == CHATTYPE_LOBBY) {
-							QRegExp rx("<a\\s+name\\s*=\\s*\"(.*)\"",Qt::CaseInsensitive, QRegExp::RegExp2);
+							QRegExp rx("<a name=\"(.*)\"",Qt::CaseSensitive, QRegExp::RegExp2);
 							rx.setMinimal(true);
 							QString sel=ui->textBrowser->textCursor().selection().toHtml();
 							QStringList anchors;
@@ -505,9 +503,7 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 							}
 
 							for (QStringList::iterator it=anchors.begin();it!=anchors.end();++it) {
-								QByteArray bytArray=it->toUtf8();
-								std::string stdString=std::string(bytArray.begin(),bytArray.end());
-								if (notify) notify->chatLobbyCleared(chatId.toLobbyId(), QString::fromUtf8(stdString.c_str()));
+								notify->chatLobbyCleared(chatId.toLobbyId(), *it);
 							}
 
 						}
@@ -529,7 +525,7 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 			cursor.select(QTextCursor::WordUnderCursor);
 			QString toolTipText = "";
 			if (!cursor.selectedText().isEmpty()){
-				QRegExp rx("<a\\s+name\\s*=\\s*\"(.*)\"",Qt::CaseInsensitive, QRegExp::RegExp2);
+				QRegExp rx("<a name=\"(.*)\"",Qt::CaseSensitive, QRegExp::RegExp2);
 				rx.setMinimal(true);
 				QString sel=cursor.selection().toHtml();
 				QStringList anchors;

--- a/retroshare-gui/src/gui/chat/ChatWidget.h
+++ b/retroshare-gui/src/gui/chat/ChatWidget.h
@@ -238,6 +238,9 @@ private:
 
 	QTextCursor qtcMark;
 
+	int lastUpdateCursorPos;
+	int lastUpdateCursorEnd;
+
 	TransferRequestFlags mDefaultExtraFileFlags ; // flags for extra files shared in this chat. Will be 0 by default, but might be ANONYMOUS for chat lobbies.
 	QDate lastMsgDate ;
 


### PR DESCRIPTION
Commit e40460bdcc608b89ee890c46b1dee467362a9354 introduced a rather complicated system to count unread messages, nick occurences and special text occurences in lobbies. To detect which messages have been read it adds an anchor (<a name="…"/>) to every message and stores a separate list of unread anchor names. Every time the mouse is moved or a key is pressed it gets the currently visible text in the chat widget, searches for all anchors in that text and removes all anchors it found from the unseen list. This introduces lags in the gui because executing the regexp on every mouse movement is expensive.

The main part of removing the lag is to only search for anchors if the visible text has actually changed not unconditionally on every event. This PR also makes some other smaller (performance) improvements, see the commit messages for details.
