### PR TITLE
Fix compile with qt < 4.7

### DIFF
--- a/retroshare-gui/src/gui/chat/CreateLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/CreateLobbyDialog.cpp
@@ -47,11 +47,10 @@ CreateLobbyDialog::CreateLobbyDialog(const std::set<RsPeerId>& peer_list, int pr
 
     ui->idChooser_CB->loadIds(IDCHOOSER_ID_REQUIRED, default_identity);
 
-//#if QT_VERSION >= 0x040700
-//	ui->lobbyName_LE->setPlaceholderText(tr("Put a sensible lobby name here")) ;
-//	ui->nickName_LE->setPlaceholderText(tr("Your nickname for this lobby (Change default name in options->chat)")) ;
-//#endif
-//	ui->nickName_LE->setText(QString::fromUtf8(default_nick.c_str())) ;
+#if QT_VERSION >= 0x040700
+	ui->lobbyName_LE->setPlaceholderText(tr("Put a sensible lobby name here"));
+	ui->lobbyTopic_LE->setPlaceholderText(tr("Set a descriptive topic here"));
+#endif
 
 	connect( ui->buttonBox, SIGNAL(accepted()), this, SLOT(createLobby()));
 	connect( ui->buttonBox, SIGNAL(rejected()), this, SLOT(close()));

--- a/retroshare-gui/src/gui/chat/CreateLobbyDialog.ui
+++ b/retroshare-gui/src/gui/chat/CreateLobbyDialog.ui
@@ -71,11 +71,7 @@
               </widget>
              </item>
              <item row="1" column="2">
-              <widget class="QLineEdit" name="lobbyTopic_LE">
-               <property name="placeholderText">
-                <string>Set a descriptive topic here</string>
-               </property>
-              </widget>
+              <widget class="QLineEdit" name="lobbyTopic_LE"/>
              </item>
              <item row="2" column="0">
               <widget class="QLabel" name="label_4">


### PR DESCRIPTION
Move placeholderText from .ui to .cpp file and check for Qt version >= 4.7. Also reenable placeholder text for lobby name, not sure why it was disabled.

Closes #64
