### PR TITLE
More qmake improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ addons:
     project:
       name: "RetroShare/RetroShare"
       description: "RetroShare Build submitted via Travis CI"
-    build_command_prepend: "qmake; make clean"
+    build_command_prepend: "qmake CONFIG+=NO_SQLCIPHER; make clean"
     build_command:   "make -j 4"
     branch_pattern: coverity_scan
 
 before_script:
-  - qmake
+  - qmake CONFIG+=NO_SQLCIPHER
 
 #script: make
 script: if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then make ; fi

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Compilation on Linux
 3. Compile
    ```bash
    cd trunk
-   qmake CONFIG=debug
+   qmake CONFIG+=debug
    make
    ```
 
@@ -55,7 +55,7 @@ For packagers
 -------------
 Packagers can use PREFIX and LIB\_DIR to customize the installation paths:
 ```bash
-qmake PREFIX=/usr LIB_DIR=/usr/lib64
+qmake PREFIX=/usr LIB_DIR=/usr/lib64 "CONFIG-=debug" "CONFIG+=release"
 make
 make INSTALL_ROOT=${PKGDIR} install
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Compilation on Linux
          /usr/bin/RetroShare06
          /usr/bin/RetroShare06-nogui
 
+Compile only retroshare-nogui
+-----------------------------
+If you want to run RetroShare on a server and don’t need the gui and plugins,
+you can run the following commands to only compile/install the nogui version:
+
+```bash
+qmake
+make retroshare-nogui
+sudo make retroshare-nogui-install_subtargets
+```
+
 For packagers
 -------------
 Packagers can use PREFIX and LIB\_DIR to customize the installation paths:

--- a/RetroShare.pro
+++ b/RetroShare.pro
@@ -1,3 +1,5 @@
+!include("retroshare.pri"): error("Could not include file retroshare.pri")
+
 TEMPLATE = subdirs
 
 SUBDIRS += \
@@ -32,11 +34,6 @@ plugins.file = plugins/plugins.pro
 plugins.depends = retroshare_gui
 
 unix {
-	isEmpty(PREFIX)   { PREFIX = /usr }
-	isEmpty(INC_DIR)  { INC_DIR = "$${PREFIX}/include/retroshare06" }
-	isEmpty(LIB_DIR)  { LIB_DIR = "$${PREFIX}/lib" }
-	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }
-
 	icon_files.path = "$${PREFIX}/share/icons/hicolor"
 	icon_files.files = data/24x24
 	icon_files.files += data/48x48

--- a/RetroShare.pro
+++ b/RetroShare.pro
@@ -26,38 +26,12 @@ pegmarkdown.file = supportlibs/pegmarkdown/pegmarkdown.pro
 
 retroshare_gui.file = retroshare-gui/src/retroshare-gui.pro
 retroshare_gui.depends = libretroshare libresapi pegmarkdown
+retroshare_gui.target = retroshare-gui
 
 retroshare_nogui.file = retroshare-nogui/src/retroshare-nogui.pro
 retroshare_nogui.depends = libretroshare libresapi
+retroshare_nogui.target = retroshare-nogui
 
 plugins.file = plugins/plugins.pro
 plugins.depends = retroshare_gui
-
-unix {
-	icon_files.path = "$${PREFIX}/share/icons/hicolor"
-	icon_files.files = data/24x24
-	icon_files.files += data/48x48
-	icon_files.files += data/64x64
-	icon_files.files += data/128x128
-	INSTALLS += icon_files
-
-	desktop_files.path = "$${PREFIX}/share/applications"
-	desktop_files.files = data/retroshare06.desktop
-	INSTALLS += desktop_files
-
-	pixmap_files.path = "$${PREFIX}/share/pixmaps"
-	pixmap_files.files = data/retroshare06.xpm
-	INSTALLS += pixmap_files
-
-	data_files.path = "$${DATA_DIR}"
-	data_files.files = libbitdht/src/bitdht/bdboot.txt
-	INSTALLS += data_files
-
-	webui_files.path = "$${DATA_DIR}/webui"
-	webui_files.files = libresapi/src/webfiles/*
-	INSTALLS += webui_files
-
-	webui_img_files.path = "$${DATA_DIR}/webui/img"
-	webui_img_files.files = retroshare-gui/src/gui/images/logo/logo_splash.png
-	INSTALLS += webui_img_files
-}
+plugins.target = plugins

--- a/build_scripts/Debian+Ubuntu/debian/rules
+++ b/build_scripts/Debian+Ubuntu/debian/rules
@@ -3,7 +3,7 @@
 configure: configure-stamp
 configure-stamp:
 	dh_testdir
-	cd src && qmake-qt4 CONFIG=release PREFIX=/usr LIB_DIR=/usr/lib RetroShare.pro
+	cd src && qmake-qt4 "CONFIG-=debug" "CONFIG+=release" PREFIX=/usr LIB_DIR=/usr/lib RetroShare.pro
 	touch $@
 
 

--- a/build_scripts/RedHat+Fedora/retroshare06.spec
+++ b/build_scripts/RedHat+Fedora/retroshare06.spec
@@ -56,7 +56,7 @@ cd lib/sqlcipher
 make
 cd -
 cd src
-qmake-qt4 CONFIG=release PREFIX=%{_prefix} LIB_DIR=%{_libdir} RetroShare.pro
+qmake-qt4 "CONFIG-=debug" "CONFIG+=release" PREFIX=%{_prefix} LIB_DIR=%{_libdir} RetroShare.pro
 make
 cd -
 

--- a/libbitdht/src/libbitdht.pro
+++ b/libbitdht/src/libbitdht.pro
@@ -1,3 +1,5 @@
+!include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
+
 TEMPLATE = lib
 CONFIG += staticlib
 CONFIG -= qt

--- a/libbitdht/src/libbitdht.pro
+++ b/libbitdht/src/libbitdht.pro
@@ -39,6 +39,13 @@ linux-g++-64 {
 	OBJECTS_DIR = temp/linux-g++-64/obj
 }
 
+unix {
+	data_files.path = "$${DATA_DIR}"
+	data_files.files = bitdht/bdboot.txt
+	INSTALLS += data_files
+}
+
+
 #################### Cross compilation for windows under Linux ####################
 
 win32-x-g++ {	

--- a/libresapi/src/libresapi.pro
+++ b/libresapi/src/libresapi.pro
@@ -1,3 +1,5 @@
+!include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
+
 TEMPLATE = lib
 CONFIG += staticlib
 CONFIG -= qt

--- a/libresapi/src/libresapi.pro
+++ b/libresapi/src/libresapi.pro
@@ -10,6 +10,16 @@ CONFIG += libmicrohttpd
 
 INCLUDEPATH += ../../libretroshare/src
 
+unix {
+	webui_files.path = "$${DATA_DIR}/webui"
+	webui_files.files = webfiles/*
+	INSTALLS += webui_files
+
+	webui_img_files.path = "$${DATA_DIR}/webui/img"
+	webui_img_files.files = ../../retroshare-gui/src/gui/images/logo/logo_splash.png
+	INSTALLS += webui_img_files
+}
+
 win32{
 	DEFINES *= WINDOWS_SYS
 	INCLUDEPATH += $$PWD/../../../libs/include

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -83,6 +83,8 @@ SOURCES +=	tcponudp/udppeer.cc \
 	# The next line is for compliance with debian packages. Keep it!
 	INCLUDEPATH += ../libbitdht
 	DEFINES *= RS_USE_BITDHT
+	PRE_TARGETDEPS *= ../../libbitdht/src/lib/libbitdht.a
+	LIBS += ../../libbitdht/src/lib/libbitdht.a
 }
 
 
@@ -175,6 +177,10 @@ linux-* {
 	DEFINES *= UBUNTU
 	INCLUDEPATH += /usr/include/glib-2.0/ /usr/lib/glib-2.0/include
 	LIBS *= -lgnome-keyring
+	LIBS *= ../../openpgpsdk/src/lib/libops.a -lbz2
+	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
+	LIBS *= -lssl -lupnp -lixml
+	LIBS *= -lcrypto -lz -lpthread
 }
 
 unix {

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -2,6 +2,7 @@
 
 TEMPLATE = lib
 CONFIG += staticlib bitdht
+CONFIG += create_prl
 CONFIG -= qt
 TARGET = retroshare
 

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -177,8 +177,6 @@ linux-* {
 	DEFINES *= UBUNTU
 	INCLUDEPATH += /usr/include/glib-2.0/ /usr/lib/glib-2.0/include
 	LIBS *= -lgnome-keyring
-	LIBS *= ../../openpgpsdk/src/lib/libops.a -lbz2
-	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
 	LIBS *= -lssl -lupnp -lixml
 	LIBS *= -lcrypto -lz -lpthread
 }
@@ -340,6 +338,10 @@ openbsd-* {
 }
 
 ################################### COMMON stuff ##################################
+
+# openpgpsdk
+PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
+LIBS *= ../../openpgpsdk/src/lib/libops.a -lbz2
 
 HEADERS +=	dbase/cachestrapper.h \
 			dbase/fimonitor.h \

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -138,15 +138,22 @@ linux-* {
 	DEPENDPATH += . $${SSL_DIR} $${UPNP_DIR}
 	INCLUDEPATH += . $${SSL_DIR} $${UPNP_DIR}
 
-        SQLCIPHER_OK = $$system(pkg-config --exists sqlcipher && echo yes)
-        isEmpty(SQLCIPHER_OK) {
-# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
-		!exists(../../../lib/sqlcipher/.libs/libsqlcipher.a) {
-			message(libsqlcipher.a not found. Compilation will not use SQLCIPER. Database will be unencrypted.)
-				DEFINES *= NO_SQLCIPHER
+	contains(CONFIG, NO_SQLCIPHER) {
+		DEFINES *= NO_SQLCIPHER
+		LIBS *= -lsqlite3
+	} else {
+	        SQLCIPHER_OK = $$system(pkg-config --exists sqlcipher && echo yes)
+	        isEmpty(SQLCIPHER_OK) {
+			# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
+			exists(../../../lib/sqlcipher/.libs/libsqlcipher.a) {
+				LIBS += ../../../lib/sqlcipher/.libs/libsqlcipher.a
+				DEPENDPATH += ../../../lib/
+				INCLUDEPATH += ../../../lib/
+			} else {
+				error("libsqlcipher is not installed and libsqlcipher.a not found. SQLCIPHER is necessary for encrypted database, to build with unencrypted database, run: qmake CONFIG+=NO_SQLCIPHER")
+			}
 		} else {
-			DEPENDPATH += ../../../lib/
-			INCLUDEPATH += ../../../lib/
+			LIBS *= -lsqlcipher
 		}
 	}
 

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -1,3 +1,5 @@
+!include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
+
 TEMPLATE = lib
 CONFIG += staticlib bitdht
 CONFIG -= qt
@@ -168,11 +170,6 @@ linux-* {
 }
 
 unix {
-	isEmpty(PREFIX)   { PREFIX = /usr }
-	isEmpty(INC_DIR)  { INC_DIR = "$${PREFIX}/include/retroshare06" }
-	isEmpty(LIB_DIR)  { LIB_DIR = "$${PREFIX}/lib" }
-	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }
-
 	DEFINES *= LIB_DIR=\"\\\"$${LIB_DIR}\\\"\"
 	DEFINES *= DATA_DIR=\"\\\"$${DATA_DIR}\\\"\"
 

--- a/openpgpsdk/src/openpgpsdk.pro
+++ b/openpgpsdk/src/openpgpsdk.pro
@@ -1,3 +1,5 @@
+!include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
+
 TEMPLATE = lib
 win32 {
 	CONFIG += staticlib

--- a/openpgpsdk/src/openpgpsdk.pro
+++ b/openpgpsdk/src/openpgpsdk.pro
@@ -1,10 +1,10 @@
 !include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
 
 TEMPLATE = lib
-win32 {
-	CONFIG += staticlib
-} else {
+macx {
 	CONFIG = staticlib 
+} else {
+	CONFIG += staticlib
 }
 
 DEFINES *= OPENSSL_NO_IDEA 

--- a/plugins/Common/retroshare_plugin.pri
+++ b/plugins/Common/retroshare_plugin.pri
@@ -1,3 +1,5 @@
+!include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
+
 TEMPLATE = lib
 CONFIG *= plugin
 
@@ -5,9 +7,6 @@ DEPENDPATH += ../../libretroshare/src/ ../../retroshare-gui/src/
 INCLUDEPATH += ../../libretroshare/src/ ../../retroshare-gui/src/
 
 unix {
-	isEmpty(PREFIX)  { PREFIX = /usr }
-	isEmpty(LIB_DIR) { LIB_DIR = "$${PREFIX}/lib" }
-
 	target.path = "$${LIB_DIR}/retroshare/extensions6"
 	INSTALLS += target
 }

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -112,7 +112,7 @@ linux-* {
 }
 
 unix {
-	target.path = "$${PREFIX}/bin"
+	target.path = "$${BIN_DIR}"
 	INSTALLS += target
 
 	data_files.path="$${DATA_DIR}/"

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -2,6 +2,7 @@
 
 QT     += network xml script
 CONFIG += qt gui uic qrc resources idle bitdht
+CONFIG += link_prl
 
 # Plz never commit the .pro with these flags enabled.
 # Use this flag when developping new features only.

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -190,12 +190,10 @@ win32 {
 	#QTPLUGIN += qjpeg
 
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
 
 	LIBS_DIR = $$PWD/../../../libs
 
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS += ../../openpgpsdk/src/lib/libops.a -lbz2
 	LIBS += -L"$$LIBS_DIR/lib"
 
 	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
@@ -240,7 +238,6 @@ macx {
 
 	CONFIG += version_detail_bash_script
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS += ../../openpgpsdk/src/lib/libops.a -lbz2
         LIBS += -lssl -lcrypto -lz 
         #LIBS += -lssl -lcrypto -lz -lgpgme -lgpg-error -lassuan
 	LIBS += ../../../miniupnpc-1.0/libminiupnpc.a
@@ -278,10 +275,8 @@ openbsd-* {
 	INCLUDEPATH *= /usr/local/include
 
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
 
 	LIBS *= ../../libretroshare/src/lib/libretroshare.a
-	LIBS *= ../../openpgpsdk/src/lib/libops.a -lbz2
 	LIBS *= -lssl -lcrypto
 	LIBS *= -lgpgme
 	LIBS *= -lupnp

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -85,27 +85,6 @@ linux-* {
 
 	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 
-	SQLCIPHER_OK = $$system(pkg-config --exists sqlcipher && echo yes)
-	isEmpty(SQLCIPHER_OK) {
-# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
-
-		exists(../../../lib/sqlcipher/.libs/libsqlcipher.a) {
-
-			LIBS += ../../../lib/sqlcipher/.libs/libsqlcipher.a
-			DEPENDPATH += ../../../lib/sqlcipher/src/
-			INCLUDEPATH += ../../../lib/sqlcipher/src/
-			DEPENDPATH += ../../../lib/sqlcipher/tsrc/
-			INCLUDEPATH += ../../../lib/sqlcipher/tsrc/
-		} else {
-			message(libsqlcipher.a not found. Compilation will not use SQLCIPHER. Database will be unencrypted.)
-			DEFINES *= NO_SQLCIPHER
-			LIBS *= -lsqlite3
-		}
-
-	} else {
-		LIBS += -lsqlcipher
-	}
-
 	LIBS *= -lglib-2.0
 	LIBS *= -rdynamic
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -122,6 +122,22 @@ unix {
 	style_files.path="$${DATA_DIR}/stylesheets"
 	style_files.files=gui/qss/chat/Bubble gui/qss/chat/Bubble_Compact
 	INSTALLS += style_files
+
+	icon_files.path = "$${PREFIX}/share/icons/hicolor"
+	icon_files.files =  ../../data/24x24
+	icon_files.files += ../../data/48x48
+	icon_files.files += ../../data/64x64
+	icon_files.files += ../../data/128x128
+	INSTALLS += icon_files
+
+	desktop_files.path = "$${PREFIX}/share/applications"
+	desktop_files.files = ../../data/retroshare06.desktop
+	INSTALLS += desktop_files
+
+	pixmap_files.path = "$${PREFIX}/share/pixmaps"
+	pixmap_files.files = ../../data/retroshare06.xpm
+	INSTALLS += pixmap_files
+
 }
 
 linux-g++ {

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -1,6 +1,6 @@
 !include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
 
-QT     += network xml script
+QT     += network xml
 CONFIG += qt gui uic qrc resources idle bitdht
 CONFIG += link_prl
 

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -1,3 +1,5 @@
+!include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
+
 QT     += network xml script
 CONFIG += qt gui uic qrc resources idle bitdht
 
@@ -110,9 +112,6 @@ linux-* {
 }
 
 unix {
-	isEmpty(PREFIX)  { PREFIX = /usr }
-	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }
-
 	target.path = "$${PREFIX}/bin"
 	INSTALLS += target
 

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -76,17 +76,14 @@ linux-* {
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
 
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS += ../../openpgpsdk/src/lib/libops.a -lbz2
-	LIBS += -lssl -lupnp -lixml -lXss -lgnome-keyring
-	LIBS *= -lcrypto -ldl -lX11 -lz
+	LIBS *= -lX11 -lXss
 
 	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 
-	LIBS *= -lglib-2.0
-	LIBS *= -rdynamic
+	#LIBS *= -lglib-2.0
+	LIBS *= -rdynamic -ldl
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
 	DEFINES *= UBUNTU
 }
@@ -305,11 +302,6 @@ openbsd-* {
 # to rename the patched version of SSL to something like libsslxpgp.a and libcryptoxpg.a
 
 # ###########################################
-
-bitdht {
-	LIBS += ../../libbitdht/src/lib/libbitdht.a
-	PRE_TARGETDEPS *= ../../libbitdht/src/lib/libbitdht.a
-}
 
 DEPENDPATH += . ../../libretroshare/src/
 INCLUDEPATH += ../../libretroshare/src/

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -58,7 +58,7 @@ linux-* {
 }
 
 unix {
-	target.path = "$${PREFIX}/bin"
+	target.path = "$${BIN_DIR}"
 	INSTALLS += target
 }
 

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -1,3 +1,5 @@
+!include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
+
 TEMPLATE = app
 TARGET = RetroShare06-nogui
 CONFIG += bitdht
@@ -56,8 +58,6 @@ linux-* {
 }
 
 unix {
-	isEmpty(PREFIX)  { PREFIX = /usr }
-
 	target.path = "$${PREFIX}/bin"
 	INSTALLS += target
 }

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -76,12 +76,10 @@ win32 {
 	MOC_DIR = temp/moc
 
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
 
 	LIBS_DIR = $$PWD/../../../libs
 
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS += ../../openpgpsdk/src/lib/libops.a -lbz2
 	LIBS += -L"$$LIBS_DIR/lib"
 	LIBS += -lssl -lcrypto -lpthread -lminiupnpc -lz
 # added after bitdht
@@ -111,7 +109,6 @@ macx {
 
 	LIBS += -Wl,-search_paths_first
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS += ../../openpgpsdk/src/lib/libops.a -lbz2
         LIBS += -lssl -lcrypto -lz 
 	LIBS += ../../../miniupnpc-1.0/libminiupnpc.a
 	LIBS += -framework CoreFoundation
@@ -150,13 +147,11 @@ openbsd-* {
 	INCLUDEPATH *= /usr/local/include
 	QMAKE_CXXFLAGS *= -Dfseeko64=fseeko -Dftello64=ftello -Dstat64=stat -Dstatvfs64=statvfs -Dfopen64=fopen
 	LIBS *= ../../libretroshare/src/lib/libretroshare.a
-	LIBS *= ../../openpgpsdk/src/lib/libops.a -lbz2
 	LIBS *= -lssl -lcrypto
 	LIBS *= -lgpgme
 	LIBS *= -lupnp
 	LIBS *= -lgnome-keyring
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
 	LIBS *= -rdynamic
 }
 

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -8,6 +8,7 @@ CONFIG += bitdht
 # webinterface, requires libmicrohttpd
 CONFIG += webui
 CONFIG -= qt xml gui
+CONFIG += link_prl
 
 # if you are linking against the libretroshare with gxs.
 # this option links against the required sqlite library.

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -31,10 +31,7 @@ linux-* {
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS += ../../openpgpsdk/src/lib/libops.a -lbz2
-	LIBS += -lssl -lupnp -lixml -lgnome-keyring
-	LIBS *= -lcrypto -ldl -lz -lpthread
-	LIBS *= -rdynamic
+	LIBS *= -rdynamic -ldl
 }
 
 unix {
@@ -165,11 +162,6 @@ openbsd-* {
 
 
 ############################## Common stuff ######################################
-
-# bitdht config
-bitdht {
-	LIBS += ../../libbitdht/src/lib/libbitdht.a
-}
 
 DEPENDPATH += . ../../libretroshare/src
 INCLUDEPATH += . ../../libretroshare/src

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -35,27 +35,6 @@ linux-* {
 	LIBS += -lssl -lupnp -lixml -lgnome-keyring
 	LIBS *= -lcrypto -ldl -lz -lpthread
 	LIBS *= -rdynamic
-
-	gxs {
-		SQLCIPHER_OK = $$system(pkg-config --exists sqlcipher && echo yes)
-			isEmpty(SQLCIPHER_OK) {
-# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
-
-				exists(../../../lib/sqlcipher/.libs/libsqlcipher.a) {
-
-					LIBS += ../../../lib/sqlcipher/.libs/libsqlcipher.a
-						DEPENDPATH += ../../../lib/sqlcipher/src/
-						INCLUDEPATH += ../../../lib/sqlcipher/src/
-				} else {
-					message(libsqlcipher.a not found. Compilation will not use SQLCIPHER. Database will be unencrypted.)
-						DEFINES *= NO_SQLCIPHER
-						LIBS *= -lsqlite3
-				}
-
-			} else {
-				LIBS *= -lsqlcipher
-			}
-	}
 }
 
 unix {

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -1,0 +1,6 @@
+unix {
+	isEmpty(PREFIX)   { PREFIX   = "/usr" }
+	isEmpty(INC_DIR)  { INC_DIR  = "$${PREFIX}/include/retroshare06" }
+	isEmpty(LIB_DIR)  { LIB_DIR  = "$${PREFIX}/lib" }
+	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }
+}

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -1,5 +1,6 @@
 unix {
 	isEmpty(PREFIX)   { PREFIX   = "/usr" }
+	isEmpty(BIN_DIR)  { BIN_DIR  = "$${PREFIX}/bin" }
 	isEmpty(INC_DIR)  { INC_DIR  = "$${PREFIX}/include/retroshare06" }
 	isEmpty(LIB_DIR)  { LIB_DIR  = "$${PREFIX}/lib" }
 	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }


### PR DESCRIPTION
This PR further improves the qmake build files: The main features:
- Possiblity to install subprojects (gui/nogui) without compiling unneeded subprojects (good to compile nogui on a raspberrypi)
- Add .pri include file for common stuff of all .pro files, so far it contains the default values for the installation paths
- Reduce duplicate code in gui/nogui, by moving LIBS*=… directives to libretroshare (see http://doc.qt.io/qt-5/qmake-advanced-usage.html#libdepend) only done for linux, as i can't test on other platforms
- Treat missing sqlcipher as error, and allow building without it only by using "qmake CONFIG+=NO_SQLCIPHER" (in which case it doesn't link to sqlcipher even if it exists on the system)

For more info see the commit messages.
