### PR TITLE
add option to disable updates to systray tooltip

### DIFF
--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -678,6 +678,7 @@ void MainWindow::updateTrayCombine()
 }
 
 void MainWindow::toggleStatusToolTip(bool toggle){
+    if(!toggle)return;
     QString tray = "RetroShare\n";
     tray += "\n" + nameAndLocation;
     trayIcon->setToolTip(tray);

--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -677,12 +677,19 @@ void MainWindow::updateTrayCombine()
     updateFriends();
 }
 
+void MainWindow::toggleStatusToolTip(bool toggle){
+    QString tray = "RetroShare\n";
+    tray += "\n" + nameAndLocation;
+    trayIcon->setToolTip(tray);
+}
+
 void MainWindow::updateStatus()
 {
     // This call is essential to remove locks due to QEventLoop re-entrance while asking gpg passwds. Dont' remove it!
     if(RsAutoUpdatePage::eventsLocked())
         return;
-
+    if(Settings->valueFromGroup("StatusBar", "DisableSysTrayToolTip", QVariant(false)).toBool())
+        return;
     float downKb = 0;
     float upKb = 0;
     rsConfig->GetCurrentDataRates(downKb, upKb);

--- a/retroshare-gui/src/gui/MainWindow.h
+++ b/retroshare-gui/src/gui/MainWindow.h
@@ -184,6 +184,7 @@ public slots:
     void setNewPage(int page);
     void setCompactStatusMode(bool compact);
 
+    void toggleStatusToolTip(bool toggle);
 protected:
     /** Default Constructor */
     MainWindow(QWidget *parent = 0, Qt::WindowFlags flags = 0);

--- a/retroshare-gui/src/gui/settings/AppearancePage.cpp
+++ b/retroshare-gui/src/gui/settings/AppearancePage.cpp
@@ -45,6 +45,7 @@ AppearancePage::AppearancePage(QWidget * parent, Qt::WindowFlags flags)
 	connect(ui.checkBoxHideSoundStatus, SIGNAL(toggled(bool)), pMainWindow->soundStatusInstance(), SLOT(setHidden(bool)));
 	connect(ui.checkBoxHideToasterDisable, SIGNAL(toggled(bool)), pMainWindow->toasterDisableInstance(), SLOT(setHidden(bool)));
 	connect(ui.checkBoxShowSystrayOnStatus, SIGNAL(toggled(bool)), pMainWindow->sysTrayStatusInstance(), SLOT(setVisible(bool)));
+	connect(ui.checkBoxDisableSysTrayToolTip, SIGNAL(toggled(bool)), pMainWindow, SLOT(toggleStatusToolTip(bool)));
 
 	/* Populate combo boxes */
 	foreach (QString code, LanguageSupport::languageCodes()) {
@@ -142,6 +143,7 @@ bool AppearancePage::save(QString &errmsg)
 	Settings->setValueToGroup("StatusBar", "HideSound", QVariant(ui.checkBoxHideSoundStatus->isChecked()));
 	Settings->setValueToGroup("StatusBar", "HideToaster", QVariant(ui.checkBoxHideToasterDisable->isChecked()));
 	Settings->setValueToGroup("StatusBar", "ShowSysTrayOnStatusBar", QVariant(ui.checkBoxShowSystrayOnStatus->isChecked()));
+	Settings->setValueToGroup("StatusBar", "DisableSysTrayToolTip", QVariant(ui.checkBoxDisableSysTrayToolTip->isChecked()));
 
 	return true;
 }
@@ -228,6 +230,7 @@ void AppearancePage::load()
 	ui.checkBoxHideSoundStatus->setChecked(Settings->valueFromGroup("StatusBar", "HideSound", QVariant(false)).toBool());
 	ui.checkBoxHideToasterDisable->setChecked(Settings->valueFromGroup("StatusBar", "HideToaster", QVariant(false)).toBool());
 	ui.checkBoxShowSystrayOnStatus->setChecked(Settings->valueFromGroup("StatusBar", "ShowSysTrayOnStatusBar", QVariant(false)).toBool());
+	ui.checkBoxDisableSysTrayToolTip->setChecked(Settings->valueFromGroup("StatusBar", "DisableSysTrayToolTip", QVariant(false)).toBool());
 
 }
 

--- a/retroshare-gui/src/gui/settings/AppearancePage.cpp
+++ b/retroshare-gui/src/gui/settings/AppearancePage.cpp
@@ -144,6 +144,7 @@ bool AppearancePage::save(QString &errmsg)
 	Settings->setValueToGroup("StatusBar", "HideToaster", QVariant(ui.checkBoxHideToasterDisable->isChecked()));
 	Settings->setValueToGroup("StatusBar", "ShowSysTrayOnStatusBar", QVariant(ui.checkBoxShowSystrayOnStatus->isChecked()));
 	Settings->setValueToGroup("StatusBar", "DisableSysTrayToolTip", QVariant(ui.checkBoxDisableSysTrayToolTip->isChecked()));
+	MainWindow::getInstance()->toggleStatusToolTip(ui.checkBoxDisableSysTrayToolTip->isChecked());
 
 	return true;
 }

--- a/retroshare-gui/src/gui/settings/AppearancePage.ui
+++ b/retroshare-gui/src/gui/settings/AppearancePage.ui
@@ -14,7 +14,16 @@
    <enum>Qt::NoContextMenu</enum>
   </property>
   <layout class="QGridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
     <number>6</number>
    </property>
    <property name="spacing">
@@ -199,7 +208,16 @@
          <enum>QFrame::Plain</enum>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>2</number>
+         </property>
+         <property name="topMargin">
+          <number>2</number>
+         </property>
+         <property name="rightMargin">
+          <number>2</number>
+         </property>
+         <property name="bottomMargin">
           <number>2</number>
          </property>
          <item>
@@ -212,7 +230,7 @@
          <item>
           <widget class="QRadioButton" name="rbtActionOnListItem">
            <property name="text">
-            <string>On List Item</string>
+            <string>On List Ite&amp;m</string>
            </property>
           </widget>
          </item>
@@ -248,7 +266,16 @@
          <enum>QFrame::Plain</enum>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>2</number>
+         </property>
+         <property name="topMargin">
+          <number>2</number>
+         </property>
+         <property name="rightMargin">
+          <number>2</number>
+         </property>
+         <property name="bottomMargin">
           <number>2</number>
          </property>
          <item>
@@ -458,6 +485,13 @@
        <widget class="QCheckBox" name="checkBoxShowSystrayOnStatus">
         <property name="text">
          <string>Show SysTray on Status Bar</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBoxDisableSysTrayToolTip">
+        <property name="text">
+         <string>Disable SysTray ToolTip</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
In KDE5/QT5 - the tooltip is updated using DBUS
This happens once a second - and includes sending the icon, which seems a little heavy for dbus.

This PR just adds an option to disable systray tooltip updates
