### PR TITLE
Fix Windows compilation of libresapi with error:

### DIFF
--- a/libresapi/src/api/ForumHandler.cpp
+++ b/libresapi/src/api/ForumHandler.cpp
@@ -8,6 +8,9 @@
 #include "GxsResponseTask.h"
 #ifndef WINDOWS_SYS
 #include "unistd.h"
+#else
+#include "stdint.h"
+typedef uint32_t u_int32_t;
 #endif
 
 namespace resource_api


### PR DESCRIPTION
\libresapi\src\api\ForumHandler.cpp:108: erreur : 'u_int32_t' was not
declared in this scope
                 KeyValueReference<u_int32_t>
vis_msg("visible_msg_count", grp.mMeta.mVisibleMsgCount);
                                   ^
