### PR TITLE
Fix subtle bug in tlv deserialization of TLV_TYPE_KEYSIGNATURETYPE

### DIFF
--- a/libretroshare/src/serialiser/rstlvkeys.cc
+++ b/libretroshare/src/serialiser/rstlvkeys.cc
@@ -649,7 +649,6 @@ bool RsTlvKeySignatureSet::GetTlv(void *data, uint32_t size, uint32_t *offset)
 
             /* get the next type */
             uint16_t tlvsubtype = GetTlvType( &(((uint8_t *) data)[*offset]) );
-            SignType currType;
 
             switch(tlvsubtype)
             {
@@ -659,16 +658,13 @@ bool RsTlvKeySignatureSet::GetTlv(void *data, uint32_t size, uint32_t *offset)
                             ok &= sign.GetTlv(data, size, offset);
                             if (ok)
                             {
-                                keySignSet[currType] = sign;
+                                keySignSet[sign_type] = sign;
                             }
                     }
                     break;
                     case TLV_TYPE_KEYSIGNATURETYPE:
                     {
                         ok = GetTlvUInt32(data, size, offset, TLV_TYPE_KEYSIGNATURETYPE, &sign_type);
-
-                        if(ok)
-                            currType = sign_type;
                     }
                     break;
                     default:


### PR DESCRIPTION
The main sympton of this bug was receiving no more forum/channel posts.

When using -O2, the variable currType is optimized out (it's declared inside the while loop), so the signature is added to the keySignSet with the wrong sign type. Then when verifying the
data, the signature is not found and verification fails.

With debug builds (-O0) this worked, that's why not every one was affected
by this.

This bug was introduced in 2012 (19e856c2a8eb56c5e43e977aac27a3dbc79ab2d0)
It surfaced only now, because before commit 2b8eafa1dbfd252b6391640bd04f2e3e92ec4bc1 from after RC2, libretroshare was always built with CONFIG+=debug, so the error was not observable.
