### PR TITLE
added more details to travis IRC output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ notifications:
       - "chat.freenode.net#retroshare"
     template:
       - "%{repository}/%{branch} (%{commit} - %{author}): %{build_url}: %{message}"
+      - "Message: %{commit_message}"
+      - "Commit details: %{compare_url}"
 #  webhooks:
 #    urls:
 #      - https://webhooks.gitter.im/e/9502afd22ca6c8e85fb3


### PR DESCRIPTION
IRC messages now looklike this:

<travis-ci> chozabu/RetroShare/more_travis (11d54b8 - Chozabu): https://travis-ci.org/chozabu/RetroShare/builds/78478543: The build passed. 
<travis-ci> Message: added more details to travis IRC output 
<travis-ci> Commit details: https://github.com/chozabu/RetroShare/commit/11d54b8c0ba2 

the second two lines are new.
