### PR TITLE
remove VOIP pre-build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
     branch_pattern: coverity_scan
 
 before_script:
+  - sed -i '/VOIP/d' ./plugins/plugins.pro
   - qmake CONFIG+=NO_SQLCIPHER
 
 #script: make


### PR DESCRIPTION
Not properly tested - but this should prevent travis from building VOIP plugin.
This means we should not constantly get "build failed" messages - but a more long term solution is to setup a compatible version of libavcoded on buntu 12.04
