### PR TITLE
Fix opensuse compile

### DIFF
--- a/plugins/VOIP/VOIP.pro
+++ b/plugins/VOIP/VOIP.pro
@@ -104,4 +104,4 @@ TRANSLATIONS +=  \
             lang/VOIP_tr.ts \
             lang/VOIP_zh_CN.ts
 
-LIBS += -lspeex -lspeexdsp -lavformat -lavcodec -lavutil
+LIBS += -lspeex -lspeexdsp -lavcodec -lavutil

--- a/plugins/VOIP/VOIP.pro
+++ b/plugins/VOIP/VOIP.pro
@@ -19,8 +19,12 @@ INCLUDEPATH += ../../retroshare-gui/src/temp/ui ../../libretroshare/src
 #################################### Windows #####################################
 
 linux-* {
-	INCLUDEPATH += /usr/include
-	LIBS += $$system(pkg-config --libs opencv)
+	CONFIG += link_pkgconfig
+
+	# Necessary for openSUSE
+	PKGCONFIG += libavcodec libavutil
+
+	PKGCONFIG += opencv
 }
 
 win32 {

--- a/plugins/VOIP/gui/VideoProcessor.cpp
+++ b/plugins/VOIP/gui/VideoProcessor.cpp
@@ -20,11 +20,11 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 
 #include <libavutil/opt.h>
-#include <libavutil/channel_layout.h>
-#include <libavutil/common.h>
+//#include <libavutil/channel_layout.h>
+//#include <libavutil/common.h>
 #include <libavutil/imgutils.h>
-#include <libavutil/mathematics.h>
-#include <libavutil/samplefmt.h>
+//#include <libavutil/mathematics.h>
+//#include <libavutil/samplefmt.h>
 }
 //#define DEBUG_MPEG_VIDEO 1
 


### PR DESCRIPTION
openSUSE installs libav stuff in /usr/include/ffmpeg so this needs to be added to the include path. I added a PKGCONFIG option to do this automatically for every distribution.
This PR also removes unused LIBS and includes
