### PR TITLE
Disable pegmarkdown build by default, only used by disabled wiki

### DIFF
--- a/RetroShare.pro
+++ b/RetroShare.pro
@@ -7,7 +7,6 @@ SUBDIRS += \
         libbitdht \
         libretroshare \
         libresapi \
-        pegmarkdown \
         retroshare_gui \
         retroshare_nogui \
         plugins
@@ -22,10 +21,8 @@ libretroshare.depends = openpgpsdk libbitdht
 libresapi.file = libresapi/src/libresapi.pro
 libresapi.depends = libretroshare
 
-pegmarkdown.file = supportlibs/pegmarkdown/pegmarkdown.pro
-
 retroshare_gui.file = retroshare-gui/src/retroshare-gui.pro
-retroshare_gui.depends = libretroshare libresapi pegmarkdown
+retroshare_gui.depends = libretroshare libresapi
 retroshare_gui.target = retroshare-gui
 
 retroshare_nogui.file = retroshare-nogui/src/retroshare-nogui.pro
@@ -35,3 +32,9 @@ retroshare_nogui.target = retroshare-nogui
 plugins.file = plugins/plugins.pro
 plugins.depends = retroshare_gui
 plugins.target = plugins
+
+wikipoos {
+    SUBDIRS += pegmarkdown
+    pegmarkdown.file = supportlibs/pegmarkdown/pegmarkdown.pro
+    retroshare_gui.depends += pegmarkdown
+}

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -778,21 +778,25 @@ SOURCES += services/p3gxschannels.cc \
 	serialiser/rsgxscommentitems.cc \
 	serialiser/rsgxschannelitems.cc \
 
-# Wiki Service
-HEADERS += retroshare/rswiki.h \
-	services/p3wiki.h \
-	serialiser/rswikiitems.h
+wikipoos {
+	# Wiki Service
+	HEADERS += retroshare/rswiki.h \
+		services/p3wiki.h \
+		serialiser/rswikiitems.h
 
-SOURCES += services/p3wiki.cc \
-	serialiser/rswikiitems.cc \
+	SOURCES += services/p3wiki.cc \
+		serialiser/rswikiitems.cc \
+}
 
-# Wire Service
-HEADERS += retroshare/rswire.h \
-	services/p3wire.h \
-	serialiser/rswireitems.h
+gxsthewire {
+	# Wire Service
+	HEADERS += retroshare/rswire.h \
+		services/p3wire.h \
+		serialiser/rswireitems.h
 
-SOURCES += services/p3wire.cc \
-	serialiser/rswireitems.cc \
+	SOURCES += services/p3wire.cc \
+		serialiser/rswireitems.cc \
+}
 
 # Posted Service
 HEADERS += services/p3postbase.h \
@@ -804,13 +808,15 @@ SOURCES +=  services/p3postbase.cc \
 	services/p3posted.cc \
 	serialiser/rsposteditems.cc
 
-#Photo Service
-HEADERS += services/p3photoservice.h \
-	retroshare/rsphoto.h \
-	serialiser/rsphotoitems.h \
+gxsphotoshare {
+	#Photo Service
+	HEADERS += services/p3photoservice.h \
+		retroshare/rsphoto.h \
+		serialiser/rsphotoitems.h \
 
-SOURCES += services/p3photoservice.cc \
-	serialiser/rsphotoitems.cc \
+	SOURCES += services/p3photoservice.cc \
+		serialiser/rsphotoitems.cc \
+}
 
 
 

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -7,11 +7,6 @@ CONFIG -= qt
 TARGET = retroshare
 TARGET_PRL = libretroshare
 
-
-#GXS Stuff.
-# This should be disabled for releases until further notice.
-CONFIG += gxs 
-
 #CONFIG += dsdv
 
 profiling {
@@ -464,8 +459,8 @@ HEADERS +=	serialiser/itempriorities.h \
 			serialiser/rsheartbeatitems.h \
 			serialiser/rsrttitems.h \
 			serialiser/rsgxsrecognitems.h \
-                        serialiser/rsgxsupdateitems.h \
-                        serialiser/rsserviceinfoitems.h \
+			serialiser/rsgxsupdateitems.h \
+			serialiser/rsserviceinfoitems.h \
 
 HEADERS +=	services/p3msgservice.h \
 			services/p3service.h \
@@ -614,8 +609,8 @@ SOURCES +=	serialiser/rsbaseserial.cc \
 			serialiser/rsheartbeatitems.cc \
 			serialiser/rsrttitems.cc \
 			serialiser/rsgxsrecognitems.cc \
-                        serialiser/rsgxsupdateitems.cc \
-                        serialiser/rsserviceinfoitems.cc \
+			serialiser/rsgxsupdateitems.cc \
+			serialiser/rsserviceinfoitems.cc \
 
 SOURCES +=	services/p3msgservice.cc \
 			services/p3service.cc \
@@ -696,129 +691,126 @@ SOURCES +=	zeroconf/p3zcnatassist.cc \
 
 # new gxs cache system
 # this should be disabled for releases until further notice.
-gxs {
-	DEFINES *= RS_ENABLE_GXS
-	DEFINES *= SQLITE_HAS_CODEC
-	DEFINES *= GXS_ENABLE_SYNC_MSGS
+DEFINES *= SQLITE_HAS_CODEC
+DEFINES *= GXS_ENABLE_SYNC_MSGS
 
-	HEADERS += serialiser/rsnxsitems.h \
-		gxs/rsgds.h \
-		gxs/rsgxs.h \
-		gxs/rsdataservice.h \
-		gxs/rsgxsnetservice.h \
-		retroshare/rsgxsflags.h \
-		retroshare/rsgxsifacetypes.h \
-		gxs/rsgenexchange.h \
-		gxs/rsnxsobserver.h \
-		gxs/rsgxsdata.h \
-		retroshare/rstokenservice.h \
-		gxs/rsgxsdataaccess.h \
-		retroshare/rsgxsservice.h \
-		serialiser/rsgxsitems.h \
-		util/retrodb.h \
-		util/rsdbbind.h \
-		gxs/rsgxsutil.h \
-		util/contentvalue.h \
-		gxs/gxssecurity.h \
-		gxs/rsgxsifacehelper.h \
-		gxs/gxstokenqueue.h \
-		gxs/rsgxsnetutils.h \
-		gxs/rsgxsiface.h \
-		gxs/rsgxsrequesttypes.h
+HEADERS += serialiser/rsnxsitems.h \
+	gxs/rsgds.h \
+	gxs/rsgxs.h \
+	gxs/rsdataservice.h \
+	gxs/rsgxsnetservice.h \
+	retroshare/rsgxsflags.h \
+	retroshare/rsgxsifacetypes.h \
+	gxs/rsgenexchange.h \
+	gxs/rsnxsobserver.h \
+	gxs/rsgxsdata.h \
+	retroshare/rstokenservice.h \
+	gxs/rsgxsdataaccess.h \
+	retroshare/rsgxsservice.h \
+	serialiser/rsgxsitems.h \
+	util/retrodb.h \
+	util/rsdbbind.h \
+	gxs/rsgxsutil.h \
+	util/contentvalue.h \
+	gxs/gxssecurity.h \
+	gxs/rsgxsifacehelper.h \
+	gxs/gxstokenqueue.h \
+	gxs/rsgxsnetutils.h \
+	gxs/rsgxsiface.h \
+	gxs/rsgxsrequesttypes.h
 
 
-	SOURCES += serialiser/rsnxsitems.cc \
-		gxs/rsdataservice.cc \
-		gxs/rsgenexchange.cc \
-		gxs/rsgxsnetservice.cc \
-		gxs/rsgxsdata.cc \
-		serialiser/rsgxsitems.cc \
-		gxs/rsgxsdataaccess.cc \
-		util/retrodb.cc \
-		util/contentvalue.cc \
-		util/rsdbbind.cc \
-		gxs/gxssecurity.cc \
-		gxs/gxstokenqueue.cc \
-		gxs/rsgxsnetutils.cc \
-		gxs/rsgxsutil.cc \
-		gxs/rsgxsrequesttypes.cc
+SOURCES += serialiser/rsnxsitems.cc \
+	gxs/rsdataservice.cc \
+	gxs/rsgenexchange.cc \
+	gxs/rsgxsnetservice.cc \
+	gxs/rsgxsdata.cc \
+	serialiser/rsgxsitems.cc \
+	gxs/rsgxsdataaccess.cc \
+	util/retrodb.cc \
+	util/contentvalue.cc \
+	util/rsdbbind.cc \
+	gxs/gxssecurity.cc \
+	gxs/gxstokenqueue.cc \
+	gxs/rsgxsnetutils.cc \
+	gxs/rsgxsutil.cc \
+	gxs/rsgxsrequesttypes.cc
 
 
-	# Identity Service
-	HEADERS += retroshare/rsidentity.h \
-		gxs/rsgixs.h \
-		services/p3idservice.h \
-		serialiser/rsgxsiditems.h \
-		services/p3gxsreputation.h \
-		serialiser/rsgxsreputationitems.h \
+# Identity Service
+HEADERS += retroshare/rsidentity.h \
+	gxs/rsgixs.h \
+	services/p3idservice.h \
+	serialiser/rsgxsiditems.h \
+	services/p3gxsreputation.h \
+	serialiser/rsgxsreputationitems.h \
 
-	SOURCES += services/p3idservice.cc \
-		serialiser/rsgxsiditems.cc \
-		services/p3gxsreputation.cc \
-		serialiser/rsgxsreputationitems.cc \
+SOURCES += services/p3idservice.cc \
+	serialiser/rsgxsiditems.cc \
+	services/p3gxsreputation.cc \
+	serialiser/rsgxsreputationitems.cc \
 
-	# GxsCircles Service
-	HEADERS += services/p3gxscircles.h \
-		serialiser/rsgxscircleitems.h \
-		retroshare/rsgxscircles.h \
+# GxsCircles Service
+HEADERS += services/p3gxscircles.h \
+	serialiser/rsgxscircleitems.h \
+	retroshare/rsgxscircles.h \
 
-	SOURCES += services/p3gxscircles.cc \
-		serialiser/rsgxscircleitems.cc \
+SOURCES += services/p3gxscircles.cc \
+	serialiser/rsgxscircleitems.cc \
 
-	# GxsForums Service
-	HEADERS += retroshare/rsgxsforums.h \
-		services/p3gxsforums.h \
-		serialiser/rsgxsforumitems.h
+# GxsForums Service
+HEADERS += retroshare/rsgxsforums.h \
+	services/p3gxsforums.h \
+	serialiser/rsgxsforumitems.h
 
-	SOURCES += services/p3gxsforums.cc \
-		serialiser/rsgxsforumitems.cc \
+SOURCES += services/p3gxsforums.cc \
+	serialiser/rsgxsforumitems.cc \
 
-	# GxsChannels Service
-	HEADERS += retroshare/rsgxschannels.h \
-		services/p3gxschannels.h \
-		services/p3gxscommon.h \
-		serialiser/rsgxscommentitems.h \
-		serialiser/rsgxschannelitems.h \
+# GxsChannels Service
+HEADERS += retroshare/rsgxschannels.h \
+	services/p3gxschannels.h \
+	services/p3gxscommon.h \
+	serialiser/rsgxscommentitems.h \
+	serialiser/rsgxschannelitems.h \
 
-	SOURCES += services/p3gxschannels.cc \
-		services/p3gxscommon.cc \
-		serialiser/rsgxscommentitems.cc \
-		serialiser/rsgxschannelitems.cc \
+SOURCES += services/p3gxschannels.cc \
+	services/p3gxscommon.cc \
+	serialiser/rsgxscommentitems.cc \
+	serialiser/rsgxschannelitems.cc \
 
-	# Wiki Service
-	HEADERS += retroshare/rswiki.h \
-		services/p3wiki.h \
-		serialiser/rswikiitems.h
+# Wiki Service
+HEADERS += retroshare/rswiki.h \
+	services/p3wiki.h \
+	serialiser/rswikiitems.h
 
-	SOURCES += services/p3wiki.cc \
-		serialiser/rswikiitems.cc \
+SOURCES += services/p3wiki.cc \
+	serialiser/rswikiitems.cc \
 
-	# Wire Service
-	HEADERS += retroshare/rswire.h \
-		services/p3wire.h \
-		serialiser/rswireitems.h
+# Wire Service
+HEADERS += retroshare/rswire.h \
+	services/p3wire.h \
+	serialiser/rswireitems.h
 
-	SOURCES += services/p3wire.cc \
-		serialiser/rswireitems.cc \
+SOURCES += services/p3wire.cc \
+	serialiser/rswireitems.cc \
 
-	# Posted Service
-	HEADERS += services/p3postbase.h \
-		services/p3posted.h \
-		retroshare/rsposted.h \
-		serialiser/rsposteditems.h
+# Posted Service
+HEADERS += services/p3postbase.h \
+	services/p3posted.h \
+	retroshare/rsposted.h \
+	serialiser/rsposteditems.h
 
-	SOURCES +=  services/p3postbase.cc \ 
-		services/p3posted.cc \
-		serialiser/rsposteditems.cc
+SOURCES +=  services/p3postbase.cc \
+	services/p3posted.cc \
+	serialiser/rsposteditems.cc
 
-	#Photo Service
-	HEADERS += services/p3photoservice.h \
-		retroshare/rsphoto.h \
-		serialiser/rsphotoitems.h \
+#Photo Service
+HEADERS += services/p3photoservice.h \
+	retroshare/rsphoto.h \
+	serialiser/rsphotoitems.h \
 
-	SOURCES += services/p3photoservice.cc \
-		serialiser/rsphotoitems.cc \
-}
+SOURCES += services/p3photoservice.cc \
+	serialiser/rsphotoitems.cc \
 
 
 
@@ -858,6 +850,3 @@ test_bitdht {
 
 	# ENABLED UDP NOW.
 }
-
-
-

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -1364,9 +1364,9 @@ int RsServer::StartupRetroShare()
                         RS_SERVICE_GXS_TYPE_WIKI,
                         NULL, rsInitConfig->gxs_passwd);
 
+#ifdef RS_USE_WIKI
         p3Wiki *mWiki = new p3Wiki(wiki_ds, NULL, mGxsIdService);
-
-        // create GXS photo service
+        // create GXS wiki service
         RsGxsNetService* wiki_ns = new RsGxsNetService(
                         RS_SERVICE_GXS_TYPE_WIKI, wiki_ds, nxsMgr, 
 			mWiki, mWiki->getServiceInfo(), 
@@ -1374,6 +1374,7 @@ int RsServer::StartupRetroShare()
 			pgpAuxUtils);
 
     mWiki->setNetworkExchangeService(wiki_ns) ;
+#endif
 
         /**** Forum GXS service ****/
 
@@ -1443,7 +1444,9 @@ int RsServer::StartupRetroShare()
         pqih->addService(gxsid_ns, true);
         pqih->addService(gxscircles_ns, true);
         pqih->addService(posted_ns, true);
+#ifdef RS_USE_WIKI
         pqih->addService(wiki_ns, true);
+#endif
         pqih->addService(gxsforums_ns, true);
         pqih->addService(gxschannels_ns, true);
         //pqih->addService(photo_ns, true);
@@ -1619,7 +1622,9 @@ int RsServer::StartupRetroShare()
 	mConfigMgr->addConfiguration("gxschannels.cfg", gxschannels_ns);
 	mConfigMgr->addConfiguration("gxscircles.cfg", gxscircles_ns);
 	mConfigMgr->addConfiguration("posted.cfg", posted_ns);
+#ifdef RS_USE_WIKI
 	mConfigMgr->addConfiguration("wiki.cfg", wiki_ns);
+#endif
 	//mConfigMgr->addConfiguration("photo.cfg", photo_ns);
 	//mConfigMgr->addConfiguration("wire.cfg", wire_ns);
 #endif
@@ -1728,7 +1733,9 @@ int RsServer::StartupRetroShare()
 	// Must Set the GXS pointers before starting threads.
     rsIdentity = mGxsIdService;
     rsGxsCircles = mGxsCircles;
+#if RS_USE_WIKI
     rsWiki = mWiki;
+#endif
     rsPosted = mPosted;
     rsGxsForums = mGxsForums;
     rsGxsChannels = mGxsChannels;
@@ -1739,7 +1746,9 @@ int RsServer::StartupRetroShare()
     startServiceThread(mGxsIdService);
     startServiceThread(mGxsCircles);
     startServiceThread(mPosted);
+#if RS_USE_WIKI
     startServiceThread(mWiki);
+#endif
     startServiceThread(mGxsForums);
     startServiceThread(mGxsChannels);
 
@@ -1750,7 +1759,9 @@ int RsServer::StartupRetroShare()
     startServiceThread(gxsid_ns);
     startServiceThread(gxscircles_ns);
     startServiceThread(posted_ns);
+#if RS_USE_WIKI
     startServiceThread(wiki_ns);
+#endif
     startServiceThread(gxsforums_ns);
     startServiceThread(gxschannels_ns);
 

--- a/retroshare-gui/src/gui/WikiPoos/WikiDialog.h
+++ b/retroshare-gui/src/gui/WikiPoos/WikiDialog.h
@@ -26,7 +26,7 @@
 
 #include <QMessageBox>
 
-#include "retroshare-gui/mainpage.h"
+#include "gui/gxs/RsGxsUpdateBroadcastPage.h"
 #include "ui_WikiDialog.h"
 
 #include <retroshare/rswiki.h>
@@ -40,7 +40,7 @@
 class WikiAddDialog;
 class WikiEditDialog;
 
-class WikiDialog : public MainPage, public TokenResponse
+class WikiDialog : public RsGxsUpdateBroadcastPage, public TokenResponse
 {
   Q_OBJECT
 
@@ -52,12 +52,13 @@ public:
 	virtual QString pageName() const { return tr("Wiki Pages") ; } //MainPage
 	virtual QString helpText() const { return ""; } //MainPage
 
+	void loadRequest(const TokenQueue *queue, const TokenRequest &req);
 
-void 	loadRequest(const TokenQueue *queue, const TokenRequest &req);
+public:
+	virtual void updateDisplay(bool complete);
 
 private slots:
 
-	void checkUpdate();
 	void OpenOrShowAddPageDialog();
 	void OpenOrShowAddGroupDialog();
 	void OpenOrShowEditDialog();
@@ -68,8 +69,6 @@ private slots:
 	void newGroup();
 	void showGroupDetails();
 	void editGroupDetails();
-
-	void insertWikiGroups();
 
 	// GroupTreeWidget stuff.
 	void groupListCustomPopupMenu(QPoint point);

--- a/retroshare-gui/src/gui/WikiPoos/WikiEditDialog.cpp
+++ b/retroshare-gui/src/gui/WikiPoos/WikiEditDialog.cpp
@@ -733,7 +733,7 @@ void WikiEditDialog::loadBaseHistory(const uint32_t &token)
 			modItem->setText(WET_COL_DATE, text);
 			modItem->setData(WET_COL_DATE, WET_ROLE_SORT, sort);
 		}
-		modItem->setId(page.mMeta.mAuthorId, WET_COL_AUTHORID);
+		modItem->setId(page.mMeta.mAuthorId, WET_COL_AUTHORID, false);
         modItem->setText(WET_COL_PAGEID, QString::fromStdString(page.mMeta.mMsgId.toStdString()));
 
 		ui.treeWidget_History->addTopLevelItem(modItem);
@@ -847,7 +847,7 @@ void WikiEditDialog::loadEditTreeData(const uint32_t &token)
 			modItem->setText(WET_COL_DATE, text);
 			modItem->setData(WET_COL_DATE, WET_ROLE_SORT, sort);
 		}
-		modItem->setId(snapshot.mMeta.mAuthorId, WET_COL_AUTHORID);
+		modItem->setId(snapshot.mMeta.mAuthorId, WET_COL_AUTHORID, false);
         modItem->setText(WET_COL_PAGEID, QString::fromStdString(snapshot.mMeta.mMsgId.toStdString()));
 
 		/* find the parent */

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -69,7 +69,6 @@ linux-* {
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -lX11 -lXss
 
-	#LIBS *= -lglib-2.0
 	LIBS *= -rdynamic -ldl
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
 	DEFINES *= UBUNTU

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -1108,7 +1108,8 @@ wikipoos {
 	HEADERS += gui/WikiPoos/WikiDialog.h \
 		gui/WikiPoos/WikiAddDialog.h \
 		gui/WikiPoos/WikiEditDialog.h \
-	
+		gui/gxs/WikiGroupDialog.h \
+
 	FORMS += gui/WikiPoos/WikiDialog.ui \
 		gui/WikiPoos/WikiAddDialog.ui \
 		gui/WikiPoos/WikiEditDialog.ui \
@@ -1116,10 +1117,10 @@ wikipoos {
 	SOURCES += gui/WikiPoos/WikiDialog.cpp \
 		gui/WikiPoos/WikiAddDialog.cpp \
 		gui/WikiPoos/WikiEditDialog.cpp \
-	
+		gui/gxs/WikiGroupDialog.cpp \
+
 	RESOURCES += gui/WikiPoos/Wiki_images.qrc
 
-	DEFINES *= RS_USE_WIKI
 }
 	
 	
@@ -1293,7 +1294,6 @@ posted {
 gxsgui {
 	
 	HEADERS += gui/gxs/GxsGroupDialog.h \
-		gui/gxs/WikiGroupDialog.h \
 		gui/gxs/GxsIdDetails.h \
 		gui/gxs/GxsIdChooser.h \
 		gui/gxs/GxsIdLabel.h \
@@ -1330,7 +1330,6 @@ gxsgui {
 #		gui/gxs/GxsCommentTreeWidget.ui 
 	
 	SOURCES += gui/gxs/GxsGroupDialog.cpp \
-		gui/gxs/WikiGroupDialog.cpp \
 		gui/gxs/GxsIdDetails.cpp \
 		gui/gxs/GxsIdChooser.cpp \
 		gui/gxs/GxsIdLabel.cpp \

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -34,13 +34,6 @@ CONFIG += gxsgui
 
 DEFINES += RS_ENABLE_GXS
 
-unfinished {
-	CONFIG += gxscircles
-	CONFIG += gxsthewire
-	CONFIG += gxsphotoshare
-	CONFIG += wikipoos
-}
-
 # Other Disabled Bits.
 #CONFIG += framecatcher
 #CONFIG += blogs
@@ -79,8 +72,6 @@ linux-* {
 
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -lX11 -lXss
-
-	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 
 	#LIBS *= -lglib-2.0
 	LIBS *= -rdynamic -ldl
@@ -199,7 +190,6 @@ win32 {
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
 	LIBS += -L"$$LIBS_DIR/lib"
 
-	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 	LIBS += -lsqlcipher
 
 	LIBS += -lssl -lcrypto -lpthread -lminiupnpc -lz -lws2_32
@@ -245,8 +235,6 @@ macx {
 	LIBS += -framework CoreFoundation
 	LIBS += -framework Security
 
-	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
-
 	LIBS += ../../../lib/libsqlcipher.a
 	#LIBS += -lsqlite3
 
@@ -266,7 +254,6 @@ freebsd-* {
 	LIBS *= -lgnome-keyring
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
 
-	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 	LIBS += -lsqlite3
 }
 
@@ -284,7 +271,6 @@ openbsd-* {
 	LIBS *= -lgnome-keyring
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
 
-	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 	LIBS += -lsqlite3
 
 	LIBS *= -rdynamic
@@ -301,6 +287,10 @@ openbsd-* {
 
 DEPENDPATH += . ../../libretroshare/src/
 INCLUDEPATH += ../../libretroshare/src/
+
+wikipoos {
+	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
+}
 
 # webinterface
 DEPENDPATH += ../../libresapi/src

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -30,10 +30,6 @@ CONFIG += gxschannels
 CONFIG += posted
 CONFIG += gxsgui
 
-# Gxs is always enabled now.
-
-DEFINES += RS_ENABLE_GXS
-
 # Other Disabled Bits.
 #CONFIG += framecatcher
 #CONFIG += blogs

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -10,10 +10,6 @@ CONFIG += webui
 CONFIG -= qt xml gui
 CONFIG += link_prl
 
-# if you are linking against the libretroshare with gxs.
-# this option links against the required sqlite library.
-CONFIG += gxs
-
 #CONFIG += debug
 debug {
         QMAKE_CFLAGS -= -O2

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -15,3 +15,5 @@ unfinished {
 	CONFIG += gxsphotoshare
 	CONFIG += wikipoos
 }
+
+wikipoos:DEFINES *= RS_USE_WIKI

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -5,3 +5,10 @@ unix {
 	isEmpty(LIB_DIR)  { LIB_DIR  = "$${PREFIX}/lib" }
 	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }
 }
+
+unfinished {
+	CONFIG += gxscircles
+	CONFIG += gxsthewire
+	CONFIG += gxsphotoshare
+	CONFIG += wikipoos
+}

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -1,3 +1,6 @@
+# Gxs is always enabled now.
+DEFINES *= RS_ENABLE_GXS
+
 unix {
 	isEmpty(PREFIX)   { PREFIX   = "/usr" }
 	isEmpty(BIN_DIR)  { BIN_DIR  = "$${PREFIX}/bin" }

--- a/supportlibs/pegmarkdown/pegmarkdown.pro
+++ b/supportlibs/pegmarkdown/pegmarkdown.pro
@@ -1,5 +1,6 @@
 TEMPLATE = lib
 CONFIG += staticlib
+CONFIG += create_prl
 CONFIG -= qt
 TARGET = pegmarkdown
 
@@ -15,6 +16,7 @@ debug {
 ################################# Linux ##########################################
 linux-* {
 	DESTDIR = lib
+	LIBS *= -lglib-2.0
 }
 
 linux-g++ {


### PR DESCRIPTION
pegmarkdown is only used by the gui parts of the wiki, which is currently disabled, so building it by default is not necessary. Also with the gui disabled, the wiki parts in libretroshare are unused so I disabled those, too. Both can be enabled with CONFIG+=wikipoos.

The wiki gui was bitrotting a bit, using a no longer existing function (rsWiki->updated()), so I ported it to use RsGxsUpdateBroadcastPage. That makes it compile and work as good as it ever has.
