### PR TITLE
Qmake: Use PKGCONFIG and reduce duplicate code in .pro files

### DIFF
--- a/libbitdht/src/libbitdht.pro
+++ b/libbitdht/src/libbitdht.pro
@@ -4,6 +4,8 @@ TEMPLATE = lib
 CONFIG += staticlib
 CONFIG -= qt
 TARGET = bitdht
+DESTDIR = lib
+
 QMAKE_CXXFLAGS *= -Wall -DBE_DEBUG
 
 profiling {
@@ -27,7 +29,6 @@ debug {
 
 ################################# Linux ##########################################
 linux-* {
-	DESTDIR = lib
 	QMAKE_CC = g++
 }
 
@@ -50,7 +51,6 @@ unix {
 
 win32-x-g++ {	
 	OBJECTS_DIR = temp/win32xgcc/obj
-	DESTDIR = lib.win32xgcc
 	# These have been replaced by _WIN32 && __MINGW32__
 	# DEFINES *= WINDOWS_SYS WIN32 WIN_CROSS_UBUNTU
 	QMAKE_CXXFLAGS *= -Wmissing-include-dirs
@@ -70,7 +70,6 @@ win32 {
 		DEFINES *= STATICLIB WIN32_LEAN_AND_MEAN _USE_32BIT_TIME_T
 		# These have been replaced by _WIN32 && __MINGW32__
 		#DEFINES *= WINDOWS_SYS WIN32 STATICLIB MINGW
-		DESTDIR = lib
 
 		# Switch on extra warnings
 		QMAKE_CFLAGS += -Wextra
@@ -93,19 +92,16 @@ mac {
 		QMAKE_CC = g++
 		OBJECTS_DIR = temp/obj
 		MOC_DIR = temp/moc
-		DESTDIR = lib
 }
 
 ################################# FreeBSD ##########################################
 
 freebsd-* {
-		DESTDIR = lib
 }
 
 ################################# OpenBSD ##########################################
 
 openbsd-* {
-		DESTDIR = lib
 }
 
 ################################### COMMON stuff ##################################

--- a/libbitdht/src/libbitdht.pro
+++ b/libbitdht/src/libbitdht.pro
@@ -168,5 +168,3 @@ SOURCES += \
 	bitdht/bdquerymgr.cc	\
 	util/bdbloom.cc		\
 	bitdht/bdfriendlist.cc	\
-
-

--- a/libresapi/src/libresapi.pro
+++ b/libresapi/src/libresapi.pro
@@ -2,8 +2,10 @@
 
 TEMPLATE = lib
 CONFIG += staticlib
+CONFIG += create_prl
 CONFIG -= qt
 TARGET = resapi
+TARGET_PRL = libresapi
 DESTDIR = lib
 
 CONFIG += libmicrohttpd
@@ -26,6 +28,12 @@ win32{
 }
 
 libmicrohttpd{
+	linux {
+		CONFIG += link_pkgconfig
+		PKGCONFIG *= libmicrohttpd
+	} else {
+		LIBS *= -lmicrohttpd
+	}
 	SOURCES += \
 		api/ApiServerMHD.cpp
 

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -281,6 +281,10 @@ mac {
 		INCLUDEPATH += . $${UPNPC_DIR} 
 
 		#INCLUDEPATH += . $${UPNPC_DIR} $${GPGME_DIR}/src $${GPG_ERROR_DIR}/src
+
+		# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
+		LIBS += ../../../lib/libsqlcipher.a
+		#LIBS += -lsqlite3
 }
 
 ################################# FreeBSD ##########################################

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -6,6 +6,7 @@ CONFIG += create_prl
 CONFIG -= qt
 TARGET = retroshare
 TARGET_PRL = libretroshare
+DESTDIR = lib
 
 #CONFIG += dsdv
 
@@ -72,15 +73,13 @@ SOURCES +=	tcponudp/udppeer.cc \
 		tcponudp/udpstunner.cc \
 		tcponudp/udprelay.cc \
 
+	DEFINES *= RS_USE_BITDHT
 
-        BITDHT_DIR = ../../libbitdht/src
+	BITDHT_DIR = ../../libbitdht/src
 	DEPENDPATH += . $${BITDHT_DIR}
 	INCLUDEPATH += . $${BITDHT_DIR}
-	# The next line is for compliance with debian packages. Keep it!
-	INCLUDEPATH += ../libbitdht
-	DEFINES *= RS_USE_BITDHT
-	PRE_TARGETDEPS *= ../../libbitdht/src/lib/libbitdht.a
-	LIBS += ../../libbitdht/src/lib/libbitdht.a
+	PRE_TARGETDEPS *= $${BITDHT_DIR}/lib/libbitdht.a
+	LIBS *= $${BITDHT_DIR}/lib/libbitdht.a
 }
 
 
@@ -122,11 +121,6 @@ HEADERS += $$PUBLIC_HEADERS
 linux-* {
 	CONFIG += link_pkgconfig
 
-	OPENPGPSDK_DIR = ../../openpgpsdk/src
-	DEPENDPATH *= $${OPENPGPSDK_DIR} ../openpgpsdk
-	INCLUDEPATH *= $${OPENPGPSDK_DIR} ../openpgpsdk
-
-	DESTDIR = lib
 	QMAKE_CXXFLAGS *= -Wall -D_FILE_OFFSET_BITS=64
 	QMAKE_CC = g++
 
@@ -150,7 +144,6 @@ linux-* {
 	}
 
 	#CONFIG += version_detail_bash_script
-
 
 	# linux/bsd can use either - libupnp is more complete and packaged.
 	#CONFIG += upnp_miniupnpc 
@@ -210,7 +203,6 @@ version_detail_bash_script {
 
 win32-x-g++ {	
 	OBJECTS_DIR = temp/win32xgcc/obj
-	DESTDIR = lib.win32xgcc
 	DEFINES *= WINDOWS_SYS WIN32 WIN_CROSS_UBUNTU
 	QMAKE_CXXFLAGS *= -Wmissing-include-dirs
 	QMAKE_CC = i586-mingw32msvc-g++
@@ -237,7 +229,6 @@ win32 {
 	DEFINES *= MINIUPNPC_VERSION=13
 	# This defines the platform to be WinXP or later and is needed for getaddrinfo (_WIN32_WINNT_WINXP)
 	DEFINES *= WINVER=0x0501
-	DESTDIR = lib
 
 	# Switch on extra warnings
 	QMAKE_CFLAGS += -Wextra
@@ -260,10 +251,9 @@ win32 {
 	LIBS += -lsqlcipher
 
 	LIBS_DIR = $$PWD/../../../libs
-	OPENPGPSDK_DIR = $$PWD/../../openpgpsdk/src
 
-	DEPENDPATH += . $$LIBS_DIR/include $$LIBS_DIR/include/miniupnpc $$OPENPGPSDK_DIR
-	INCLUDEPATH += . $$LIBS_DIR/include $$LIBS_DIR/include/miniupnpc $$OPENPGPSDK_DIR
+	DEPENDPATH += . $$LIBS_DIR/include $$LIBS_DIR/include/miniupnpc
+	INCLUDEPATH += . $$LIBS_DIR/include $$LIBS_DIR/include/miniupnpc
 }
 
 ################################# MacOSX ##########################################
@@ -274,7 +264,6 @@ mac {
 		MOC_DIR = temp/moc
 		#DEFINES = WINDOWS_SYS WIN32 STATICLIB MINGW
                 #DEFINES *= MINIUPNPC_VERSION=13
-		DESTDIR = lib
 
 		CONFIG += upnp_miniupnpc
 
@@ -289,12 +278,8 @@ mac {
 		#GPG_ERROR_DIR = ../../../../libgpg-error-1.7
 		#GPGME_DIR  = ../../../../gpgme-1.1.8
 
-		OPENPGPSDK_DIR = ../../openpgpsdk/src
-
 		INCLUDEPATH += . $${UPNPC_DIR} 
-		INCLUDEPATH += $${OPENPGPSDK_DIR} 
 
-		#../openpgpsdk
 		#INCLUDEPATH += . $${UPNPC_DIR} $${GPGME_DIR}/src $${GPG_ERROR_DIR}/src
 }
 
@@ -309,8 +294,6 @@ freebsd-* {
 	# linux/bsd can use either - libupnp is more complete and packaged.
 	#CONFIG += upnp_miniupnpc 
 	CONFIG += upnp_libupnp
-
-	DESTDIR = lib
 }
 
 ################################# OpenBSD ##########################################
@@ -319,21 +302,19 @@ openbsd-* {
 	INCLUDEPATH *= /usr/local/include
 	INCLUDEPATH += $$system(pkg-config --cflags glib-2.0 | sed -e "s/-I//g")
 
-	OPENPGPSDK_DIR = ../../openpgpsdk/src
-	INCLUDEPATH *= $${OPENPGPSDK_DIR} ../openpgpsdk
-
 	QMAKE_CXXFLAGS *= -Dfseeko64=fseeko -Dftello64=ftello -Dstat64=stat -Dstatvfs64=statvfs -Dfopen64=fopen
 
 	CONFIG += upnp_libupnp
-
-	DESTDIR = lib
 }
 
 ################################### COMMON stuff ##################################
 
 # openpgpsdk
-PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
-LIBS *= ../../openpgpsdk/src/lib/libops.a -lbz2
+OPENPGPSDK_DIR = ../../openpgpsdk/src
+DEPENDPATH *= $${OPENPGPSDK_DIR}
+INCLUDEPATH *= $${OPENPGPSDK_DIR}
+PRE_TARGETDEPS *= $${OPENPGPSDK_DIR}/lib/libops.a
+LIBS *= $${OPENPGPSDK_DIR}/lib/libops.a -lbz2
 
 HEADERS +=	dbase/cachestrapper.h \
 			dbase/fimonitor.h \

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -120,8 +120,7 @@ HEADERS += $$PUBLIC_HEADERS
 
 ################################# Linux ##########################################
 linux-* {
-	# These two lines fixe compilation on ubuntu natty. Probably a ubuntu packaging error.
-	INCLUDEPATH += $$system(pkg-config --cflags glib-2.0 | sed -e "s/-I//g")
+	CONFIG += link_pkgconfig
 
 	OPENPGPSDK_DIR = ../../openpgpsdk/src
 	DEPENDPATH *= $${OPENPGPSDK_DIR} ../openpgpsdk
@@ -131,17 +130,12 @@ linux-* {
 	QMAKE_CXXFLAGS *= -Wall -D_FILE_OFFSET_BITS=64
 	QMAKE_CC = g++
 
-	SSL_DIR = /usr/include/openssl
-	UPNP_DIR = /usr/include/upnp
-	DEPENDPATH += . $${SSL_DIR} $${UPNP_DIR}
-	INCLUDEPATH += . $${SSL_DIR} $${UPNP_DIR}
-
 	contains(CONFIG, NO_SQLCIPHER) {
 		DEFINES *= NO_SQLCIPHER
-		LIBS *= -lsqlite3
+		PKGCONFIG *= sqlite3
 	} else {
-	        SQLCIPHER_OK = $$system(pkg-config --exists sqlcipher && echo yes)
-	        isEmpty(SQLCIPHER_OK) {
+		SQLCIPHER_OK = $$system(pkg-config --exists sqlcipher && echo yes)
+		isEmpty(SQLCIPHER_OK) {
 			# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
 			exists(../../../lib/sqlcipher/.libs/libsqlcipher.a) {
 				LIBS += ../../../lib/sqlcipher/.libs/libsqlcipher.a
@@ -151,7 +145,7 @@ linux-* {
 				error("libsqlcipher is not installed and libsqlcipher.a not found. SQLCIPHER is necessary for encrypted database, to build with unencrypted database, run: qmake CONFIG+=NO_SQLCIPHER")
 			}
 		} else {
-			LIBS *= -lsqlcipher
+			PKGCONFIG *= sqlcipher
 		}
 	}
 
@@ -163,7 +157,7 @@ linux-* {
 	CONFIG += upnp_libupnp
 
 	# Check if the systems libupnp has been Debian-patched
-	system(grep -E 'char[[:space:]]+PublisherUrl' $${UPNP_DIR}/upnp.h >/dev/null 2>&1) {
+	system(grep -E 'char[[:space:]]+PublisherUrl' /usr/include/upnp/upnp.h >/dev/null 2>&1) {
 		# Normal libupnp
 	} else {
 		# Patched libupnp or new unreleased version
@@ -171,10 +165,10 @@ linux-* {
 	}
 
 	DEFINES *= UBUNTU
-	INCLUDEPATH += /usr/include/glib-2.0/ /usr/lib/glib-2.0/include
-	LIBS *= -lgnome-keyring
-	LIBS *= -lssl -lupnp -lixml
-	LIBS *= -lcrypto -lz -lpthread
+	PKGCONFIG *= gnome-keyring-1
+	PKGCONFIG *= libssl libupnp
+	PKGCONFIG *= libcrypto zlib
+	LIBS *= -lpthread -ldl
 }
 
 unix {

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -165,7 +165,7 @@ linux-* {
 }
 
 unix {
-	DEFINES *= LIB_DIR=\"\\\"$${LIB_DIR}\\\"\"
+	DEFINES *= PLUGIN_DIR=\"\\\"$${PLUGIN_DIR}\\\"\"
 	DEFINES *= DATA_DIR=\"\\\"$${DATA_DIR}\\\"\"
 
 	## where to put the librarys interface

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -1251,7 +1251,7 @@ int RsServer::StartupRetroShare()
 	std::vector<std::string> plugins_directories ;
 
 #ifndef WINDOWS_SYS
-	plugins_directories.push_back(std::string(LIB_DIR) + "/retroshare/extensions6/") ;
+	plugins_directories.push_back(std::string(PLUGIN_DIR)) ;
 #endif
 	std::string extensions_dir = rsAccounts->PathBaseDirectory() + "/extensions6/" ;
 	plugins_directories.push_back(extensions_dir) ;

--- a/plugins/Common/retroshare_plugin.pri
+++ b/plugins/Common/retroshare_plugin.pri
@@ -7,7 +7,7 @@ DEPENDPATH += ../../libretroshare/src/ ../../retroshare-gui/src/
 INCLUDEPATH += ../../libretroshare/src/ ../../retroshare-gui/src/
 
 unix {
-	target.path = "$${LIB_DIR}/retroshare/extensions6"
+	target.path = "$${PLUGIN_DIR}"
 	INSTALLS += target
 }
 

--- a/plugins/FeedReader/FeedReader.pro
+++ b/plugins/FeedReader/FeedReader.pro
@@ -81,12 +81,9 @@ TRANSLATIONS +=  \
 			lang/FeedReader_zh_CN.ts
 
 linux-* {
-	LIBXML2_DIR = /usr/include/libxml2
+	CONFIG += link_pkgconfig
 
-	DEPENDPATH += $${LIBXML2_DIR}
-	INCLUDEPATH += $${LIBXML2_DIR}
-
-	LIBS += -lcurl -lxml2 -lxslt
+	PKGCONFIG *= libcurl libxml-2.0 libxslt
 }
 
 win32 {
@@ -102,4 +99,3 @@ openbsd-* {
 
 	LIBS += -lcurl -lxml2 -lxslt
 }
-

--- a/plugins/VOIP/VOIP.pro
+++ b/plugins/VOIP/VOIP.pro
@@ -21,10 +21,11 @@ INCLUDEPATH += ../../retroshare-gui/src/temp/ui ../../libretroshare/src
 linux-* {
 	CONFIG += link_pkgconfig
 
-	# Necessary for openSUSE
 	PKGCONFIG += libavcodec libavutil
-
+	PKGCONFIG += speex speexdsp
 	PKGCONFIG += opencv
+} else {
+	LIBS += -lspeex -lspeexdsp -lavcodec -lavutil
 }
 
 win32 {
@@ -103,5 +104,3 @@ TRANSLATIONS +=  \
             lang/VOIP_sv.ts \
             lang/VOIP_tr.ts \
             lang/VOIP_zh_CN.ts
-
-LIBS += -lspeex -lspeexdsp -lavcodec -lavutil

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -220,9 +220,6 @@ macx {
 	LIBS += -framework CoreFoundation
 	LIBS += -framework Security
 
-	LIBS += ../../../lib/libsqlcipher.a
-	#LIBS += -lsqlite3
-
 	INCLUDEPATH += .
 	#DEFINES* = MAC_IDLE # for idle feature
 	CONFIG -= uitools

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -64,9 +64,6 @@ linux-* {
 	#CONFIG += version_detail_bash_script
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-
-	LIBS += ../../libretroshare/src/lib/libretroshare.a
 	PKGCONFIG *= x11 xscrnsaver
 
 	LIBS *= -rdynamic
@@ -130,7 +127,6 @@ version_detail_bash_script {
 win32-x-g++ {
 		OBJECTS_DIR = temp/win32-x-g++/obj
 
-		LIBS += ../../libretroshare/src/lib.win32xgcc/libretroshare.a
 		LIBS += ../../../../lib/win32-x-g++-v0.5/libssl.a
 		LIBS += ../../../../lib/win32-x-g++-v0.5/libcrypto.a
 		LIBS += ../../../../lib/win32-x-g++-v0.5/libgpgme.dll.a
@@ -178,11 +174,8 @@ win32 {
 	#LIBS += -L"D/Qt/2009.03/qt/plugins/imageformats"
 	#QTPLUGIN += qjpeg
 
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-
 	LIBS_DIR = $$PWD/../../../libs
 
-	LIBS += ../../libretroshare/src/lib/libretroshare.a
 	LIBS += -L"$$LIBS_DIR/lib"
 
 	LIBS += -lssl -lcrypto -lpthread -lminiupnpc -lz -lws2_32
@@ -221,7 +214,6 @@ macx {
 	QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.4
 
 	CONFIG += version_detail_bash_script
-	LIBS += ../../libretroshare/src/lib/libretroshare.a
         LIBS += -lssl -lcrypto -lz 
         #LIBS += -lssl -lcrypto -lz -lgpgme -lgpg-error -lassuan
 	LIBS += ../../../miniupnpc-1.0/libminiupnpc.a
@@ -240,12 +232,10 @@ macx {
 
 freebsd-* {
 	INCLUDEPATH *= /usr/local/include/gpgme
-	LIBS *= ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -lssl
 	LIBS *= -lgpgme
 	LIBS *= -lupnp
 	LIBS *= -lgnome-keyring
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
 
 	LIBS += -lsqlite3
 }
@@ -255,17 +245,11 @@ freebsd-* {
 openbsd-* {
 	INCLUDEPATH *= /usr/local/include
 
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-
-	LIBS *= ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -lssl -lcrypto
 	LIBS *= -lgpgme
 	LIBS *= -lupnp
 	LIBS *= -lgnome-keyring
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-
 	LIBS += -lsqlite3
-
 	LIBS *= -rdynamic
 }
 
@@ -281,8 +265,12 @@ openbsd-* {
 DEPENDPATH += . ../../libretroshare/src/
 INCLUDEPATH += ../../libretroshare/src/
 
+PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
+LIBS *= ../../libretroshare/src/lib/libretroshare.a
+
 wikipoos {
-	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
+	PRE_TARGETDEPS *= ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
+	LIBS *= ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
 }
 
 # webinterface

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -1,8 +1,10 @@
 !include("../../retroshare.pri"): error("Could not include file ../../retroshare.pri")
 
+TEMPLATE = app
 QT     += network xml
 CONFIG += qt gui uic qrc resources idle bitdht
 CONFIG += link_prl
+TARGET = RetroShare06
 
 # Plz never commit the .pro with these flags enabled.
 # Use this flag when developping new features only.
@@ -34,9 +36,6 @@ CONFIG += gxsgui
 #CONFIG += framecatcher
 #CONFIG += blogs
 
-TEMPLATE = app
-TARGET = RetroShare06
-
 DEFINES += RS_RELEASE_VERSION
 RCC_DIR = temp/qrc
 UI_DIR  = temp/ui
@@ -61,15 +60,16 @@ INCLUDEPATH *= retroshare-gui
 ################################# Linux ##########################################
 # Put lib dir in QMAKE_LFLAGS so it appears before -L/usr/lib
 linux-* {
+	CONFIG += link_pkgconfig
 	#CONFIG += version_detail_bash_script
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
 
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS *= -lX11 -lXss
+	PKGCONFIG *= x11 xscrnsaver
 
-	LIBS *= -rdynamic -ldl
+	LIBS *= -rdynamic
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
 	DEFINES *= UBUNTU
 }
@@ -289,7 +289,7 @@ wikipoos {
 DEPENDPATH += ../../libresapi/src
 INCLUDEPATH += ../../libresapi/src
 PRE_TARGETDEPS *= ../../libresapi/src/lib/libresapi.a
-LIBS += ../../libresapi/src/lib/libresapi.a -lmicrohttpd
+LIBS += ../../libresapi/src/lib/libresapi.a
 
 # Input
 HEADERS +=  rshare.h \

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -27,7 +27,7 @@ linux-* {
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
 	LIBS += ../../libretroshare/src/lib/libretroshare.a
-	LIBS *= -rdynamic -ldl
+	LIBS *= -rdynamic
 }
 
 unix {
@@ -169,7 +169,7 @@ introserver {
 webui {
 	DEFINES *= ENABLE_WEBUI
         PRE_TARGETDEPS *= ../../libresapi/src/lib/libresapi.a
-	LIBS += ../../libresapi/src/lib/libresapi.a -lmicrohttpd
+	LIBS += ../../libresapi/src/lib/libresapi.a
         DEPENDPATH += ../../libresapi/src
 	INCLUDEPATH += ../../libresapi/src
         HEADERS += \

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -26,7 +26,6 @@ linux-* {
 	#CONFIG += version_detail_bash_script
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
-	LIBS += ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -rdynamic
 }
 
@@ -48,7 +47,6 @@ linux-g++-64 {
 win32-x-g++ {
 	OBJECTS_DIR = temp/win32-x-g++/obj
 
-	LIBS += ../../../../lib/win32-x-g++/libretroshare.a 
 	LIBS += ../../../../lib/win32-x-g++/libssl.a 
 	LIBS += ../../../../lib/win32-x-g++/libcrypto.a 
 	LIBS += ../../../../lib/win32-x-g++/libminiupnpc.a 
@@ -74,11 +72,8 @@ win32 {
 	# solve linker warnings because of the order of the libraries
 	QMAKE_LFLAGS += -Wl,--start-group
 
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-
 	LIBS_DIR = $$PWD/../../../libs
 
-	LIBS += ../../libretroshare/src/lib/libretroshare.a
 	LIBS += -L"$$LIBS_DIR/lib"
 	LIBS += -lssl -lcrypto -lpthread -lminiupnpc -lz
 	LIBS += -lcrypto -lws2_32 -lgdi32
@@ -102,7 +97,6 @@ macx {
     # CONFIG += ppc x86 
 
 	LIBS += -Wl,-search_paths_first
-	LIBS += ../../libretroshare/src/lib/libretroshare.a
         LIBS += -lssl -lcrypto -lz 
 	LIBS += ../../../miniupnpc-1.0/libminiupnpc.a
 	LIBS += -framework CoreFoundation
@@ -127,12 +121,10 @@ macx {
 
 freebsd-* {
 	INCLUDEPATH *= /usr/local/include/gpgme
-	LIBS *= ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -lssl
 	LIBS *= -lgpgme
 	LIBS *= -lupnp
 	LIBS *= -lgnome-keyring
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
 }
 
 ##################################### OpenBSD  ######################################
@@ -140,12 +132,10 @@ freebsd-* {
 openbsd-* {
 	INCLUDEPATH *= /usr/local/include
 	QMAKE_CXXFLAGS *= -Dfseeko64=fseeko -Dftello64=ftello -Dstat64=stat -Dstatvfs64=statvfs -Dfopen64=fopen
-	LIBS *= ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -lssl -lcrypto
 	LIBS *= -lgpgme
 	LIBS *= -lupnp
 	LIBS *= -lgnome-keyring
-	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
 	LIBS *= -rdynamic
 }
 
@@ -154,6 +144,9 @@ openbsd-* {
 
 DEPENDPATH += . ../../libretroshare/src
 INCLUDEPATH += . ../../libretroshare/src
+
+PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
+LIBS *= ../../libretroshare/src/lib/libretroshare.a
 
 # Input
 HEADERS +=  notifytxt.h

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -102,12 +102,6 @@ macx {
 	LIBS += -framework CoreFoundation
 	LIBS += -framework Security
 
-	gxs {
-		# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
-	    # LIBS += ../../../lib/sqlcipher/.libs/libsqlcipher.a
-	    LIBS += ../../../lib/libsqlcipher.a
-	}
-
 	sshserver {
 		LIBS += -L../../../lib
 		#LIBS += -L../../../lib/libssh-0.6.0

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -7,6 +7,7 @@ unix {
 	isEmpty(INC_DIR)  { INC_DIR  = "$${PREFIX}/include/retroshare06" }
 	isEmpty(LIB_DIR)  { LIB_DIR  = "$${PREFIX}/lib" }
 	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }
+	isEmpty(PLUGIN_DIR) { PLUGIN_DIR  = "$${LIB_DIR}/retroshare/extensions6" }
 }
 
 unfinished {

--- a/supportlibs/pegmarkdown/pegmarkdown.pro
+++ b/supportlibs/pegmarkdown/pegmarkdown.pro
@@ -15,8 +15,9 @@ debug {
 
 ################################# Linux ##########################################
 linux-* {
-	DESTDIR = lib
-	LIBS *= -lglib-2.0
+	CONFIG += link_pkgconfig
+
+	PKGCONFIG *= glib-2.0
 }
 
 linux-g++ {

--- a/supportlibs/pegmarkdown/pegmarkdown.pro
+++ b/supportlibs/pegmarkdown/pegmarkdown.pro
@@ -3,6 +3,7 @@ CONFIG += staticlib
 CONFIG += create_prl
 CONFIG -= qt
 TARGET = pegmarkdown
+DESTDIR = lib
 
 QMAKE_CFLAGS *= -Wall -ansi  -D_GNU_SOURCE
 QMAKE_CC = gcc
@@ -33,7 +34,6 @@ linux-g++-64 {
 win32 {
 		OBJECTS_DIR = temp/obj
 		MOC_DIR = temp/moc
-		DESTDIR = lib
 
 		# Switch on extra warnings
 		QMAKE_CFLAGS += -Wextra
@@ -56,7 +56,6 @@ win32 {
 mac {
 		OBJECTS_DIR = temp/obj
 		MOC_DIR = temp/moc
-		DESTDIR = lib
 
 		CONFIG += dummy_glib 
 }
@@ -64,13 +63,11 @@ mac {
 ################################# FreeBSD ##########################################
 
 freebsd-* {
-		DESTDIR = lib
 }
 
 ################################# OpenBSD ##########################################
 
 openbsd-* {
-		DESTDIR = lib
 }
 
 ################################### COMMON stuff ##################################


### PR DESCRIPTION
The advantage of using PKGCONFIG is that this method automatically includes additional dependencies of LIBS (e.g. libupnp needs -lixml). Also if some distribution moves headers to non default locations the correct locations get added by PKGCONFIG. And if a dependency is missing, this will print an error when qmake is run, not only when linking.

The DESTDIR and LIBS (for libops.a and libretroshare.a) variables were defined multiple times with the same values in the platform specific parts, I moved those to the common section to declare only once.

I tested the compile on Arch, Debian 7 & 8, CentOS, Fedora and openSUSE.
