### PR TITLE
Create Debian source without re-cloning

### DIFF
--- a/build_scripts/Debian+Ubuntu/control.jessie
+++ b/build_scripts/Debian+Ubuntu/control.jessie
@@ -2,7 +2,7 @@ Source: retroshare06
 Section: devel
 Priority: standard
 Maintainer: Cyril Soler <csoler@users.sourceforge.net>
-Build-Depends: debhelper (>= 7),  libglib2.0-dev, libupnp-dev, qt4-dev-tools, libqt4-dev, libssl-dev, libxss-dev, libgnome-keyring-dev, libbz2-dev, libqt4-opengl-dev, libqtmultimediakit1, qtmobility-dev, libspeex-dev, libspeexdsp-dev, libxslt1-dev, cmake, libcurl4-openssl-dev, libopencv-dev, tcl8.6, libsqlcipher-dev, libmicrohttpd-dev, libavcodec-dev
+Build-Depends: debhelper (>= 7),  libglib2.0-dev, libupnp-dev, qt4-dev-tools, libqt4-dev, libssl-dev, libxss-dev, libgnome-keyring-dev, libbz2-dev, libqt4-opengl-dev, libqtmultimediakit1, qtmobility-dev, libspeex-dev, libspeexdsp-dev, libxslt1-dev, cmake, libcurl4-openssl-dev, libopencv-dev, tcl8.6, libmicrohttpd-dev
 Standards-Version: 3.9.3
 Homepage: http://retroshare.sourceforge.net
 
@@ -40,5 +40,3 @@ Description: Secure communication with friends
  friends and family, using a web-of-trust to authenticate peers and OpenSSL to 
  encrypt all communication. RetroShare provides filesharing, chat, messages, 
  forums and channels.
-
-

--- a/build_scripts/Debian+Ubuntu/control.wheezy
+++ b/build_scripts/Debian+Ubuntu/control.wheezy
@@ -2,7 +2,7 @@ Source: retroshare06
 Section: devel
 Priority: standard
 Maintainer: Cyril Soler <csoler@users.sourceforge.net>
-Build-Depends: debhelper (>= 7),  libglib2.0-dev, libupnp-dev, qt4-dev-tools, libqt4-dev, libssl-dev, libxss-dev, libgnome-keyring-dev, libbz2-dev, libqt4-opengl-dev, libqtmultimediakit1, qtmobility-dev, libspeex-dev, libspeexdsp-dev, libxslt1-dev, cmake, libcurl4-openssl-dev, libopencv-dev, tcl8.6, libsqlcipher-dev, libmicrohttpd-dev, libavcodec-dev
+Build-Depends: debhelper (>= 7),  libglib2.0-dev, libupnp-dev, qt4-dev-tools, libqt4-dev, libssl-dev, libxss-dev, libgnome-keyring-dev, libbz2-dev, libqt4-opengl-dev, libqtmultimediakit1, qtmobility-dev, libspeex-dev, libspeexdsp-dev, libxslt1-dev, cmake, libcurl4-openssl-dev, libopencv-dev, tcl8.5, libmicrohttpd-dev
 Standards-Version: 3.9.3
 Homepage: http://retroshare.sourceforge.net
 
@@ -40,5 +40,3 @@ Description: Secure communication with friends
  friends and family, using a web-of-trust to authenticate peers and OpenSSL to 
  encrypt all communication. RetroShare provides filesharing, chat, messages, 
  forums and channels.
-
-

--- a/build_scripts/Debian+Ubuntu/makeSourcePackage.sh
+++ b/build_scripts/Debian+Ubuntu/makeSourcePackage.sh
@@ -1,43 +1,33 @@
-#!/bin/sh
+#!/bin/bash
 
 ###################### PARAMETERS ####################
-version="0.6.0"
-gitpath="https://github.com/RetroShare/RetroShare.git"
-workdir=retroshare06-${version}
-#bubba3="Y"		# comment out to compile for bubba3
+VERSION="0.6.0"
 ######################################################
+dirs -c
 
-echo This script is going to build the debian source package for RetroShare, from the Git repository.
-
-if test -d "${workdir}" ;  then
-    echo Removing the ${workdir} directory...
-    rm -rf ${workdir}
-fi
+echo "This script is going to build the debian source package for RetroShare, from a clone of the GitHub repository."
+echo
 
 # Parse options
-rev=""
-dist=""
+REV=""
+DISTS=""
 # This is the key for "Cyril Soler <csoler@sourceforge.net>"
-gpgkey="0932399B"
+GPGKEY="0932399B"
 
 while [ ${#} -gt 0 ]; do
     case ${1} in
-        "-rev") shift
-            rev=${1}
-            shift
-            ;;
         "-distribution") shift
-            dist=${1}
+            DISTS=${1}
             shift
             ;;
         "-key") shift
-            gpgkey=${1}
+            GPGKEY=${1}
             shift
             ;;
         "-h") shift
-            echo Package building script for debian/ubuntu distributions
-            echo Usage:
-            echo "  "${0} '-key [PGP key id] -rev [svn revision number]  -distribution [distrib name list with quotes, in (wheezy, sid, precise, saucy, etc)]'
+            echo "Package building script for debian/ubuntu distributions"
+            echo "Usage:"
+            echo "  ${0} '-key [PGP key id] -rev [svn revision number]  -distribution [distrib name list with quotes, in (wheezy, sid, precise, saucy, etc)]'"
             exit 1
             ;;
         "*") echo "Unknown option"
@@ -46,99 +36,83 @@ while [ ${#} -gt 0 ]; do
     esac
 done
 
-if test "${dist}" = "" ; then
-	dist="precise trusty vivid"
+if test "${DISTS}" = "" ; then
+	DISTS="precise trusty vivid"
 fi
 
 echo Attempting to get revision number...
-ccount=`git rev-list --count --all`
-ccount=`expr $ccount + 8613 - 8267`
+CCOUNT=`git rev-list --count --all`
+CCOUNT=`expr ${CCOUNT} + 8613 - 8267`
 
-date=`git log --pretty=format:"%ai" | head -1 | cut -d\  -f1 | sed -e s/-//g`
-time=`git log --pretty=format:"%aD" | head -1 | cut -d\  -f5 | sed -e s/://g`
-hhsh=`git log --pretty=format:"%H" | head -1 | cut -c1-8`
+DATE=`git log --pretty=format:"%ai" | head -1 | cut -d\  -f1 | sed -e s/-//g`
+TIME=`git log --pretty=format:"%aD" | head -1 | cut -d\  -f5 | sed -e s/://g`
+HASH=`git log --pretty=format:"%H" | head -1 | cut -c1-8`
 
-rev=${date}.${hhsh}
+GITROOT=`git rev-parse --show-toplevel`
+REV=${DATE}.${HASH}
+FULL_VERSION="${VERSION}"."${REV}"
 
-echo "  "Using PGP key id   : ${gpgkey}
-echo "  "Using distributions: ${dist}
-echo "  "Commit count       : ${ccount}
-echo "  "Date               : ${date}
-echo "  "Time               : ${time}
-echo "  "Hash               : ${hhsh}
-echo "  "Using revision     : ${rev}
-
-echo Done.
-version="${version}"."${rev}"
-echo Got version number ${version}. 
-echo Please check that the changelog is up to date. 
-echo Hit ENTER if this is correct. Otherwise hit Ctrl+C 
+echo "Using PGP key id    : ${GPGKEY}"
+echo "Using distributions : ${DISTS}"
+echo "Commit count        : ${CCOUNT}"
+echo "Date                : ${DATE}"
+echo "Time                : ${TIME}"
+echo "Hash                : ${HASH}"
+echo "Using revision      : ${REV}"
+echo "Using version number: ${VERSION}"
+echo
+echo "Hit ENTER if this is correct. Otherwise hit Ctrl+C"
 read tmp
 
-echo Extracting base archive...
+WORKDIR="retroshare06-${FULL_VERSION}"
 
-mkdir -p ${workdir}/src
-echo Checking out latest snapshot...
-cd ${workdir}/src
-git clone --depth 1 https://github.com/RetroShare/RetroShare.git .
-cd -
-
-if ! test -d ${workdir}/src/libretroshare/; then
-	echo Git clone failed. 
-	exit
+if [[ -d ${WORKDIR} ]]
+then
+    echo "Removing the directory ${WORKDIR}..."
+    rm -rf ${WORKDIR}
 fi
+mkdir -p ${WORKDIR}/src
 
-#cp -r data   ${workdir}/src/
-cp -r debian ${workdir}/debian
-
-#svn co -r${rev} ${svnpath}/trunk/ . 
+echo "Copying sources into workdir..."
+rsync -rc --exclude build_scripts ${GITROOT}/* ${WORKDIR}/src
+cp -r debian ${WORKDIR}/debian
+pushd ${WORKDIR} >/dev/null
 
 # VOIP tweak  
-cp ${workdir}/src/retroshare-gui/src/gui/chat/PopupChatDialog.ui ${workdir}/src/plugins/VOIP/gui/PopupChatDialog.ui
+cp src/retroshare-gui/src/gui/chat/PopupChatDialog.ui src/plugins/VOIP/gui/PopupChatDialog.ui
 
-#   # handling of libssh
-#   LIBSSH_VERSION=0.6.4
-#   LIBSSH_LOCATION=https://git.libssh.org/projects/libssh.git/snapshot/libssh-${LIBSSH_VERSION}.tar.gz
-#   
-#   [ -f libssh-${LIBSSH_VERSION}.tar.gz ] || wget --no-check-certificate -O libssh-${LIBSSH_VERSION}.tar.gz $LIBSSH_LOCATION 
-#   tar zxvf ../libssh-${LIBSSH_VERSION}.tar.gz
+echo "Setting version numbers..."
+sed -e "s%RS_REVISION_NUMBER.*%RS_REVISION_NUMBER   0x${HASH}%"  src/libretroshare/src/retroshare/rsversion.in > src/libretroshare/src/retroshare/rsversion.h
 
-# Cloning sqlcipher
-# git clone https://github.com/sqlcipher/sqlcipher.git
+echo "Calling debuild..."
+for DIST in ${DISTS}; do
+    echo "opying changelog for ${DIST}..."
+    sed -e s/XXXXXX/"${REV}"/g -e s/YYYYYY/"${DIST}"/g ../changelog > debian/changelog
 
-# cleaning up protobof generated files
-# rm -f src/retroshare-nogui/src/rpc/proto/gencc/*.pb.h
-# rm -f src/retroshare-nogui/src/rpc/proto/gencc/*.pb.cc
+    [ -d sqlcipher ] && rm -rf sqlcipher
 
-cd ${workdir}
-echo Setting version numbers...
+    if test "${DIST}" = "lucid" ; then
+        cp ../control.ubuntu_${DIST} debian/control
+    elif test "${DIST}" = "squeeze" ; then
+        cp ../control.${DIST}_bubba3 debian/control
+    elif test "${DIST}" = "precise" ; then
+        cp ../control.${DIST} debian/control
+    elif test "${DIST}" = "wheezy" -o "${DIST}" = "jessie" ; then
+        # Cloning sqlcipher
+        git clone https://github.com/sqlcipher/sqlcipher.git
+        pushd sqlcipher >/dev/null
+        git checkout v3.3.1
+        rm -rf .git
+        popd >/dev/null
 
-# setup version numbers
-sed -e "s%RS_REVISION_NUMBER.*%RS_REVISION_NUMBER   0x${hhsh}%"  src/libretroshare/src/retroshare/rsversion.in > src/libretroshare/src/retroshare/rsversion.h
-
-# Various cleaning
-echo Cleaning...
-
-\rm -rf src/.git
-#find . -depth -name ".svn" -a -type d -exec rm -rf {} \;    # remove all svn repositories
-
-echo Calling debuild...
-for i in ${dist}; do
-    echo copying changelog for ${i}
-    sed -e s/XXXXXX/"${rev}"/g -e s/YYYYYY/"${i}"/g ../changelog > debian/changelog
-
-    if test "${i}" = "lucid" ; then
-        cp ../control.ubuntu_lucid debian/control
-    elif test "${i}" = "squeeze" ; then
-        cp ../control.squeeze_bubba3 debian/control
-    elif test "${i}" = "precise" ; then
-        cp ../control.precise debian/control
+        cp ../control.${DIST} debian/control
+        cp ../rules.${DIST} debian/rules
     else
         cp ../debian/control debian/control
     fi
 
-    debuild -S -k${gpgkey}
+    debuild -S -k${GPGKEY}
 done
-cd -
+popd >/dev/null
 
 exit 0

--- a/build_scripts/Debian+Ubuntu/rules.jessie
+++ b/build_scripts/Debian+Ubuntu/rules.jessie
@@ -1,0 +1,104 @@
+#!/usr/bin/make -f
+
+builddir:
+	mkdir -p builddir
+
+builddir/Makefile: builddir
+	touch $@
+
+build: build-stamp
+
+build-stamp: builddir/Makefile
+	dh_testdir
+	# Add here commands to compile the package.
+	# cd libssh-0.6.4 && mkdir -p build && cd build && cmake -DWITH_STATIC_LIB=ON .. && make 
+	cd sqlcipher && ./configure --disable-shared --enable-static --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" LDFLAGS="-lcrypto" && make
+	mkdir lib
+	# cp -r libssh-0.6.4 lib/
+	cp -r sqlcipher lib/
+	#cd src/rsctrl/src && make
+	cd src && qmake-qt4 CONFIG=release RetroShare.pro && make
+	touch $@
+
+clean:
+	dh_testdir
+	dh_testroot
+	rm -f build-stamp
+	# Add here commands to clean up after the build process.
+	rm -rf builddir
+	dh_clean
+
+install: build
+	dh_testdir
+	dh_testroot
+	dh_clean -k
+	dh_installdirs
+	install -D -m 644 src/data/retroshare.desktop                     $(CURDIR)/debian/retroshare06/usr/share/applications/retroshare06.desktop
+	install -D -m 644 src/data/24x24/retroshare.png                   $(CURDIR)/debian/retroshare06/usr/share/icons/hicolor/24x24/apps/retroshare06.png
+	install -D -m 644 src/data/48x48/retroshare.png                   $(CURDIR)/debian/retroshare06/usr/share/icons/hicolor/48x48/apps/retroshare06.png
+	install -D -m 644 src/data/64x64/retroshare.png                   $(CURDIR)/debian/retroshare06/usr/share/icons/hicolor/64x64/apps/retroshare06.png
+	install -D -m 644 src/data/retroshare.xpm                         $(CURDIR)/debian/retroshare06/usr/share/pixmaps/retroshare06.xpm
+	install -D -m 644 src/plugins/VOIP/libVOIP.so.1.0.0              	$(CURDIR)/debian/retroshare06-voip-plugin/usr/lib/retroshare/extensions6/libVOIP.so
+	install -D -m 644 src/plugins/FeedReader/libFeedReader.so.1.0.0  	$(CURDIR)/debian/retroshare06-feedreader-plugin/usr/lib/retroshare/extensions6/libFeedReader.so
+	install -D -m 644 src/libbitdht/src/bitdht/bdboot.txt             $(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/bdboot.txt
+	install -D -m 644 src/libbitdht/src/bitdht/bdboot.txt             $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/bdboot.txt
+	install -D -m 755 src/retroshare-nogui/src/retroshare-nogui       $(CURDIR)/debian/retroshare06-nogui/usr/bin/RetroShare06-nogui
+	install -D -m 755 src/retroshare-nogui/src/retroshare-nogui       $(CURDIR)/debian/retroshare06/usr/bin/RetroShare06-nogui
+	install -D -m 755 src/retroshare-gui/src/RetroShare               $(CURDIR)/debian/retroshare06/usr/bin/RetroShare06
+	install -D -m 644 src/libresapi/src/webfiles/JSXTransformer.js    $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/JSXTransformer.js   
+	install -D -m 644 src/libresapi/src/webfiles/RsApi.js     			$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/RsApi.js     		 
+	install -D -m 644 src/libresapi/src/webfiles/RsXHRConnection.js   $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/RsXHRConnection.js  
+	install -D -m 644 src/libresapi/src/webfiles/green-black.css     	$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/green-black.css     
+	install -D -m 644 src/libresapi/src/webfiles/gui.jsx     			$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/gui.jsx     			 
+	install -D -m 644 src/libresapi/src/webfiles/index.html     		$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/index.html     		 
+	install -D -m 644 src/libresapi/src/webfiles/react.js     			$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/react.js     		 
+	install -D -m 644 src/retroshare-gui/src/gui/images/logo/logo_splash.png	$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/img/logo_splash.png    		 
+	install -D -m 644 src/libresapi/src/webfiles/JSXTransformer.js    $(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/JSXTransformer.js   
+	install -D -m 644 src/libresapi/src/webfiles/RsApi.js     			$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/RsApi.js     		 
+	install -D -m 644 src/libresapi/src/webfiles/RsXHRConnection.js   $(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/RsXHRConnection.js  
+	install -D -m 644 src/libresapi/src/webfiles/green-black.css     	$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/green-black.css     
+	install -D -m 644 src/libresapi/src/webfiles/gui.jsx     			$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/gui.jsx     			 
+	install -D -m 644 src/libresapi/src/webfiles/index.html     		$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/index.html     		 
+	install -D -m 644 src/libresapi/src/webfiles/react.js     			$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/react.js     		 
+	install -D -m 644 src/retroshare-gui/src/gui/images/logo/logo_splash.png	$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/img/logo_splash.png    		 
+	install -D -m 644 src/retroshare-gui/src/sounds/alert.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/alert.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/chat1.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/chat1.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/chat2.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/chat2.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/file.wav          $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/file.wav         
+	install -D -m 644 src/retroshare-gui/src/sounds/ft_complete.wav   $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/ft_complete.wav  
+	install -D -m 644 src/retroshare-gui/src/sounds/ft_incoming.wav   $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/ft_incoming.wav  
+	install -D -m 644 src/retroshare-gui/src/sounds/incomingchat.wav  $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/incomingchat.wav 
+	install -D -m 644 src/retroshare-gui/src/sounds/notify.wav        $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/notify.wav       
+	install -D -m 644 src/retroshare-gui/src/sounds/offline.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/offline.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/online1.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/online1.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/online2.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/online2.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/receive.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/receive.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/send1.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/send1.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/send2.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/send2.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/startup.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/startup.wav      
+
+# Add here commands to install the package into debian/your_appname
+#    cd builddir && $(MAKE) INSTALL_ROOT=$(CURDIR)/debian/$(APPNAME) install
+# Build architecture-independent files here.
+binary-indep: build install
+# We have nothing to do by default.
+
+# Build architecture-dependent files here.
+binary-arch: build install
+	dh_testdir
+	dh_testroot
+	dh_installdocs
+	dh_installexamples
+	dh_installman
+	dh_link
+	dh_strip
+	dh_compress
+	dh_fixperms
+	dh_installdeb
+	dh_shlibdeps
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
+
+binary: binary-indep binary-arch
+.PHONY: build clean binary-indep binary-arch binary install configure

--- a/build_scripts/Debian+Ubuntu/rules.wheezy
+++ b/build_scripts/Debian+Ubuntu/rules.wheezy
@@ -1,0 +1,104 @@
+#!/usr/bin/make -f
+
+builddir:
+	mkdir -p builddir
+
+builddir/Makefile: builddir
+	touch $@
+
+build: build-stamp
+
+build-stamp: builddir/Makefile
+	dh_testdir
+	# Add here commands to compile the package.
+	# cd libssh-0.6.4 && mkdir -p build && cd build && cmake -DWITH_STATIC_LIB=ON .. && make 
+	cd sqlcipher && ./configure --disable-shared --enable-static --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" LDFLAGS="-lcrypto" && make
+	mkdir lib
+	# cp -r libssh-0.6.4 lib/
+	cp -r sqlcipher lib/
+	#cd src/rsctrl/src && make
+	cd src && qmake-qt4 CONFIG=release RetroShare.pro && make
+	touch $@
+
+clean:
+	dh_testdir
+	dh_testroot
+	rm -f build-stamp
+	# Add here commands to clean up after the build process.
+	rm -rf builddir
+	dh_clean
+
+install: build
+	dh_testdir
+	dh_testroot
+	dh_clean -k
+	dh_installdirs
+	install -D -m 644 src/data/retroshare.desktop                     $(CURDIR)/debian/retroshare06/usr/share/applications/retroshare06.desktop
+	install -D -m 644 src/data/24x24/retroshare.png                   $(CURDIR)/debian/retroshare06/usr/share/icons/hicolor/24x24/apps/retroshare06.png
+	install -D -m 644 src/data/48x48/retroshare.png                   $(CURDIR)/debian/retroshare06/usr/share/icons/hicolor/48x48/apps/retroshare06.png
+	install -D -m 644 src/data/64x64/retroshare.png                   $(CURDIR)/debian/retroshare06/usr/share/icons/hicolor/64x64/apps/retroshare06.png
+	install -D -m 644 src/data/retroshare.xpm                         $(CURDIR)/debian/retroshare06/usr/share/pixmaps/retroshare06.xpm
+	install -D -m 644 src/plugins/VOIP/libVOIP.so.1.0.0              	$(CURDIR)/debian/retroshare06-voip-plugin/usr/lib/retroshare/extensions6/libVOIP.so
+	install -D -m 644 src/plugins/FeedReader/libFeedReader.so.1.0.0  	$(CURDIR)/debian/retroshare06-feedreader-plugin/usr/lib/retroshare/extensions6/libFeedReader.so
+	install -D -m 644 src/libbitdht/src/bitdht/bdboot.txt             $(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/bdboot.txt
+	install -D -m 644 src/libbitdht/src/bitdht/bdboot.txt             $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/bdboot.txt
+	install -D -m 755 src/retroshare-nogui/src/retroshare-nogui       $(CURDIR)/debian/retroshare06-nogui/usr/bin/RetroShare06-nogui
+	install -D -m 755 src/retroshare-nogui/src/retroshare-nogui       $(CURDIR)/debian/retroshare06/usr/bin/RetroShare06-nogui
+	install -D -m 755 src/retroshare-gui/src/RetroShare               $(CURDIR)/debian/retroshare06/usr/bin/RetroShare06
+	install -D -m 644 src/libresapi/src/webfiles/JSXTransformer.js    $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/JSXTransformer.js   
+	install -D -m 644 src/libresapi/src/webfiles/RsApi.js     			$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/RsApi.js     		 
+	install -D -m 644 src/libresapi/src/webfiles/RsXHRConnection.js   $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/RsXHRConnection.js  
+	install -D -m 644 src/libresapi/src/webfiles/green-black.css     	$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/green-black.css     
+	install -D -m 644 src/libresapi/src/webfiles/gui.jsx     			$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/gui.jsx     			 
+	install -D -m 644 src/libresapi/src/webfiles/index.html     		$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/index.html     		 
+	install -D -m 644 src/libresapi/src/webfiles/react.js     			$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/react.js     		 
+	install -D -m 644 src/retroshare-gui/src/gui/images/logo/logo_splash.png	$(CURDIR)/debian/retroshare06/usr/share/RetroShare06/webui/img/logo_splash.png    		 
+	install -D -m 644 src/libresapi/src/webfiles/JSXTransformer.js    $(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/JSXTransformer.js   
+	install -D -m 644 src/libresapi/src/webfiles/RsApi.js     			$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/RsApi.js     		 
+	install -D -m 644 src/libresapi/src/webfiles/RsXHRConnection.js   $(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/RsXHRConnection.js  
+	install -D -m 644 src/libresapi/src/webfiles/green-black.css     	$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/green-black.css     
+	install -D -m 644 src/libresapi/src/webfiles/gui.jsx     			$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/gui.jsx     			 
+	install -D -m 644 src/libresapi/src/webfiles/index.html     		$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/index.html     		 
+	install -D -m 644 src/libresapi/src/webfiles/react.js     			$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/react.js     		 
+	install -D -m 644 src/retroshare-gui/src/gui/images/logo/logo_splash.png	$(CURDIR)/debian/retroshare06-nogui/usr/share/RetroShare06/webui/img/logo_splash.png    		 
+	install -D -m 644 src/retroshare-gui/src/sounds/alert.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/alert.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/chat1.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/chat1.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/chat2.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/chat2.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/file.wav          $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/file.wav         
+	install -D -m 644 src/retroshare-gui/src/sounds/ft_complete.wav   $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/ft_complete.wav  
+	install -D -m 644 src/retroshare-gui/src/sounds/ft_incoming.wav   $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/ft_incoming.wav  
+	install -D -m 644 src/retroshare-gui/src/sounds/incomingchat.wav  $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/incomingchat.wav 
+	install -D -m 644 src/retroshare-gui/src/sounds/notify.wav        $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/notify.wav       
+	install -D -m 644 src/retroshare-gui/src/sounds/offline.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/offline.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/online1.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/online1.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/online2.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/online2.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/receive.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/receive.wav      
+	install -D -m 644 src/retroshare-gui/src/sounds/send1.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/send1.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/send2.wav         $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/send2.wav        
+	install -D -m 644 src/retroshare-gui/src/sounds/startup.wav       $(CURDIR)/debian/retroshare06/usr/share/RetroShare06/sounds/startup.wav      
+
+# Add here commands to install the package into debian/your_appname
+#    cd builddir && $(MAKE) INSTALL_ROOT=$(CURDIR)/debian/$(APPNAME) install
+# Build architecture-independent files here.
+binary-indep: build install
+# We have nothing to do by default.
+
+# Build architecture-dependent files here.
+binary-arch: build install
+	dh_testdir
+	dh_testroot
+	dh_installdocs
+	dh_installexamples
+	dh_installman
+	dh_link
+	dh_strip
+	dh_compress
+	dh_fixperms
+	dh_installdeb
+	dh_shlibdeps
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
+
+binary: binary-indep binary-arch
+.PHONY: build clean binary-indep binary-arch binary install configure


### PR DESCRIPTION
Reworked the makeSourcePackage.sh script, so that it creates the source package directly from the checked out revision, w/o re-cloning the repository into a subdirectory. It now works similar to the package creation script for RedHat/Fedora.
