### PR TITLE
Send Mouse event to FriendList's item, since ElidedLabel was fixed.

### DIFF
--- a/retroshare-gui/src/gui/common/FriendList.cpp
+++ b/retroshare-gui/src/gui/common/FriendList.cpp
@@ -500,10 +500,6 @@ static void getNameWidget(QTreeWidget *treeWidget, QTreeWidgetItem *item, Elided
         nameLabel = new ElidedLabel(widget);
         textLabel = new ElidedLabel(widget);
 
-        widget->setAttribute(Qt::WA_TransparentForMouseEvents, true);
-        nameLabel->setAttribute(Qt::WA_TransparentForMouseEvents, true);
-        textLabel->setAttribute(Qt::WA_TransparentForMouseEvents, true);
-
         widget->setProperty("nameLabel", qVariantFromValue(nameLabel));
         widget->setProperty("textLabel", qVariantFromValue(textLabel));
 


### PR DESCRIPTION
Now you can click on [...] to get missing text.
