### PR TITLE
Adding I2P support to RS 

### DIFF
--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -2026,11 +2026,16 @@ void  p3LinkMgrIMPL::locked_ConnectAttempt_ProxyAddress(peerConnectState *peer, 
 	peerConnectAddress pca;
 	pca.addr = proxy_addr;
 
-	if (mPeerMgr->hiddenDomainToHiddenType(domain_addr) == RS_HIDDEN_TYPE_I2P)
+	switch (mPeerMgr->hiddenDomainToHiddenType(domain_addr)) {
+	case RS_HIDDEN_TYPE_I2P:
 		pca.type = RS_NET_CONN_TCP_HIDDEN_I2P;
-	else
+		break;
+	case RS_HIDDEN_TYPE_TOR:
+	default:
 		/* default tor */
 		pca.type = RS_NET_CONN_TCP_HIDDEN_TOR;
+		break;
+	}
 
 	//for the delay, we add a random time and some more time when the friend list is big
 	pca.delay = P3CONNMGR_TCP_DEFAULT_DELAY;

--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -2026,7 +2026,11 @@ void  p3LinkMgrIMPL::locked_ConnectAttempt_ProxyAddress(peerConnectState *peer, 
 	peerConnectAddress pca;
 	pca.addr = proxy_addr;
 
-	pca.type = RS_NET_CONN_TCP_HIDDEN;
+	if (mPeerMgr->hiddenDomainToHiddenType(domain_addr) == RS_HIDDEN_TYPE_I2P)
+		pca.type = RS_NET_CONN_TCP_HIDDEN_I2P;
+	else
+		/* default tor */
+		pca.type = RS_NET_CONN_TCP_HIDDEN_TOR;
 
 	//for the delay, we add a random time and some more time when the friend list is big
 	pca.delay = P3CONNMGR_TCP_DEFAULT_DELAY;

--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -964,24 +964,25 @@ bool p3LinkMgrIMPL::connectResult(const RsPeerId &id, bool success, bool isIncom
 	if (flags == RS_NET_CONN_UDP_ALL)
 	{
 #ifdef LINKMGR_DEBUG
-#endif
 		std::cerr << "p3LinkMgrIMPL::connectResult() Sending Feedback for UDP connection";
 		std::cerr << std::endl;
+#endif
 		if (success)
 		{
 #ifdef LINKMGR_DEBUG
-#endif
 			std::cerr << "p3LinkMgrIMPL::connectResult() UDP Update CONNECTED to: " << id;
 			std::cerr << std::endl;
+#endif
 
 			mNetMgr->netAssistStatusUpdate(id, NETMGR_DHT_FEEDBACK_CONNECTED);
 		}
 		else
 		{
 #ifdef LINKMGR_DEBUG
-#endif
+
 			std::cerr << "p3LinkMgrIMPL::connectResult() UDP Update FAILED to: " << id;
 			std::cerr << std::endl;
+#endif
 
 			/* have no differentiation between failure and closed? */
 			mNetMgr->netAssistStatusUpdate(id, NETMGR_DHT_FEEDBACK_CONN_FAILED);

--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -2030,9 +2030,13 @@ void  p3LinkMgrIMPL::locked_ConnectAttempt_ProxyAddress(peerConnectState *peer, 
 	case RS_HIDDEN_TYPE_I2P:
 		pca.type = RS_NET_CONN_TCP_HIDDEN_I2P;
 		break;
-	case RS_HIDDEN_TYPE_TOR:
+	case RS_HIDDEN_TYPE_UNKNOWN:
 	default:
-		/* default tor */
+#ifdef LINKMGR_DEBUG
+	std::cerr << "p3LinkMgrIMPL::locked_ConnectAttempt_ProxyAddress() hidden type of addr: " << domain_addr << " is unkown -> fallback to tor" << std::endl;
+#endif
+		/* the type should be set! since this connection involves a proxy -> fallback to tor */
+	case RS_HIDDEN_TYPE_TOR:
 		pca.type = RS_NET_CONN_TCP_HIDDEN_TOR;
 		break;
 	}

--- a/libretroshare/src/pqi/p3linkmgr.h
+++ b/libretroshare/src/pqi/p3linkmgr.h
@@ -40,17 +40,17 @@ class DNSResolver ;
 
 
 /* order of attempts ... */
-const uint32_t RS_NET_CONN_TCP_ALL             = 0x001f;
-const uint32_t RS_NET_CONN_UDP_ALL             = 0x00e0;
+const uint32_t RS_NET_CONN_TCP_ALL             = 0x00ff;
+const uint32_t RS_NET_CONN_UDP_ALL             = 0x0f00;
  
 const uint32_t RS_NET_CONN_TCP_LOCAL           = 0x0001;
 const uint32_t RS_NET_CONN_TCP_EXTERNAL        = 0x0002;
 const uint32_t RS_NET_CONN_TCP_UNKNOW_TOPOLOGY = 0x0004;
-const uint32_t RS_NET_CONN_TCP_HIDDEN_TOR 	   = 0x0008;
-const uint32_t RS_NET_CONN_TCP_HIDDEN_I2P 	   = 0x0010;
+const uint32_t RS_NET_CONN_TCP_HIDDEN_TOR      = 0x0008;
+const uint32_t RS_NET_CONN_TCP_HIDDEN_I2P      = 0x0010;
 
-const uint32_t RS_NET_CONN_UDP_DHT_SYNC        = 0x0020;
-const uint32_t RS_NET_CONN_UDP_PEER_SYNC       = 0x0040; /* coming soon */
+const uint32_t RS_NET_CONN_UDP_DHT_SYNC        = 0x0100;
+const uint32_t RS_NET_CONN_UDP_PEER_SYNC       = 0x0200; /* coming soon */
 
 // These are set in pqipersongroup.
 const uint32_t RS_TCP_STD_TIMEOUT_PERIOD	= 5; /* 5 seconds! */

--- a/libretroshare/src/pqi/p3linkmgr.h
+++ b/libretroshare/src/pqi/p3linkmgr.h
@@ -40,8 +40,8 @@ class DNSResolver ;
 
 
 /* order of attempts ... */
-const uint32_t RS_NET_CONN_TCP_ALL             = 0x000f;
-const uint32_t RS_NET_CONN_UDP_ALL             = 0x00f0;
+const uint32_t RS_NET_CONN_TCP_ALL             = 0x001f;
+const uint32_t RS_NET_CONN_UDP_ALL             = 0x00e0;
  
 const uint32_t RS_NET_CONN_TCP_LOCAL           = 0x0001;
 const uint32_t RS_NET_CONN_TCP_EXTERNAL        = 0x0002;
@@ -49,8 +49,8 @@ const uint32_t RS_NET_CONN_TCP_UNKNOW_TOPOLOGY = 0x0004;
 const uint32_t RS_NET_CONN_TCP_HIDDEN_TOR 	   = 0x0008;
 const uint32_t RS_NET_CONN_TCP_HIDDEN_I2P 	   = 0x0010;
 
-const uint32_t RS_NET_CONN_UDP_DHT_SYNC        = 0x0010;
-const uint32_t RS_NET_CONN_UDP_PEER_SYNC       = 0x0020; /* coming soon */
+const uint32_t RS_NET_CONN_UDP_DHT_SYNC        = 0x0020;
+const uint32_t RS_NET_CONN_UDP_PEER_SYNC       = 0x0040; /* coming soon */
 
 // These are set in pqipersongroup.
 const uint32_t RS_TCP_STD_TIMEOUT_PERIOD	= 5; /* 5 seconds! */

--- a/libretroshare/src/pqi/p3linkmgr.h
+++ b/libretroshare/src/pqi/p3linkmgr.h
@@ -303,7 +303,7 @@ void 	locked_ConnectAttempt_CurrentAddresses(peerConnectState *peer, const struc
 void 	locked_ConnectAttempt_HistoricalAddresses(peerConnectState *peer, const pqiIpAddrSet &ipAddrs);
 void 	locked_ConnectAttempt_AddDynDNS(peerConnectState *peer, std::string dyndns, uint16_t dynPort);
 void 	locked_ConnectAttempt_AddTunnel(peerConnectState *peer);
-void  	locked_ConnectAttempt_ProxyAddress(peerConnectState *peer, const struct sockaddr_storage &proxy_addr, const std::string &domain_addr, uint16_t domain_port);
+void  	locked_ConnectAttempt_ProxyAddress(peerConnectState *peer, const uint32_t type, const struct sockaddr_storage &proxy_addr, const std::string &domain_addr, uint16_t domain_port);
 
 bool  	locked_ConnectAttempt_Complete(peerConnectState *peer);
 

--- a/libretroshare/src/pqi/p3linkmgr.h
+++ b/libretroshare/src/pqi/p3linkmgr.h
@@ -46,7 +46,8 @@ const uint32_t RS_NET_CONN_UDP_ALL             = 0x00f0;
 const uint32_t RS_NET_CONN_TCP_LOCAL           = 0x0001;
 const uint32_t RS_NET_CONN_TCP_EXTERNAL        = 0x0002;
 const uint32_t RS_NET_CONN_TCP_UNKNOW_TOPOLOGY = 0x0004;
-const uint32_t RS_NET_CONN_TCP_HIDDEN 	       = 0x0008;
+const uint32_t RS_NET_CONN_TCP_HIDDEN_TOR 	   = 0x0008;
+const uint32_t RS_NET_CONN_TCP_HIDDEN_I2P 	   = 0x0010;
 
 const uint32_t RS_NET_CONN_UDP_DHT_SYNC        = 0x0010;
 const uint32_t RS_NET_CONN_UDP_PEER_SYNC       = 0x0020; /* coming soon */

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -483,7 +483,7 @@ uint32_t p3PeerMgrIMPL::hiddenDomainToHiddenType(const std::string &domain)
 		std::cerr << "p3PeerMgrIMPL::hiddenDomainToHiddenType() unknown hidden type: " << domain;
 		std::cerr << std::endl;
 #endif
-	return RS_HIDDEN_TYPE_NONE;
+	return RS_HIDDEN_TYPE_UNKNOWN;
 }
 
 bool p3PeerMgrIMPL::setHiddenDomainPort(const RsPeerId &ssl_id, const std::string &domain_addr, const uint16_t domain_port)
@@ -560,13 +560,19 @@ bool p3PeerMgrIMPL::setProxyServerAddress(const uint32_t type, const struct sock
 		}
 		break;
 	case RS_HIDDEN_TYPE_TOR:
-	default:
 		if (!sockaddr_storage_same(mProxyServerAddressTor,proxy_addr))
 		{
 			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
 			mProxyServerAddressTor = proxy_addr;
 		}
 		break;
+	case RS_HIDDEN_TYPE_UNKNOWN:
+	default:
+#ifdef PEER_DEBUG
+	std::cerr << "p3PeerMgrIMPL::setProxyServerAddress() unknown hidden type " << type << " -> false";
+	std::cerr << std::endl;
+#endif
+		return false;
 	}
 
 	return true;
@@ -593,9 +599,15 @@ bool p3PeerMgrIMPL::getProxyServerStatus(const uint32_t type, uint32_t& proxy_st
 		proxy_status = mProxyServerStatusI2P;
 		break;
 	case RS_HIDDEN_TYPE_TOR:
-	default:
 		proxy_status = mProxyServerStatusTor;
 		break;
+	case RS_HIDDEN_TYPE_UNKNOWN:
+	default:
+#ifdef PEER_DEBUG
+	std::cerr << "p3PeerMgrIMPL::getProxyServerStatus() unknown hidden type " << type << " -> false";
+	std::cerr << std::endl;
+#endif
+		return false;
 	}
 
 	return true;
@@ -610,9 +622,15 @@ bool p3PeerMgrIMPL::getProxyServerAddress(const uint32_t type, struct sockaddr_s
 		proxy_addr = mProxyServerAddressI2P;
 		break;
 	case RS_HIDDEN_TYPE_TOR:
-	default:
 		proxy_addr = mProxyServerAddressTor;
 		break;
+	case RS_HIDDEN_TYPE_UNKNOWN:
+	default:
+#ifdef PEER_DEBUG
+	std::cerr << "p3PeerMgrIMPL::getProxyServerAddress() unknown hidden type " << type << " -> false";
+	std::cerr << std::endl;
+#endif
+		return false;
 	}
 	return true;
 }
@@ -642,10 +660,15 @@ bool p3PeerMgrIMPL::getProxyAddress(const RsPeerId &ssl_id, struct sockaddr_stor
 		proxy_addr = mProxyServerAddressI2P;
 		break;
 	case RS_HIDDEN_TYPE_TOR:
-	default:
-		/* default tor */
 		proxy_addr = mProxyServerAddressTor;
 		break;
+	case RS_HIDDEN_TYPE_UNKNOWN:
+	default:
+#ifdef PEER_DEBUG
+	std::cerr << "p3PeerMgrIMPL::getProxyAddress() no valid hidden type (" << it->second.hiddenType << ") for peer id " << ssl_id << " -> false";
+	std::cerr << std::endl;
+#endif
+		return false;
 	}
 	return true;
 }

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -75,7 +75,7 @@ const uint32_t PEER_IP_CONNECT_STATE_MAX_LIST_SIZE =     	4;
 
 static const std::string kConfigDefaultProxyServerIpAddr = "127.0.0.1";
 static const uint16_t    kConfigDefaultProxyServerPortTor = 9050; // standard port.
-static const uint16_t    kConfigDefaultProxyServerPortI2P = 9051; // there is no standard port though
+static const uint16_t    kConfigDefaultProxyServerPortI2P = 10; // there is no standard port though
 
 static const std::string kConfigKeyExtIpFinder = "USE_EXTR_IP_FINDER";
 static const std::string kConfigKeyProxyServerIpAddrTor = "PROXY_SERVER_IPADDR";

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -486,6 +486,13 @@ uint32_t p3PeerMgrIMPL::hiddenDomainToHiddenType(const std::string &domain)
 	return RS_HIDDEN_TYPE_UNKNOWN;
 }
 
+/**
+ * @brief sets hidden domain and port for a given ssl ID
+ * @param ssl_id peer to set domain and port for
+ * @param domain_addr
+ * @param domain_port
+ * @return true on success
+ */
 bool p3PeerMgrIMPL::setHiddenDomainPort(const RsPeerId &ssl_id, const std::string &domain_addr, const uint16_t domain_port)
 {
 	RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
@@ -547,6 +554,12 @@ bool p3PeerMgrIMPL::setHiddenDomainPort(const RsPeerId &ssl_id, const std::strin
 	return true;
 }
 
+/**
+ * @brief sets the proxy server address for a hidden service
+ * @param type hidden service type
+ * @param proxy_addr proxy address
+ * @return true on success
+ */
 bool p3PeerMgrIMPL::setProxyServerAddress(const uint32_t type, const struct sockaddr_storage &proxy_addr)
 {
 	RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
@@ -590,6 +603,12 @@ bool p3PeerMgrIMPL::resetOwnExternalAddressList()
     return true ;
 }
 
+/**
+ * @brief returs proxy server status for a hidden service proxy
+ * @param type hidden service type
+ * @param proxy_status
+ * @return true on success
+ */
 bool p3PeerMgrIMPL::getProxyServerStatus(const uint32_t type, uint32_t& proxy_status)
 {
 	RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
@@ -613,6 +632,12 @@ bool p3PeerMgrIMPL::getProxyServerStatus(const uint32_t type, uint32_t& proxy_st
 	return true;
 }
 
+/**
+ * @brief returs proxy server address for a hidden service proxy
+ * @param type hidden service type
+ * @param proxy_addr
+ * @return true on success
+ */
 bool p3PeerMgrIMPL::getProxyServerAddress(const uint32_t type, struct sockaddr_storage &proxy_addr)
 {
 	RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
@@ -634,7 +659,15 @@ bool p3PeerMgrIMPL::getProxyServerAddress(const uint32_t type, struct sockaddr_s
 	}
 	return true;
 }
-	
+
+/**
+ * @brief looks up the proxy address and domain/port that have to be used when connecting to a peer
+ * @param ssl_id peer to connect to
+ * @param proxy_addr proxy address to be used
+ * @param domain_addr domain to connect to
+ * @param domain_port port to connect to
+ * @return true on success
+ */
 bool p3PeerMgrIMPL::getProxyAddress(const RsPeerId &ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port)
 {
 	RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -637,11 +637,16 @@ bool p3PeerMgrIMPL::getProxyAddress(const RsPeerId &ssl_id, struct sockaddr_stor
 	domain_addr = it->second.hiddenDomain;
 	domain_port = it->second.hiddenPort;
 
-	if(it->second.hiddenType == RS_HIDDEN_TYPE_I2P)
+	switch (it->second.hiddenType) {
+	case RS_HIDDEN_TYPE_I2P:
 		proxy_addr = mProxyServerAddressI2P;
-	else
+		break;
+	case RS_HIDDEN_TYPE_TOR:
+	default:
 		/* default tor */
 		proxy_addr = mProxyServerAddressTor;
+		break;
+	}
 	return true;
 }
 

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -566,14 +566,14 @@ bool p3PeerMgrIMPL::setProxyServerAddress(const uint32_t type, const struct sock
 
 	switch (type) {
 	case RS_HIDDEN_TYPE_I2P:
-		if (!sockaddr_storage_same(mProxyServerAddressI2P,proxy_addr))
+		if (!sockaddr_storage_same(mProxyServerAddressI2P, proxy_addr))
 		{
 			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
 			mProxyServerAddressI2P = proxy_addr;
 		}
 		break;
 	case RS_HIDDEN_TYPE_TOR:
-		if (!sockaddr_storage_same(mProxyServerAddressTor,proxy_addr))
+		if (!sockaddr_storage_same(mProxyServerAddressTor, proxy_addr))
 		{
 			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
 			mProxyServerAddressTor = proxy_addr;
@@ -1938,7 +1938,7 @@ bool p3PeerMgrIMPL::saveList(bool &cleanup, std::list<RsItem *>& saveData)
 
 	// I2P
 #ifdef PEER_DEBUG
-	std::cerr << "Saving proxyServerAddress for I2P: " << sockaddr_storage_tostring(proxy_addr_tor);
+	std::cerr << "Saving proxyServerAddress for I2P: " << sockaddr_storage_tostring(proxy_addr_i2p);
 	std::cerr << std::endl;
 #endif
 
@@ -1986,7 +1986,7 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
 	std::string proxyIpAddressTor = kConfigDefaultProxyServerIpAddr;
 	uint16_t    proxyPortTor = kConfigDefaultProxyServerPort;
 	std::string proxyIpAddressI2P = kConfigDefaultProxyServerIpAddr;
-	uint16_t    proxyPortI2P = kConfigDefaultProxyServerPort;
+	uint16_t    proxyPortI2P = kConfigDefaultProxyServerPort + 1;
 
         if (load.empty()) {
             std::cerr << "p3PeerMgrIMPL::loadList() list is empty, it may be a configuration problem."  << std::endl;
@@ -2108,7 +2108,6 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
 					std::cerr << "Loaded proxyIpAddress for I2P: " << proxyIpAddressI2P;
 					std::cerr << std::endl ;
 #endif
-
 				}
 				else if (kit->key == kConfigKeyProxyServerPortI2P)
 				{

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -74,7 +74,8 @@ const uint32_t PEER_IP_CONNECT_STATE_MAX_LIST_SIZE =     	4;
 #define MIN_RETRY_PERIOD 140
 
 static const std::string kConfigDefaultProxyServerIpAddr = "127.0.0.1";
-static const uint16_t    kConfigDefaultProxyServerPort = 9050; // standard port.
+static const uint16_t    kConfigDefaultProxyServerPortTor = 9050; // standard port.
+static const uint16_t    kConfigDefaultProxyServerPortI2P = 9051; // there is no standard port though
 
 static const std::string kConfigKeyExtIpFinder = "USE_EXTR_IP_FINDER";
 static const std::string kConfigKeyProxyServerIpAddrTor = "PROXY_SERVER_IPADDR";
@@ -137,13 +138,13 @@ p3PeerMgrIMPL::p3PeerMgrIMPL(const RsPeerId& ssl_own_id, const RsPgpId& gpg_own_
 		sockaddr_storage_ipv4_aton(mProxyServerAddressTor,
 				kConfigDefaultProxyServerIpAddr.c_str());
 		sockaddr_storage_ipv4_setport(mProxyServerAddressTor,
-                kConfigDefaultProxyServerPort);
+				kConfigDefaultProxyServerPortTor);
 		// I2P
 		sockaddr_storage_clear(mProxyServerAddressI2P);
 		sockaddr_storage_ipv4_aton(mProxyServerAddressI2P,
 				kConfigDefaultProxyServerIpAddr.c_str());
 		sockaddr_storage_ipv4_setport(mProxyServerAddressI2P,
-				kConfigDefaultProxyServerPort);
+				kConfigDefaultProxyServerPortI2P);
 
         mProxyServerStatusTor = RS_NET_PROXY_STATUS_UNKNOWN ;
 		mProxyServerStatusI2P = RS_NET_PROXY_STATUS_UNKNOWN;
@@ -199,6 +200,7 @@ bool p3PeerMgrIMPL::forceHiddenNode()
 #endif
 		}
 		mOwnState.hiddenNode = true;
+		mOwnState.hiddenType = hiddenDomainToHiddenType(mOwnState.hiddenDomain);
 
 		// force external address - otherwise its invalid.
 		sockaddr_storage_clear(mOwnState.serveraddr);
@@ -1984,9 +1986,9 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
 	// DEFAULTS.
 	bool useExtAddrFinder = true;
 	std::string proxyIpAddressTor = kConfigDefaultProxyServerIpAddr;
-	uint16_t    proxyPortTor = kConfigDefaultProxyServerPort;
+	uint16_t    proxyPortTor = kConfigDefaultProxyServerPortTor;
 	std::string proxyIpAddressI2P = kConfigDefaultProxyServerIpAddr;
-	uint16_t    proxyPortI2P = kConfigDefaultProxyServerPort + 1;
+	uint16_t    proxyPortI2P = kConfigDefaultProxyServerPortI2P;
 
         if (load.empty()) {
             std::cerr << "p3PeerMgrIMPL::loadList() list is empty, it may be a configuration problem."  << std::endl;

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -146,7 +146,7 @@ p3PeerMgrIMPL::p3PeerMgrIMPL(const RsPeerId& ssl_own_id, const RsPgpId& gpg_own_
 		sockaddr_storage_ipv4_setport(mProxyServerAddressI2P,
 				kConfigDefaultProxyServerPortI2P);
 
-        mProxyServerStatusTor = RS_NET_PROXY_STATUS_UNKNOWN ;
+		mProxyServerStatusTor = RS_NET_PROXY_STATUS_UNKNOWN ;
 		mProxyServerStatusI2P = RS_NET_PROXY_STATUS_UNKNOWN;
 	}
 	
@@ -486,6 +486,38 @@ uint32_t p3PeerMgrIMPL::hiddenDomainToHiddenType(const std::string &domain)
 		std::cerr << std::endl;
 #endif
 	return RS_HIDDEN_TYPE_UNKNOWN;
+}
+
+/**
+ * @brief returns the hidden type of a peer
+ * @param ssl_id peer id
+ * @return hidden type
+ */
+uint32_t p3PeerMgrIMPL::getHiddenType(const RsPeerId &ssl_id)
+{
+	RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
+
+	if (ssl_id == AuthSSL::getAuthSSL()->OwnId())
+		return mOwnState.hiddenType;
+
+	/* check for existing */
+	std::map<RsPeerId, peerState>::iterator it;
+	it = mFriendList.find(ssl_id);
+	if (it == mFriendList.end())
+	{
+#ifdef PEER_DEBUG
+		std::cerr << "p3PeerMgrIMPL::getHiddenType(" << ssl_id << ") Missing Peer => false";
+		std::cerr << std::endl;
+#endif
+
+		return false;
+	}
+
+#ifdef PEER_DEBUG
+	std::cerr << "p3PeerMgrIMPL::getHiddenType(" << ssl_id << ") = " << (it->second).hiddenType;
+	std::cerr << std::endl;
+#endif
+	return (it->second).hiddenType;
 }
 
 /**

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -190,11 +190,9 @@ virtual bool    setProxyServerAddress(const uint32_t type, const struct sockaddr
 virtual bool    getProxyServerAddress(const uint32_t type, struct sockaddr_storage &proxy_addr) = 0;
 virtual bool    getProxyServerStatus(const uint32_t type, uint32_t& status) = 0;
 virtual bool    isHidden() = 0;
+virtual bool    isHidden(const uint32_t type) = 0;
 virtual bool    isHiddenPeer(const RsPeerId &ssl_id) = 0;
-virtual bool    isHiddenTor() = 0;
-virtual bool    isHiddenTorPeer(const RsPeerId &ssl_id) = 0;
-virtual bool    isHiddenI2P() = 0;
-virtual bool    isHiddenI2PPeer(const RsPeerId &ssl_id) = 0;
+virtual bool    isHiddenPeer(const RsPeerId &ssl_id, const uint32_t type) = 0;
 virtual bool    getProxyAddress(const RsPeerId &ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port) = 0;
 
 
@@ -297,11 +295,9 @@ virtual bool    setProxyServerAddress(const uint32_t type, const struct sockaddr
 virtual bool    getProxyServerAddress(const uint32_t type, struct sockaddr_storage &proxy_addr);
 virtual bool    getProxyServerStatus(const uint32_t type, uint32_t &proxy_status);
 virtual bool    isHidden();
-virtual bool    isHiddenPeer(const RsPeerId& ssl_id);
-virtual bool    isHiddenTor();
-virtual bool    isHiddenTorPeer(const RsPeerId &ssl_id);
-virtual bool    isHiddenI2P();
-virtual bool    isHiddenI2PPeer(const RsPeerId &ssl_id);
+virtual bool    isHidden(const uint32_t type);
+virtual bool    isHiddenPeer(const RsPeerId &ssl_id);
+virtual bool    isHiddenPeer(const RsPeerId &ssl_id, const uint32_t type);
 virtual bool    getProxyAddress(const RsPeerId& ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port);
 virtual uint32_t hiddenDomainToHiddenType(const std::string &domain);
 

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -90,7 +90,7 @@ class peerState
 	bool hiddenNode; /* all IP addresses / dyndns must be blank */
 	std::string hiddenDomain;
 	uint16_t    hiddenPort;
-	uint32_t	hiddenType;
+	uint32_t    hiddenType;
 
 	std::string location;
 	std::string name;

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -194,6 +194,7 @@ virtual bool    isHidden(const uint32_t type) = 0;
 virtual bool    isHiddenPeer(const RsPeerId &ssl_id) = 0;
 virtual bool    isHiddenPeer(const RsPeerId &ssl_id, const uint32_t type) = 0;
 virtual bool    getProxyAddress(const RsPeerId &ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port) = 0;
+virtual uint32_t hiddenDomainToHiddenType(const std::string &domain) = 0;
 
 
 virtual int 	getFriendCount(bool ssl, bool online) = 0;

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -195,6 +195,7 @@ virtual bool    isHiddenPeer(const RsPeerId &ssl_id) = 0;
 virtual bool    isHiddenPeer(const RsPeerId &ssl_id, const uint32_t type) = 0;
 virtual bool    getProxyAddress(const RsPeerId &ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port) = 0;
 virtual uint32_t hiddenDomainToHiddenType(const std::string &domain) = 0;
+virtual uint32_t getHiddenType(const RsPeerId &ssl_id) = 0;
 
 
 virtual int 	getFriendCount(bool ssl, bool online) = 0;
@@ -301,6 +302,7 @@ virtual bool    isHiddenPeer(const RsPeerId &ssl_id);
 virtual bool    isHiddenPeer(const RsPeerId &ssl_id, const uint32_t type);
 virtual bool    getProxyAddress(const RsPeerId& ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port);
 virtual uint32_t hiddenDomainToHiddenType(const std::string &domain);
+virtual uint32_t getHiddenType(const RsPeerId &ssl_id);
 
 virtual int 	getFriendCount(bool ssl, bool online);
 

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -90,6 +90,7 @@ class peerState
 	bool hiddenNode; /* all IP addresses / dyndns must be blank */
 	std::string hiddenDomain;
 	uint16_t    hiddenPort;
+	uint32_t	hiddenType;
 
 	std::string location;
 	std::string name;
@@ -185,11 +186,15 @@ virtual bool    getPeerName(const RsPeerId &ssl_id, std::string &name) = 0;
 virtual bool	getGpgId(const RsPeerId &sslId, RsPgpId &gpgId) = 0;
 virtual uint32_t getConnectionType(const RsPeerId &sslId) = 0;
 
-virtual bool    setProxyServerAddress(const struct sockaddr_storage &proxy_addr) = 0;
-virtual bool    getProxyServerAddress(struct sockaddr_storage &proxy_addr) = 0;
-virtual bool    getProxyServerStatus(uint32_t& status) = 0;
+virtual bool    setProxyServerAddress(const uint32_t type, const struct sockaddr_storage &proxy_addr) = 0;
+virtual bool    getProxyServerAddress(const uint32_t type, struct sockaddr_storage &proxy_addr) = 0;
+virtual bool    getProxyServerStatus(const uint32_t type, uint32_t& status) = 0;
 virtual bool    isHidden() = 0;
 virtual bool    isHiddenPeer(const RsPeerId &ssl_id) = 0;
+virtual bool    isHiddenTor() = 0;
+virtual bool    isHiddenTorPeer(const RsPeerId &ssl_id) = 0;
+virtual bool    isHiddenI2P() = 0;
+virtual bool    isHiddenI2PPeer(const RsPeerId &ssl_id) = 0;
 virtual bool    getProxyAddress(const RsPeerId &ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port) = 0;
 
 
@@ -288,12 +293,17 @@ virtual bool    getPeerName(const RsPeerId& ssl_id, std::string& name);
 virtual bool	getGpgId(const RsPeerId& sslId, RsPgpId& gpgId);
 virtual uint32_t getConnectionType(const RsPeerId& sslId);
 
-virtual bool    setProxyServerAddress(const struct sockaddr_storage &proxy_addr);
-virtual bool    getProxyServerAddress(struct sockaddr_storage &proxy_addr);
-virtual bool    getProxyServerStatus(uint32_t &proxy_status);
+virtual bool    setProxyServerAddress(const uint32_t type, const struct sockaddr_storage &proxy_addr);
+virtual bool    getProxyServerAddress(const uint32_t type, struct sockaddr_storage &proxy_addr);
+virtual bool    getProxyServerStatus(const uint32_t type, uint32_t &proxy_status);
 virtual bool    isHidden();
 virtual bool    isHiddenPeer(const RsPeerId& ssl_id);
+virtual bool    isHiddenTor();
+virtual bool    isHiddenTorPeer(const RsPeerId &ssl_id);
+virtual bool    isHiddenI2P();
+virtual bool    isHiddenI2PPeer(const RsPeerId &ssl_id);
 virtual bool    getProxyAddress(const RsPeerId& ssl_id, struct sockaddr_storage &proxy_addr, std::string &domain_addr, uint16_t &domain_port);
+virtual uint32_t hiddenDomainToHiddenType(const std::string &domain);
 
 virtual int 	getFriendCount(bool ssl, bool online);
 
@@ -369,8 +379,10 @@ private:
 
 	std::map<RsPgpId, ServicePermissionFlags> mFriendsPermissionFlags ; // permission flags for each gpg key
 
-	struct sockaddr_storage mProxyServerAddress;
-    uint32_t mProxyServerStatus ;
+	struct sockaddr_storage mProxyServerAddressTor;
+	struct sockaddr_storage mProxyServerAddressI2P;
+	uint32_t mProxyServerStatusTor ;
+	uint32_t mProxyServerStatusI2P ;
 
 };
 

--- a/libretroshare/src/pqi/pqi_base.h
+++ b/libretroshare/src/pqi/pqi_base.h
@@ -249,7 +249,8 @@ class PQInterface: public RateInterface
 
 const uint32_t PQI_CONNECT_TCP = 0x0001;
 const uint32_t PQI_CONNECT_UDP = 0x0002;
-const uint32_t PQI_CONNECT_HIDDEN_TCP = 0x0004;
+const uint32_t PQI_CONNECT_HIDDEN_TOR_TCP = 0x0004;
+const uint32_t PQI_CONNECT_HIDDEN_I2P_TCP = 0x0008;
 
 
 #define BIN_FLAGS_NO_CLOSE  0x0001

--- a/libretroshare/src/pqi/pqibin.cc
+++ b/libretroshare/src/pqi/pqibin.cc
@@ -500,7 +500,7 @@ void printNetBinID(std::ostream &out, const RsPeerId& id, uint32_t t)
 	{
 		out << "TCP)";
 	}
-	else if (t == PQI_CONNECT_HIDDEN_TOR_TCP || t == PQI_CONNECT_HIDDEN_I2P_TCP)
+	else if (t & (PQI_CONNECT_HIDDEN_TOR_TCP | PQI_CONNECT_HIDDEN_I2P_TCP))
 	{
 		out << "HTCP";
 	}

--- a/libretroshare/src/pqi/pqibin.cc
+++ b/libretroshare/src/pqi/pqibin.cc
@@ -500,7 +500,7 @@ void printNetBinID(std::ostream &out, const RsPeerId& id, uint32_t t)
 	{
 		out << "TCP)";
 	}
-	else if (t == PQI_CONNECT_HIDDEN_TCP)
+	else if (t == PQI_CONNECT_HIDDEN_TOR_TCP || t == PQI_CONNECT_HIDDEN_I2P_TCP)
 	{
 		out << "HTCP";
 	}

--- a/libretroshare/src/pqi/pqipersongrp.cc
+++ b/libretroshare/src/pqi/pqipersongrp.cc
@@ -617,10 +617,15 @@ int     pqipersongrp::connectPeer(const RsPeerId& id
 	uint32_t ptype;
 	if (type & RS_NET_CONN_TCP_ALL)
 	{
-		if (type == RS_NET_CONN_TCP_HIDDEN)
+		if (type == RS_NET_CONN_TCP_HIDDEN_TOR)
 		{
-			ptype = PQI_CONNECT_HIDDEN_TCP;
-			timeout = RS_TCP_HIDDEN_TIMEOUT_PERIOD; 
+			ptype = PQI_CONNECT_HIDDEN_TOR_TCP;
+			timeout = RS_TCP_HIDDEN_TIMEOUT_PERIOD;
+		}
+		else if (type == RS_NET_CONN_TCP_HIDDEN_I2P)
+		{
+			ptype = PQI_CONNECT_HIDDEN_I2P_TCP;
+			timeout = RS_TCP_HIDDEN_TIMEOUT_PERIOD;
 		}
 		else
 		{

--- a/libretroshare/src/pqi/pqipersongrp.cc
+++ b/libretroshare/src/pqi/pqipersongrp.cc
@@ -617,20 +617,19 @@ int     pqipersongrp::connectPeer(const RsPeerId& id
 	uint32_t ptype;
 	if (type & RS_NET_CONN_TCP_ALL)
 	{
-		if (type == RS_NET_CONN_TCP_HIDDEN_TOR)
-		{
+		switch (type) {
+		case RS_NET_CONN_TCP_HIDDEN_TOR:
 			ptype = PQI_CONNECT_HIDDEN_TOR_TCP;
 			timeout = RS_TCP_HIDDEN_TIMEOUT_PERIOD;
-		}
-		else if (type == RS_NET_CONN_TCP_HIDDEN_I2P)
-		{
+			break;
+		case RS_NET_CONN_TCP_HIDDEN_I2P:
 			ptype = PQI_CONNECT_HIDDEN_I2P_TCP;
 			timeout = RS_TCP_HIDDEN_TIMEOUT_PERIOD;
-		}
-		else
-		{
+			break;
+		default:
 			ptype = PQI_CONNECT_TCP;
-			timeout = RS_TCP_STD_TIMEOUT_PERIOD; 
+			timeout = RS_TCP_STD_TIMEOUT_PERIOD;
+			break;
 		}
 #ifdef PGRP_DEBUG
 		std::cerr << " pqipersongrp::connectPeer() connecting with TCP: Timeout :" << timeout;

--- a/libretroshare/src/pqi/pqisslpersongrp.cc
+++ b/libretroshare/src/pqi/pqisslpersongrp.cc
@@ -91,7 +91,11 @@ pqiperson * pqisslpersongrp::locked_createPerson(const RsPeerId& id, pqilistener
 	
 		pqiconnect *pqisc = new pqiconnect(pqip, rss, pqis);
 	
-		pqip -> addChildInterface(PQI_CONNECT_HIDDEN_TCP, pqisc);
+		if (mPeerMgr->isHiddenI2P() | mPeerMgr->isHiddenI2PPeer(id))
+			pqip -> addChildInterface(PQI_CONNECT_HIDDEN_I2P_TCP, pqisc);
+		else
+			/* default tor */
+			pqip -> addChildInterface(PQI_CONNECT_HIDDEN_TOR_TCP, pqisc);
 	}
 	else
 	{	

--- a/libretroshare/src/pqi/pqisslpersongrp.cc
+++ b/libretroshare/src/pqi/pqisslpersongrp.cc
@@ -91,7 +91,7 @@ pqiperson * pqisslpersongrp::locked_createPerson(const RsPeerId& id, pqilistener
 	
 		pqiconnect *pqisc = new pqiconnect(pqip, rss, pqis);
 	
-		if (mPeerMgr->isHiddenI2P() | mPeerMgr->isHiddenI2PPeer(id))
+		if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P) | mPeerMgr->isHiddenPeer(id, RS_HIDDEN_TYPE_I2P))
 			pqip -> addChildInterface(PQI_CONNECT_HIDDEN_I2P_TCP, pqisc);
 		else
 			/* default tor */

--- a/libretroshare/src/pqi/pqisslpersongrp.cc
+++ b/libretroshare/src/pqi/pqisslpersongrp.cc
@@ -91,11 +91,19 @@ pqiperson * pqisslpersongrp::locked_createPerson(const RsPeerId& id, pqilistener
 	
 		pqiconnect *pqisc = new pqiconnect(pqip, rss, pqis);
 	
-		if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P) | mPeerMgr->isHiddenPeer(id, RS_HIDDEN_TYPE_I2P))
+		/* first select type based on peer */
+		if (mPeerMgr->isHiddenPeer(id, RS_HIDDEN_TYPE_I2P)) {
 			pqip -> addChildInterface(PQI_CONNECT_HIDDEN_I2P_TCP, pqisc);
-		else
-			/* default tor */
+		} else if (mPeerMgr->isHiddenPeer(id, RS_HIDDEN_TYPE_TOR)) {
 			pqip -> addChildInterface(PQI_CONNECT_HIDDEN_TOR_TCP, pqisc);
+		} else {
+			/* peer is not a hidden one but we are */
+			/* select type based on ourselves */
+			if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P))
+				pqip -> addChildInterface(PQI_CONNECT_HIDDEN_I2P_TCP, pqisc);
+			else
+				pqip -> addChildInterface(PQI_CONNECT_HIDDEN_TOR_TCP, pqisc);
+		}
 	}
 	else
 	{	

--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -68,6 +68,8 @@ const uint32_t RS_HIDDEN_TYPE_NONE	= 0x0000;
 const uint32_t RS_HIDDEN_TYPE_UNKNOWN	= 0x0001;
 const uint32_t RS_HIDDEN_TYPE_TOR	= 0x0002;
 const uint32_t RS_HIDDEN_TYPE_I2P	= 0x0004;
+/* mask to match all valid hidden types */
+const uint32_t RS_HIDDEN_TYPE_MASK	= RS_HIDDEN_TYPE_I2P | RS_HIDDEN_TYPE_TOR;
 
 /* Visibility */
 const uint32_t RS_VS_DISC_OFF		= 0x0000;

--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -65,8 +65,9 @@ const uint32_t RS_NETMODE_UNREACHABLE	= 0x0005;
 
 /* Hidden Type */
 const uint32_t RS_HIDDEN_TYPE_NONE	= 0x0000;
-const uint32_t RS_HIDDEN_TYPE_TOR	= 0x0001;
-const uint32_t RS_HIDDEN_TYPE_I2P	= 0x0002;
+const uint32_t RS_HIDDEN_TYPE_UNKNOWN	= 0x0001;
+const uint32_t RS_HIDDEN_TYPE_TOR	= 0x0002;
+const uint32_t RS_HIDDEN_TYPE_I2P	= 0x0004;
 
 /* Visibility */
 const uint32_t RS_VS_DISC_OFF		= 0x0000;

--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -101,7 +101,8 @@ const uint32_t RS_PEER_CONNECTSTATE_TRYING_UDP        = 3;
 const uint32_t RS_PEER_CONNECTSTATE_CONNECTED_TCP     = 4;
 const uint32_t RS_PEER_CONNECTSTATE_CONNECTED_UDP     = 5;
 const uint32_t RS_PEER_CONNECTSTATE_CONNECTED_TOR     = 6;
-const uint32_t RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN = 7;
+const uint32_t RS_PEER_CONNECTSTATE_CONNECTED_I2P     = 7;
+const uint32_t RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN = 8;
 
 /* Error codes for certificate cleaning and cert parsing. Numbers should not overlap. */
 

--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -238,6 +238,7 @@ class RsPeerDetails
 	bool 			isHiddenNode;
 	std::string		hiddenNodeAddress;
 	uint16_t		hiddenNodePort;
+	uint32_t        hiddenType;
 
 	// Filled in for Standard Node.
 	std::string             localAddr;

--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -355,8 +355,8 @@ class RsPeers
 		virtual	bool setNetworkMode(const RsPeerId &ssl_id, uint32_t netMode) 	= 0;
 		virtual bool setVisState(const RsPeerId &ssl_id, uint16_t vs_disc, uint16_t vs_dht)	= 0;
 
-        virtual bool getProxyServer(std::string &addr, uint16_t &port,uint32_t& status_flags) = 0;
-		virtual bool setProxyServer(const std::string &addr, const uint16_t port) = 0;
+		virtual bool getProxyServer(const uint32_t type, std::string &addr, uint16_t &port,uint32_t& status_flags) = 0;
+		virtual bool setProxyServer(const uint32_t type, const std::string &addr, const uint16_t port) = 0;
 
 		virtual void getIPServersList(std::list<std::string>& ip_servers) = 0;
 		virtual void allowServerIPDetermination(bool) = 0;

--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -63,6 +63,11 @@ const uint32_t RS_NETMODE_EXT		= 0x0003;
 const uint32_t RS_NETMODE_HIDDEN	= 0x0004;
 const uint32_t RS_NETMODE_UNREACHABLE	= 0x0005;
 
+/* Hidden Type */
+const uint32_t RS_HIDDEN_TYPE_NONE	= 0x0000;
+const uint32_t RS_HIDDEN_TYPE_TOR	= 0x0001;
+const uint32_t RS_HIDDEN_TYPE_I2P	= 0x0002;
+
 /* Visibility */
 const uint32_t RS_VS_DISC_OFF		= 0x0000;
 const uint32_t RS_VS_DISC_MINIMAL	= 0x0001;

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -930,10 +930,10 @@ bool p3Peers::getProxyServer(std::string &addr, uint16_t &port, uint32_t &status
     #endif
 
 	struct sockaddr_storage proxy_addr;
-	mPeerMgr->getProxyServerAddress(proxy_addr);
+	mPeerMgr->getProxyServerAddressTor(proxy_addr);
 	addr = sockaddr_storage_iptostring(proxy_addr);
 	port = sockaddr_storage_port(proxy_addr);
-    mPeerMgr->getProxyServerStatus(status);
+    mPeerMgr->getProxyServerStatusTor(status);
     return true;
 }
 
@@ -958,7 +958,7 @@ bool p3Peers::setProxyServer(const std::string &addr_str, const uint16_t port)
 #endif
 /********************************** WINDOWS/UNIX SPECIFIC PART *******************/
 	{
-		return mPeerMgr->setProxyServerAddress(addr);
+		return mPeerMgr->setProxyServerAddressTor(addr);
 	}
 	else
 	{

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -435,7 +435,7 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 	}
 	else if (pcs.state & RS_PEER_S_CONNECTED)
     {
-        if(isProxyAddress(pcs.connectaddr) || mPeerMgr->isHidden())
+		if(isProxyAddress(RS_HIDDEN_TYPE_TOR, pcs.connectaddr) || isProxyAddress(RS_HIDDEN_TYPE_I2P, pcs.connectaddr) || mPeerMgr->isHidden())
             d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
         else if (pcs.connecttype == RS_NET_CONN_TCP_ALL)
         {
@@ -457,13 +457,13 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 	return true;
 }
 
-bool p3Peers::isProxyAddress(const sockaddr_storage& addr)
+bool p3Peers::isProxyAddress(const uint32_t type, const sockaddr_storage& addr)
 {
     uint16_t port ;
     std::string string_addr;
-   uint32_t status ;
+	uint32_t status ;
 
-    if(!getProxyServer(string_addr, port, status))
+	if(!getProxyServer(type, string_addr, port, status))
         return false ;
 
     return sockaddr_storage_iptostring(addr)==string_addr && sockaddr_storage_port(addr)==port ;
@@ -923,21 +923,21 @@ bool p3Peers::setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_t vs_dht)
 	return mPeerMgr->setVisState(id, vs_disc, vs_dht);
 }
 
-bool p3Peers::getProxyServer(std::string &addr, uint16_t &port, uint32_t &status)
+bool p3Peers::getProxyServer(const uint32_t type, std::string &addr, uint16_t &port, uint32_t &status)
 {
 	#ifdef P3PEERS_DEBUG
         std::cerr << "p3Peers::getProxyServer()" << std::endl;
     #endif
 
 	struct sockaddr_storage proxy_addr;
-	mPeerMgr->getProxyServerAddressTor(proxy_addr);
+	mPeerMgr->getProxyServerAddress(type, proxy_addr);
 	addr = sockaddr_storage_iptostring(proxy_addr);
 	port = sockaddr_storage_port(proxy_addr);
-    mPeerMgr->getProxyServerStatusTor(status);
+	mPeerMgr->getProxyServerStatus(type, status);
     return true;
 }
 
-bool p3Peers::setProxyServer(const std::string &addr_str, const uint16_t port)
+bool p3Peers::setProxyServer(const uint32_t type, const std::string &addr_str, const uint16_t port)
 {
 	#ifdef P3PEERS_DEBUG
         std::cerr << "p3Peers::setProxyServer() " << std::endl;
@@ -958,7 +958,7 @@ bool p3Peers::setProxyServer(const std::string &addr_str, const uint16_t port)
 #endif
 /********************************** WINDOWS/UNIX SPECIFIC PART *******************/
 	{
-		return mPeerMgr->setProxyServerAddressTor(addr);
+		return mPeerMgr->setProxyServerAddress(type, addr);
 	}
 	else
 	{

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -313,6 +313,7 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 		d.isHiddenNode = true;
 		d.hiddenNodeAddress = ps.hiddenDomain;
 		d.hiddenNodePort = ps.hiddenPort;
+		d.hiddenType = ps.hiddenType;
 		d.localAddr	= sockaddr_storage_iptostring(ps.localaddr);
 		d.localPort	= sockaddr_storage_port(ps.localaddr);
 		d.extAddr = "hidden";
@@ -324,6 +325,7 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 		d.isHiddenNode = false;
 		d.hiddenNodeAddress = "";
 		d.hiddenNodePort = 0;
+		d.hiddenType = RS_HIDDEN_TYPE_NONE;
 
 		d.localAddr	= sockaddr_storage_iptostring(ps.localaddr);
 		d.localPort	= sockaddr_storage_port(ps.localaddr);
@@ -1113,6 +1115,7 @@ bool 	p3Peers::loadDetailsFromStringCert(const std::string &certstr, RsPeerDetai
 			{
 				pd.hiddenNodeAddress = domain;
 				pd.hiddenNodePort = port;
+				pd.hiddenType = mPeerMgr->hiddenDomainToHiddenType(domain);
 			}
 		}
 		else
@@ -1317,7 +1320,7 @@ RsPeerDetails::RsPeerDetails()
 	hasSignedMe(false),accept_connection(false),
 	state(0),localAddr(""),localPort(0),extAddr(""),extPort(0),netMode(0),vs_disc(0), vs_dht(0),
 	lastConnect(0),connectState(0),connectStateString(""),connectPeriod(0),foundDHT(false), 
-	wasDeniedConnection(false), deniedTS(0)
+	wasDeniedConnection(false), deniedTS(0), hiddenType(RS_HIDDEN_TYPE_NONE)
 {
 }
 

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -435,8 +435,14 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 	}
 	else if (pcs.state & RS_PEER_S_CONNECTED)
     {
-		if(isProxyAddress(RS_HIDDEN_TYPE_TOR, pcs.connectaddr) || isProxyAddress(RS_HIDDEN_TYPE_I2P, pcs.connectaddr) || mPeerMgr->isHidden())
+        if(isProxyAddress(RS_HIDDEN_TYPE_TOR, pcs.connectaddr) || mPeerMgr->isHidden(RS_HIDDEN_TYPE_TOR))
+        {
             d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
+        }
+        else if (isProxyAddress(RS_HIDDEN_TYPE_I2P, pcs.connectaddr) || mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P))
+        {
+            d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
+        }
         else if (pcs.connecttype == RS_NET_CONN_TCP_ALL)
         {
             d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TCP;

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -440,40 +440,40 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 		/* peer is connected - determine how and set proper connectState */
 		if(mPeerMgr->isHidden())
 		{
+			uint32_t type;
 			/* hidden location */
 			/* use connection direction to determine connection type */
 			if(pcs.actAsServer)
 			{
 				/* incoming connection */
 				/* use own type to set connectState */
-				if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_TOR))
-				{
+				type = mPeerMgr->getHiddenType(AuthSSL::getAuthSSL()->OwnId());
+				switch (type) {
+				case RS_HIDDEN_TYPE_TOR:
 					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
-				}
-				else if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P))
-				{
+					break;
+				case RS_HIDDEN_TYPE_I2P:
 					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
-				}
-				else
-				{
+					break;
+				default:
 					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
+					break;
 				}
 			}
 			else
 			{
 				/* outgoing connection */
 				/* use peer hidden type to set connectState */
-				if (ps.hiddenType == RS_HIDDEN_TYPE_TOR)
-				{
+				switch (ps.hiddenType) {
+				case RS_HIDDEN_TYPE_TOR:
 					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
-				}
-				else if (ps.hiddenType == RS_HIDDEN_TYPE_I2P)
-				{
+					break;
+				case RS_HIDDEN_TYPE_I2P:
 					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
-				}
-				else
-				{
+					break;
+				default:
 					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
+					break;
 				}
 			}
 		}
@@ -481,17 +481,16 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 		{
 			/* hidden peer */
 			/* use hidden type to set connectState */
-			if (ps.hiddenType == RS_HIDDEN_TYPE_TOR)
-			{
+			switch (ps.hiddenType) {
+			case RS_HIDDEN_TYPE_TOR:
 				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
-			}
-			else if (ps.hiddenType == RS_HIDDEN_TYPE_I2P)
-			{
+				break;
+			case RS_HIDDEN_TYPE_I2P:
 				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
-			}
-			else
-			{
+				break;
+			default:
 				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
+				break;
 			}
 		}
 		else

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -437,26 +437,80 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 	}
 	else if (pcs.state & RS_PEER_S_CONNECTED)
     {
-        if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_TOR) || isProxyAddress(RS_HIDDEN_TYPE_TOR, pcs.connectaddr))
-        {
-            d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
-        }
-        else if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P) || isProxyAddress(RS_HIDDEN_TYPE_I2P, pcs.connectaddr))
-        {
-            d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
-        }
-        else if (pcs.connecttype == RS_NET_CONN_TCP_ALL)
-        {
-            d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TCP;
-        }
-        else if (pcs.connecttype == RS_NET_CONN_UDP_ALL)
-        {
-            d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UDP;
-        }
-        else
-        {
-            d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
-        }
+		/* peer is connected - determine how and set proper connectState */
+		if(mPeerMgr->isHidden())
+		{
+			/* hidden location */
+			/* use connection direction to determine connection type */
+			if(pcs.actAsServer)
+			{
+				/* incoming connection */
+				/* use own type to set connectState */
+				if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_TOR))
+				{
+					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
+				}
+				else if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P))
+				{
+					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
+				}
+				else
+				{
+					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
+				}
+			}
+			else
+			{
+				/* outgoing connection */
+				/* use peer hidden type to set connectState */
+				if (ps.hiddenType == RS_HIDDEN_TYPE_TOR)
+				{
+					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
+				}
+				else if (ps.hiddenType == RS_HIDDEN_TYPE_I2P)
+				{
+					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
+				}
+				else
+				{
+					d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
+				}
+			}
+		}
+		else if (ps.hiddenType & RS_HIDDEN_TYPE_MASK)
+		{
+			/* hidden peer */
+			/* use hidden type to set connectState */
+			if (ps.hiddenType == RS_HIDDEN_TYPE_TOR)
+			{
+				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
+			}
+			else if (ps.hiddenType == RS_HIDDEN_TYPE_I2P)
+			{
+				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
+			}
+			else
+			{
+				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
+			}
+		}
+		else
+		{
+			/* peer and we are normal nodes */
+			/* use normal detection to set connectState */
+			if (pcs.connecttype == RS_NET_CONN_TCP_ALL)
+			{
+				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TCP;
+			}
+			else if (pcs.connecttype == RS_NET_CONN_UDP_ALL)
+			{
+				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UDP;
+			}
+			else
+			{
+				d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN;
+			}
+		}
     }
 
 	d.wasDeniedConnection = pcs.wasDeniedConnection;

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -435,11 +435,11 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 	}
 	else if (pcs.state & RS_PEER_S_CONNECTED)
     {
-        if(isProxyAddress(RS_HIDDEN_TYPE_TOR, pcs.connectaddr) || mPeerMgr->isHidden(RS_HIDDEN_TYPE_TOR))
+        if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_TOR) || isProxyAddress(RS_HIDDEN_TYPE_TOR, pcs.connectaddr))
         {
             d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_TOR;
         }
-        else if (isProxyAddress(RS_HIDDEN_TYPE_I2P, pcs.connectaddr) || mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P))
+        else if (mPeerMgr->isHidden(RS_HIDDEN_TYPE_I2P) || isProxyAddress(RS_HIDDEN_TYPE_I2P, pcs.connectaddr))
         {
             d.connectState = RS_PEER_CONNECTSTATE_CONNECTED_I2P;
         }

--- a/libretroshare/src/rsserver/p3peers.h
+++ b/libretroshare/src/rsserver/p3peers.h
@@ -94,9 +94,9 @@ virtual	bool setDynDNS(const RsPeerId &id, const std::string &dyndns);
 virtual	bool setNetworkMode(const RsPeerId &id, uint32_t netMode);
 virtual bool setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_t vs_dht);
 
-virtual bool getProxyServer(std::string &addr, uint16_t &port,uint32_t& status);
-virtual bool setProxyServer(const std::string &addr, const uint16_t port);
-virtual bool isProxyAddress(const sockaddr_storage&);
+virtual bool getProxyServer(const uint32_t type, std::string &addr, uint16_t &port,uint32_t& status);
+virtual bool setProxyServer(const uint32_t type,const std::string &addr, const uint16_t port);
+virtual bool isProxyAddress(const uint32_t type,const sockaddr_storage&);
 
 virtual void getIPServersList(std::list<std::string>& ip_servers) ;
 virtual void allowServerIPDetermination(bool) ;

--- a/retroshare-gui/src/gui/GenCertDialog.cpp
+++ b/retroshare-gui/src/gui/GenCertDialog.cpp
@@ -165,7 +165,7 @@ GenCertDialog::GenCertDialog(bool onlyGenerateIdentity, QWidget *parent)
 #if QT_VERSION >= 0x040700
 	ui.email_input->setPlaceholderText(tr("[Optional] Visible to your friends, and friends of friends.")) ;
 	ui.node_input->setPlaceholderText(tr("[Required] Examples: Home, Laptop,...")) ;
-	ui.hiddenaddr_input->setPlaceholderText(tr("[Required] Examples: xa76giaf6ifda7ri63i263.onion (obtained by you from Tor)")) ;
+	ui.hiddenaddr_input->setPlaceholderText(tr("[Required] Tor/I2P address - Examples: xa76giaf6ifda7ri63i263.onion (obtained by you from Tor)")) ;
 	ui.name_input->setPlaceholderText(tr("[Required] Visible to your friends, and friends of friends."));
 	ui.password_input->setPlaceholderText(tr("[Required] This password protects your private PGP key."));
 	ui.password_input_2->setPlaceholderText(tr("[Required] Type the same password again here."));
@@ -458,7 +458,7 @@ void GenCertDialog::genPerson()
 			/* Message Dialog */
 			QMessageBox::warning(this,
 				tr("Invalid hidden node"),
-			tr("Please enter a valid address of the form: 31769173498.onion:7800"),
+			tr("Please enter a valid address of the form: 31769173498.onion:7800 or [52 characters].b32.i2p"),
 			QMessageBox::Ok);
 			return;
 		}

--- a/retroshare-gui/src/gui/GenCertDialog.ui
+++ b/retroshare-gui/src/gui/GenCertDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>853</width>
-    <height>592</height>
+    <height>711</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -111,7 +111,7 @@
      </property>
      <property name="text">
       <string>You can create a new profile with this form.
-Alternatively you can use an existing profile. Just uncheck "Create a new profile"</string>
+Alternatively you can use an existing profile. Just uncheck &quot;Create a new profile&quot;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -431,7 +431,7 @@ Alternatively you can use an existing profile. Just uncheck "Create a new profil
        <item>
         <widget class="QLabel" name="hiddenaddr_label">
          <property name="text">
-          <string>Tor address</string>
+          <string>hidden address</string>
          </property>
         </widget>
        </item>
@@ -593,7 +593,7 @@ anonymous, you can use a fake email.</string>
    <item>
     <widget class="QLabel" name="label_hiddenaddr2">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a Tor Onion address of the form: xa76giaf6ifda7ri63i263.onion &lt;/p&gt;&lt;p&gt;In order to get one, you must configure Tor to create a new hidden service. If you do not yet have one, you can still go on, and make it right later in Retroshare's Options-&amp;gt;Server-&amp;gt;Tor configuration panel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This can be a Tor Onion address of the form: xa76giaf6ifda7ri63i263.onion &lt;br/&gt;or an I2P address in the form: [52 characters].b32.i2p &lt;/p&gt;&lt;p&gt;In order to get one, you must configure either Tor or I2P to create a new hidden service / server tunnel. If you do not yet have one, you can still go on, and make it right later in Retroshare's Options-&amp;gt;Server-&amp;gt;Hidden Service configuration panel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -761,6 +761,7 @@ anonymous, you can use a fake email.</string>
     </spacer>
    </item>
   </layout>
+  <zorder>no_node_label</zorder>
   <zorder>genButton2</zorder>
   <zorder>header_label</zorder>
   <zorder>genprofileinfo_label</zorder>
@@ -773,15 +774,15 @@ anonymous, you can use a fake email.</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>StyledLabel</class>
+   <extends>QLabel</extends>
+   <header>gui/common/StyledLabel.h</header>
+  </customwidget>
+  <customwidget>
    <class>HeaderFrame</class>
    <extends>QFrame</extends>
    <header>gui/common/HeaderFrame.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>StyledLabel</class>
-   <extends>QLabel</extends>
-   <header>gui/common/StyledLabel.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/retroshare-gui/src/gui/common/StatusDefs.cpp
+++ b/retroshare-gui/src/gui/common/StatusDefs.cpp
@@ -182,6 +182,10 @@ QString StatusDefs::connectStateString(RsPeerDetails &details)
 		stateString = qApp->translate("StatusDefs", "Connected: Tor");
 		isConnected = true;
 		break;
+	case RS_PEER_CONNECTSTATE_CONNECTED_I2P:
+		stateString = qApp->translate("StatusDefs", "Connected: I2P");
+		isConnected = true;
+		break;
 	case RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN:
 		stateString = qApp->translate("StatusDefs", "Connected: Unknown");
 		isConnected = true;
@@ -231,6 +235,7 @@ QString StatusDefs::connectStateWithoutTransportTypeString(RsPeerDetails &detail
 	case RS_PEER_CONNECTSTATE_CONNECTED_TCP:
 	case RS_PEER_CONNECTSTATE_CONNECTED_UDP:
 	case RS_PEER_CONNECTSTATE_CONNECTED_TOR:
+	case RS_PEER_CONNECTSTATE_CONNECTED_I2P:
 	case RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN:
 		stateString = qApp->translate("StatusDefs", "Connected");
 		break;
@@ -257,6 +262,9 @@ QString StatusDefs::connectStateIpString(RsPeerDetails &details)
 		break;
 	case RS_PEER_CONNECTSTATE_CONNECTED_TOR:
 		stateString += QString(details.actAsServer ? qApp->translate("StatusDefs", "Tor-in") : qApp->translate("StatusDefs", "Tor-out"));
+		break;
+	case RS_PEER_CONNECTSTATE_CONNECTED_I2P:
+		stateString += QString(details.actAsServer ? qApp->translate("StatusDefs", "I2P-in") : qApp->translate("StatusDefs", "I2P-out"));
 		break;
 	case RS_PEER_CONNECTSTATE_CONNECTED_UNKNOWN:
 		stateString += qApp->translate("StatusDefs", "unkown");

--- a/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
+++ b/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
@@ -488,6 +488,7 @@ void ConnectFriendWizard::initializePage(int id)
 			}
 
 			ui->nodeEdit->setText(loc);
+			ui->ipEdit->setText(QString::fromStdString(peerDetails.isHiddenNode ? peerDetails.hiddenNodeAddress : peerDetails.extAddr));
 			ui->signersEdit->setPlainText(ts);
 
 			fillGroups(this, ui->groupComboBox, groupId);

--- a/retroshare-gui/src/gui/connect/ConnectFriendWizard.ui
+++ b/retroshare-gui/src/gui/connect/ConnectFriendWizard.ui
@@ -31,7 +31,7 @@
     <item>
      <widget class="QRadioButton" name="textRadioButton">
       <property name="text">
-       <string>Enter the &amp;certificate manually</string>
+       <string>Enter the certificate manually</string>
       </property>
      </widget>
     </item>
@@ -52,7 +52,7 @@
     <item>
      <widget class="QRadioButton" name="rsidRadioButton">
       <property name="text">
-       <string>E&amp;nter RetroShare ID manually</string>
+       <string>Enter RetroShare ID manually</string>
       </property>
      </widget>
     </item>
@@ -67,7 +67,7 @@
     <item>
      <widget class="QRadioButton" name="friendRecommendationsRadioButton">
       <property name="text">
-       <string>&amp;Recommend many friends to each others</string>
+       <string>Recommend many friends to each others</string>
       </property>
      </widget>
     </item>

--- a/retroshare-gui/src/gui/connect/ConnectFriendWizard.ui
+++ b/retroshare-gui/src/gui/connect/ConnectFriendWizard.ui
@@ -31,7 +31,7 @@
     <item>
      <widget class="QRadioButton" name="textRadioButton">
       <property name="text">
-       <string>&amp;Enter the certificate manually</string>
+       <string>Enter the &amp;certificate manually</string>
       </property>
      </widget>
     </item>
@@ -52,7 +52,7 @@
     <item>
      <widget class="QRadioButton" name="rsidRadioButton">
       <property name="text">
-       <string>&amp;Enter RetroShare ID manually</string>
+       <string>E&amp;nter RetroShare ID manually</string>
       </property>
      </widget>
     </item>
@@ -67,7 +67,7 @@
     <item>
      <widget class="QRadioButton" name="friendRecommendationsRadioButton">
       <property name="text">
-       <string>Recommend many friends to each others</string>
+       <string>&amp;Recommend many friends to each others</string>
       </property>
      </widget>
     </item>
@@ -1038,27 +1038,41 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="signersLabel">
          <property name="text">
           <string>Signers</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <widget class="QPlainTextEdit" name="signersEdit">
          <property name="readOnly">
           <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
+       <item row="7" column="0" colspan="2">
         <widget class="QLabel" name="alreadyRegisteredLabel">
          <property name="text">
           <string>This peer is already on your friend list. Adding it might just set it's ip address.</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="ipLabel">
+         <property name="text">
+          <string>IP-Addr:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="ipEdit">
+         <property name="text">
+          <string>IP-Address</string>
          </property>
         </widget>
        </item>

--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -813,7 +813,7 @@ void ServerPage::saveAddresses()
 	rsConfig->SetMaxDataRates( ui.totalDownloadRate->value(), ui.totalUploadRate->value() );
 
 	// HANDLE PROXY SERVER.
-	std::string orig_proxyaddr,new_proxyaddr;
+	std::string orig_proxyaddr, new_proxyaddr;
 	uint16_t orig_proxyport, new_proxyport;
 	uint32_t status ;
 	// Tor
@@ -1151,7 +1151,7 @@ void ServerPage::updateOutProxyIndicator()
 	else
 	{
 		ui.iconlabel_i2p_outgoing->setPixmap(QPixmap(ICON_STATUS_UNKNOWN)) ;
-		ui.iconlabel_i2p_outgoing->setToolTip(tr("Tor proxy is not enabled")) ;
+		ui.iconlabel_i2p_outgoing->setToolTip(tr("I2P proxy is not enabled")) ;
 	}
 }
 
@@ -1181,11 +1181,11 @@ void ServerPage::updateInProxyIndicator()
 	}
     proxy.setCapabilities(QNetworkProxy::HostNameLookupCapability | proxy.capabilities()) ;
 
-        //ui.iconlabel_tor_incoming->setPixmap(QPixmap(ICON_STATUS_UNKNOWN)) ;
-        //ui.testIncomingTor_PB->setIcon(QIcon(":/loader/circleball-16.gif")) ;
-        QMovie *movie = new QMovie(":/images/loader/circleball-16.gif");
-		ui.iconlabel_service_incoming->setMovie(movie);
-    movie->start() ;
+	//ui.iconlabel_tor_incoming->setPixmap(QPixmap(ICON_STATUS_UNKNOWN)) ;
+	//ui.testIncomingTor_PB->setIcon(QIcon(":/loader/circleball-16.gif")) ;
+	QMovie *movie = new QMovie(":/images/loader/circleball-16.gif");
+	ui.iconlabel_service_incoming->setMovie(movie);
+	movie->start() ;
 
     QNetworkProxy::setApplicationProxy(proxy) ;
 
@@ -1217,7 +1217,7 @@ void ServerPage::handleNetworkReply(QNetworkReply *reply)
 
         //ui.testIncomingTor_PB->setIcon(QIcon(ICON_STATUS_UNKNOWN)) ;
 		ui.iconlabel_service_incoming->setPixmap(QPixmap(ICON_STATUS_UNKNOWN)) ;
-		ui.iconlabel_service_incoming->setToolTip(tr("The proxy is not enabled or broken.\Are all services up and running fine??\nAlso check your ports!")) ;
+		ui.iconlabel_service_incoming->setToolTip(tr("The proxy is not enabled or broken.\nAre all services up and running fine??\nAlso check your ports!")) ;
     }
 
     reply->close();

--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -980,7 +980,6 @@ void ServerPage::loadHiddenNode()
 		expected += QString::number(detail.localPort);
 		break;
 	case RS_HIDDEN_TYPE_TOR:
-	default:
 		ui.l_serviceAddress->setText(tr("Onion Address"));
 		ui.l_incomingTestResult->setText(tr("Tor incoming ok"));
 
@@ -991,6 +990,13 @@ void ServerPage::loadHiddenNode()
 		expected += QString::fromStdString(detail.localAddr);
 		expected += ":";
 		expected += QString::number(detail.localPort);
+		break;
+	default:
+		ui.l_serviceAddress->setText(tr("Service Address"));
+		ui.l_incomingTestResult->setText(tr("incoming ok"));
+
+		expected += "Please fill in a service address";
+
 		break;
 	}
 	ui.hiddenpage_configuration->setPlainText(expected);
@@ -1174,10 +1180,11 @@ void ServerPage::updateInProxyIndicator()
 		proxy.setPort(ui.hiddenpage_proxyPort_i2p->text().toInt());
 		break;
 	case RS_HIDDEN_TYPE_TOR:
-	default:
 		proxy.setHostName(ui.hiddenpage_proxyAddress_tor->text());
 		proxy.setPort(ui.hiddenpage_proxyPort_tor->text().toInt());
 		break;
+	default:
+		return;
 	}
     proxy.setCapabilities(QNetworkProxy::HostNameLookupCapability | proxy.capabilities()) ;
 

--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -967,20 +967,24 @@ void ServerPage::loadHiddenNode()
 
 	updateOutProxyIndicator();
 
-	QString expected;
+	QString expected = "";
 	switch (mHiddenType) {
 	case RS_HIDDEN_TYPE_I2P:
 		ui.l_serviceAddress->setText(tr("I2P Address"));
 		ui.l_incomingTestResult->setText(tr("I2P incoming ok"));
 
-		expected = "--TODO-- see http://127.0.0.1:7657/i2ptunnelmgr";
+		expected += "http://127.0.0.1:7657/i2ptunnelmgr - I2P Hidden Services\n";
+		expected += tr("Points at: ");
+		expected += QString::fromStdString(detail.localAddr);
+		expected += ":";
+		expected += QString::number(detail.localPort);
 		break;
 	case RS_HIDDEN_TYPE_TOR:
 	default:
 		ui.l_serviceAddress->setText(tr("Onion Address"));
 		ui.l_incomingTestResult->setText(tr("Tor incoming ok"));
 
-		expected = "HiddenServiceDir </your/path/to/hidden/directory/service>\n";
+		expected += "HiddenServiceDir </your/path/to/hidden/directory/service>\n";
 		expected += "HiddenServicePort ";
 		expected += QString::number(detail.hiddenNodePort);
 		expected += " ";

--- a/retroshare-gui/src/gui/settings/ServerPage.h
+++ b/retroshare-gui/src/gui/settings/ServerPage.h
@@ -78,7 +78,7 @@ private slots:
     void toggleTunnelConnection(bool) ;
     void clearKnownAddressList() ;
     void handleNetworkReply(QNetworkReply *reply);
-    void updateTorInProxyIndicator();
+    void updateInProxyIndicator();
 
 private:
     // ban list
@@ -98,6 +98,7 @@ private:
     QNetworkAccessManager *manager ;
 
     bool mIsHiddenNode;
+	u_int32_t mHiddenType;
 };
 
 #endif // !SERVERPAGE_H

--- a/retroshare-gui/src/gui/settings/ServerPage.h
+++ b/retroshare-gui/src/gui/settings/ServerPage.h
@@ -52,6 +52,7 @@ public slots:
     void updateStatus();
 
 private slots:
+    // ban list
     void updateSelectedBlackListIP(int row, int, int, int);
     void updateSelectedWhiteListIP(int row,int,int,int);
     void addIpRangeToBlackList();
@@ -69,6 +70,8 @@ private slots:
     void ipFilterContextMenu(const QPoint &);
     void ipWhiteListContextMenu(const QPoint &point);
     void removeBannedIp();
+
+    // server
     void saveAddresses();
     void toggleUPnP();
     void toggleIpDetermination(bool) ;
@@ -78,11 +81,12 @@ private slots:
     void updateTorInProxyIndicator();
 
 private:
-
-    // Alternative Versions for HiddenNode Mode.
+    // ban list
     void addPeerToIPTable(QTableWidget *table, int row, const BanListPeer &blp);
     bool removeCurrentRowFromBlackList(sockaddr_storage& collected_addr,int& masked_bytes);
     bool removeCurrentRowFromWhiteList(sockaddr_storage &collected_addr, int &masked_bytes);
+
+    // Alternative Versions for HiddenNode Mode.
     void loadHiddenNode();
     void updateStatusHiddenNode();
     void saveAddressesHiddenNode();

--- a/retroshare-gui/src/gui/settings/ServerPage.h
+++ b/retroshare-gui/src/gui/settings/ServerPage.h
@@ -90,8 +90,7 @@ private:
     void loadHiddenNode();
     void updateStatusHiddenNode();
     void saveAddressesHiddenNode();
-    void updateTorOutProxyIndicator();
-    void updateLocInProxyIndicator();
+    void updateOutProxyIndicator();
     void loadFilteredIps() ;
 
     Ui::ServerPage ui;

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -1011,7 +1011,7 @@ You can connect to Hidden Nodes, even if you are running a standard Node, so why
               <item>
                <widget class="QLabel" name="l_incomingTestResult">
                 <property name="text">
-                 <string>Tor incoming  ok</string>
+                 <string>incoming  ok</string>
                 </property>
                </widget>
               </item>
@@ -1055,8 +1055,7 @@ You can connect to Hidden Nodes, even if you are running a standard Node, so why
                <bool>true</bool>
               </property>
               <property name="plainText">
-               <string>HiddenServiceDir &lt;/your/path/to/hidden/directory/service&gt;
-HiddenServicePort 9191 127.0.0.1:9191</string>
+               <string>Please fill in a service address</string>
               </property>
              </widget>
             </item>

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -942,7 +942,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
               <item>
                <widget class="QPushButton" name="testIncoming_PB">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This button simulates a SSL connection to your Tor address using the Tor proxy. If your Tor node is reachable, it should cause a SSL handshake error, which RS will interpret as a valid connection state. This operation might also cause several &quot;security warning&quot; about connections from your local host IP (127.0.0.1) in the News Feed if you enabled it,&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This button simulates a SSL connection to your hidden address using the corresponding proxy. If your hidden node is reachable, it should cause a SSL handshake error, which RS will interpret as a valid connection state. This operation might also cause several &amp;quot;security warning&amp;quot; about connections from your local host IP (127.0.0.1) in the News Feed if you enabled it,&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>Test</string>
@@ -978,14 +978,14 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
             <item row="1" column="1">
              <widget class="QLineEdit" name="hiddenpage_serviceAddress">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is your onion address. It should look like &lt;span style=&quot; font-weight:600;&quot;&gt;[something].onion. &lt;/span&gt;If you configured a hidden service with Tor, the onion address is generated automatically by Tor.  You can get it in e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;/var/lib/tor/[service name]/hostname&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is your hidden address. It should look like &lt;span style=&quot; font-weight:600;&quot;&gt;[something].onion&lt;/span&gt; or &lt;span style=&quot; font-weight:600;&quot;&gt;[something].b32.i2p. &lt;/span&gt;If you configured a hidden service with Tor, the onion address is generated automatically by Tor. You can get it in e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;/var/lib/tor/[service name]/hostname&lt;/span&gt;. For I2P: Setup a server tunnel ( http://127.0.0.1:7657/i2ptunnelmgr ) and copy it's base32 address when it is started (should end with .b32.i2p)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="hiddenpage_localAddress">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the local address to which the Tor hidden service points at your localhost. Most of the time, &lt;span style=&quot; font-weight:600;&quot;&gt;127.0.0.1&lt;/span&gt; is the right answer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the local address to which the hidden service points at your localhost. Most of the time, &lt;span style=&quot; font-weight:600;&quot;&gt;127.0.0.1&lt;/span&gt; is the right answer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -11,13 +11,22 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
     <number>6</number>
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -515,7 +524,7 @@ behind a firewall or a VPN.</string>
          <property name="currentIndex">
           <number>0</number>
          </property>
-         <widget class="QWidget" name="tabWidgetPage1" native="true">
+         <widget class="QWidget" name="tabWidgetPage1">
           <attribute name="title">
            <string>IP blacklist</string>
           </attribute>
@@ -756,15 +765,15 @@ behind a firewall or a VPN.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="TorTAB">
+     <widget class="QWidget" name="HiddenTAB">
       <attribute name="title">
-       <string>Tor Configuration</string>
+       <string>Hidden Service Configuration</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
         <widget class="QGroupBox" name="torpage_outgoing">
          <property name="title">
-          <string>Outgoing Tor Connections</string>
+          <string>Outgoing Connections</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
@@ -779,10 +788,10 @@ behind a firewall or a VPN.</string>
                </widget>
               </item>
               <item>
-               <widget class="QLineEdit" name="torpage_proxyAddress"/>
+               <widget class="QLineEdit" name="hiddenpage_proxyAddress_tor"/>
               </item>
               <item>
-               <widget class="QSpinBox" name="torpage_proxyPort">
+               <widget class="QSpinBox" name="hiddenpage_proxyPort_tor">
                 <property name="minimum">
                  <number>10</number>
                 </property>
@@ -823,11 +832,66 @@ behind a firewall or a VPN.</string>
            </layout>
           </item>
           <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_15">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_17">
+              <item>
+               <widget class="QLabel" name="label_6">
+                <property name="text">
+                 <string>I2P Socks Proxy</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="hiddenpage_proxyAddress_i2p"/>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="hiddenpage_proxyPort_i2p">
+                <property name="minimum">
+                 <number>10</number>
+                </property>
+                <property name="maximum">
+                 <number>65535</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_18">
+              <item>
+               <widget class="QLabel" name="iconlabel_i2p_outgoing">
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="pixmap">
+                 <pixmap resource="../images.qrc">:/images/ledoff1.png</pixmap>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>I2P outgoing Okay</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="QPlainTextEdit" name="plainTextEdit">
             <property name="maximumSize">
              <size>
               <width>16777215</width>
-              <height>100</height>
+              <height>145</height>
              </size>
             </property>
             <property name="verticalScrollBarPolicy">
@@ -839,8 +903,10 @@ behind a firewall or a VPN.</string>
             <property name="plainText">
              <string>Tor Socks Proxy default: 127.0.0.1:9050.  Set in torrc config and update here.
 
+I2P Socks Proxy: see http://127.0.0.1:7657/i2ptunnelmgr for setting up a client tunnel.
+
 You can connect to Hidden Nodes, even if you 
-are running a standard Node, so why not setup Tor? </string>
+are running a standard Node, so why not setup Tor and/or I2P? </string>
             </property>
            </widget>
           </item>

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -914,7 +914,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="torpage_incoming">
+        <widget class="QGroupBox" name="hiddenpage_incoming">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -922,13 +922,13 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
           </sizepolicy>
          </property>
          <property name="title">
-          <string>Incoming Tor Connections</string>
+          <string>Incoming Service Connections</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_7">
           <item>
            <layout class="QGridLayout" name="gridLayout">
             <item row="0" column="2">
-             <widget class="QSpinBox" name="torpage_localPort">
+             <widget class="QSpinBox" name="hiddenpage_localPort">
               <property name="minimum">
                <number>10</number>
               </property>
@@ -940,7 +940,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
             <item row="0" column="3">
              <layout class="QHBoxLayout" name="horizontalLayout_9">
               <item>
-               <widget class="QPushButton" name="testIncomingTor_PB">
+               <widget class="QPushButton" name="testIncoming_PB">
                 <property name="toolTip">
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This button simulates a SSL connection to your Tor address using the Tor proxy. If your Tor node is reachable, it should cause a SSL handshake error, which RS will interpret as a valid connection state. This operation might also cause several &quot;security warning&quot; about connections from your local host IP (127.0.0.1) in the News Feed if you enabled it,&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
@@ -952,7 +952,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
              </layout>
             </item>
             <item row="1" column="2">
-             <widget class="QSpinBox" name="torpage_onionPort">
+             <widget class="QSpinBox" name="hiddenpage_servicePort">
               <property name="minimum">
                <number>10</number>
               </property>
@@ -962,7 +962,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_11">
+             <widget class="QLabel" name="l_serviceAddress">
               <property name="text">
                <string>Onion Address</string>
               </property>
@@ -976,14 +976,14 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QLineEdit" name="torpage_onionAddress">
+             <widget class="QLineEdit" name="hiddenpage_serviceAddress">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is your onion address. It should look like &lt;span style=&quot; font-weight:600;&quot;&gt;[something].onion. &lt;/span&gt;If you configured a hidden service with Tor, the onion address is generated automatically by Tor.  You can get it in e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;/var/lib/tor/[service name]/hostname&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLineEdit" name="torpage_localAddress">
+             <widget class="QLineEdit" name="hiddenpage_localAddress">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the local address to which the Tor hidden service points at your localhost. Most of the time, &lt;span style=&quot; font-weight:600;&quot;&gt;127.0.0.1&lt;/span&gt; is the right answer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -992,7 +992,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
             <item row="1" column="3">
              <layout class="QHBoxLayout" name="horizontalLayout">
               <item>
-               <widget class="QLabel" name="iconlabel_tor_incoming">
+               <widget class="QLabel" name="iconlabel_service_incoming">
                 <property name="maximumSize">
                  <size>
                   <width>16</width>
@@ -1008,7 +1008,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_16">
+               <widget class="QLabel" name="l_incomingTestResult">
                 <property name="text">
                  <string>Tor incoming  ok</string>
                 </property>
@@ -1028,7 +1028,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
              </widget>
             </item>
             <item>
-             <widget class="QPlainTextEdit" name="torpage_configuration">
+             <widget class="QPlainTextEdit" name="hiddenpage_configuration">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                 <horstretch>0</horstretch>

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -1087,7 +1087,7 @@ Once this is done, paste the Onion/I2P (Base32) Address in the box above.
 This is your external address on the Tor/I2P network.
 Finally make sure that the Ports match the configuration.
 
-If you have issues connecting over Tor check the Tor logs, too.</string>
+If you have issues connecting over Tor check the Tor logs too.</string>
             </property>
            </widget>
           </item>

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -965,7 +965,7 @@ You can connect to Hidden Nodes, even if you are running a standard Node, so why
             <item row="1" column="0">
              <widget class="QLabel" name="l_serviceAddress">
               <property name="text">
-               <string>Onion Address</string>
+               <string>Service Address</string>
               </property>
              </widget>
             </item>
@@ -1082,7 +1082,8 @@ HiddenServicePort 9191 127.0.0.1:9191</string>
             <property name="plainText">
              <string>To Receive Connections, you must first setup a Tor/I2P Hidden Service. 
 For Tor: See torrc and documentation for HOWTO details.
-For I2P: See http://127.0.0.1:7657/i2ptunnelmgr and documentation for HOWTO details.
+For I2P: See http://127.0.0.1:7657/i2ptunnelmgr for setting up a server tunnel:
+Tunnel Wizard -&gt; Server Tunnel -&gt; Standard -&gt; enter a name -&gt; enter the address and port your RS is using (see Local Address above) -&gt; check 'Auto Start' -&gt; finish!
 
 Once this is done, paste the Onion/I2P (Base32) Address in the box above.
 This is your external address on the Tor/I2P network.

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -1023,7 +1023,7 @@ are running a standard Node, so why not setup Tor and/or I2P? </string>
             <item>
              <widget class="QLabel" name="label_12">
               <property name="text">
-               <string>Expected torrc Port Configuration:</string>
+               <string>Expected Configuration:</string>
               </property>
              </widget>
             </item>
@@ -1079,14 +1079,15 @@ HiddenServicePort 9191 127.0.0.1:9191</string>
              <bool>true</bool>
             </property>
             <property name="plainText">
-             <string>To Receive Connections, you must first setup a Tor Hidden Service. 
-See Tor documentation for HOWTO details.
+             <string>To Receive Connections, you must first setup a Tor/I2P Hidden Service. 
+For Tor: See torrc and documentation for HOWTO details.
+For I2P: See http://127.0.0.1:7657/i2ptunnelmgr and documentation for HOWTO details.
 
-Once this is done, paste the Onion Address in the box above.
-This is your external address on the Tor network.
-Finally make sure that the Ports match the Tor configuration.
+Once this is done, paste the Onion/I2P (Base32) Address in the box above.
+This is your external address on the Tor/I2P network.
+Finally make sure that the Ports match the configuration.
 
-If you have issues connecting over Tor check the Tor logs too.</string>
+If you have issues connecting over Tor check the Tor logs, too.</string>
             </property>
            </widget>
           </item>

--- a/retroshare-gui/src/gui/settings/ServerPage.ui
+++ b/retroshare-gui/src/gui/settings/ServerPage.ui
@@ -895,7 +895,7 @@ behind a firewall or a VPN.</string>
              </size>
             </property>
             <property name="verticalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
+             <enum>Qt::ScrollBarAsNeeded</enum>
             </property>
             <property name="readOnly">
              <bool>true</bool>
@@ -903,10 +903,11 @@ behind a firewall or a VPN.</string>
             <property name="plainText">
              <string>Tor Socks Proxy default: 127.0.0.1:9050.  Set in torrc config and update here.
 
-I2P Socks Proxy: see http://127.0.0.1:7657/i2ptunnelmgr for setting up a client tunnel.
+I2P Socks Proxy: see http://127.0.0.1:7657/i2ptunnelmgr for setting up a client tunnel:
+Tunnel Wizard -&gt; Client Tunnel -&gt; SOCKS 4/4a/5 -&gt; enter a name -&gt; leave 'Outproxies' empty -&gt; enter port (memorize!) [you may also want to set the reachability to 127.0.0.1] -&gt; check 'Auto Start' -&gt; finish!
+Now enter the address (e.g. 127.0.0.1) and the port you've picked before for the I2P Proxy.
 
-You can connect to Hidden Nodes, even if you 
-are running a standard Node, so why not setup Tor and/or I2P? </string>
+You can connect to Hidden Nodes, even if you are running a standard Node, so why not setup Tor and/or I2P?</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Similar to Tor I2P provides hidden services and socks5 proxies to reach those.
This patch set adds I2P support to RetroShare.

It does:
- enable libretroshare to manage more than one in-proxy (tor + i2p)
- libretroshare will pick the right proxy based on the address to connect to
- generalize the gui - wherever appropriated - and add I2P support to hidden nodes (a hidden node can either be a Tor or an I2P hidden node)

Also:
- existing proxy code and gui functions (to check connectivity) are reused and expanded
- adding more proxies is easier now
- new functions have doxygen comments
