### PR TITLE
Improved reliability of the determination of external address

### DIFF
--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -1246,20 +1246,51 @@ bool p3PeerMgrIMPL::addCandidateForOwnExternalAddress(const RsPeerId &from, cons
     //		* emit a warnign when the address is unknown
     // 		* if multiple peers report the same address => notify the LinkMgr that the external address had changed.
 
-    sockaddr_storage addr_filtered ;
-    sockaddr_storage_copyip(addr_filtered,addr) ;
+	sockaddr_storage addr_filtered ;
+	sockaddr_storage_clear(addr_filtered) ;
+	sockaddr_storage_copyip(addr_filtered,addr) ;
 
 #ifdef PEER_DEBUG
-    std::cerr << "Own external address is " << sockaddr_storage_iptostring(addr_filtered) << ", as reported by friend " << from << std::endl;
+	std::cerr << "Own external address is " << sockaddr_storage_iptostring(addr_filtered) << ", as reported by friend " << from << std::endl;
 #endif
 
-    if(!sockaddr_storage_isExternalNet(addr_filtered))
+	if(!sockaddr_storage_isExternalNet(addr_filtered))
+	{
+#ifdef PEER_DEBUG
+		std::cerr << "  address is not an external address. Returning false" << std::endl ;
+#endif
+		return false ;
+	}
+
+    // Update a list of own IPs:
+    //	- remove old values for that same peer
+    //	- remove values for non connected peers
+    
     {
-#ifdef PEER_DEBUG
-        std::cerr << "  address is not an external address. Returning false" << std::endl ;
-#endif
-        return false ;
+	    RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
+            
+	    mReportedOwnAddresses[from] = addr_filtered ;
+
+	    for(std::map<RsPeerId,sockaddr_storage>::iterator it(mReportedOwnAddresses.begin());it!=mReportedOwnAddresses.end();)
+		    if(!mLinkMgr->isOnline(it->first))
+		    {
+			    std::map<RsPeerId,sockaddr_storage>::iterator tmp(it) ;
+			    ++tmp ;
+			    mReportedOwnAddresses.erase(it) ;
+			    it=tmp ;
+		    }
+	    else
+		    ++it ;
+
+	    sockaddr_storage current_best_ext_address_guess ;
+	    uint32_t count ;
+
+	    locked_computeCurrentBestOwnExtAddressCandidate(current_best_ext_address_guess,count) ;
+
+	    std::cerr << "p3PeerMgr::  Current external address is calculated to be: " << sockaddr_storage_iptostring(current_best_ext_address_guess) << " (simultaneously reported by " << count << " peers)." << std::endl;
     }
+       
+    // now current 
 
     sockaddr_storage own_addr ;
 
@@ -1282,8 +1313,54 @@ bool p3PeerMgrIMPL::addCandidateForOwnExternalAddress(const RsPeerId &from, cons
 
         RsServer::notify()->AddFeedItem(RS_FEED_ITEM_SEC_IP_WRONG_EXTERNAL_IP_REPORTED, from.toStdString(), sockaddr_storage_iptostring(own_addr), sockaddr_storage_iptostring(addr));
     }
+    
+    // we could also sweep over all connected friends and see if some report a different address.
 
     return true ;
+}
+
+bool p3PeerMgrIMPL::locked_computeCurrentBestOwnExtAddressCandidate(sockaddr_storage& addr, uint32_t& count)
+{
+    std::map<sockaddr_storage,ZeroedInt> addr_counts ;
+    
+    for(std::map<RsPeerId,sockaddr_storage>::iterator it(mReportedOwnAddresses.begin());it!=mReportedOwnAddresses.end();++it)
+	    ++addr_counts[it->second].n ;
+
+#ifdef PEER_DEBUG
+    std::cerr << "Current ext addr statistics:" << std::endl;
+#endif
+    
+    count = 0 ;
+    
+    for(std::map<sockaddr_storage,ZeroedInt>::const_iterator it(addr_counts.begin());it!=addr_counts.end();++it)
+    {
+        if(it->second.n > count)
+        {
+            addr = it->first ;
+            count = it->second.n ;
+        }
+        
+#ifdef PEER_DEBUG
+        std::cerr << sockaddr_storage_iptostring(it->first) << " : " << it->second.n << std::endl;
+#endif
+    }
+    
+    return true ;
+}
+ 
+bool p3PeerMgrIMPL::getExtAddressReportedByFriends(sockaddr_storage &addr, uint8_t& isstable)
+{
+        RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
+        
+        uint32_t count ;
+        
+        locked_computeCurrentBestOwnExtAddressCandidate(addr,count) ;
+        
+#ifdef PEER_DEBUG
+        std::cerr << "Estimation count = " << count << ". Trusted? = " << (count>=2) << std::endl;
+#endif
+        
+        return count >= 2 ;// 2 is not conservative enough. 3 should be probably better.	
 }
 
 static bool cleanIpList(std::list<pqiIpAddress>& lst,const RsPeerId& pid,p3LinkMgr *link_mgr)

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -153,6 +153,7 @@ virtual bool 	setLocalAddress(const RsPeerId &id, const struct sockaddr_storage 
 virtual bool 	setExtAddress(const RsPeerId &id, const struct sockaddr_storage &addr) = 0;
 virtual bool    setDynDNS(const RsPeerId &id, const std::string &dyndns) = 0;
 virtual bool 	addCandidateForOwnExternalAddress(const RsPeerId& from, const struct sockaddr_storage &addr) = 0;
+virtual bool 	getExtAddressReportedByFriends(struct sockaddr_storage& addr,uint8_t& isstable) = 0;
 
 virtual bool 	setNetworkMode(const RsPeerId &id, uint32_t netMode) = 0;
 virtual bool 	setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_t vs_dht) = 0;
@@ -200,6 +201,7 @@ virtual int 	getFriendCount(bool ssl, bool online) = 0;
 		// Single Use Function... shouldn't be here. used by p3serverconfig.cc
 virtual bool 	haveOnceConnected() = 0;
 
+virtual bool   locked_computeCurrentBestOwnExtAddressCandidate(sockaddr_storage &addr, uint32_t &count)=0;
 
 /*************************************************************************************************/
 /*************************************************************************************************/
@@ -256,6 +258,7 @@ virtual bool 	setLocalAddress(const RsPeerId &id, const struct sockaddr_storage 
 virtual bool 	setExtAddress(const RsPeerId &id, const struct sockaddr_storage &addr);
 virtual bool    setDynDNS(const RsPeerId &id, const std::string &dyndns);
 virtual bool 	addCandidateForOwnExternalAddress(const RsPeerId& from, const struct sockaddr_storage &addr) ;
+virtual bool 	getExtAddressReportedByFriends(struct sockaddr_storage& addr, uint8_t &isstable) ;
 
 virtual bool 	setNetworkMode(const RsPeerId &id, uint32_t netMode);
 virtual bool 	setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_t vs_dht);
@@ -327,6 +330,7 @@ int 	getConnectAddresses(const RsPeerId &id,
 				struct sockaddr_storage &lAddr, struct sockaddr_storage &eAddr, 
 				pqiIpAddrSet &histAddrs, std::string &dyndns);
 
+
 protected:
 	/* Internal Functions */
 
@@ -334,6 +338,8 @@ bool 	removeUnusedLocations();
 bool 	removeBannedIps();
 
 void    printPeerLists(std::ostream &out);
+
+virtual bool   locked_computeCurrentBestOwnExtAddressCandidate(sockaddr_storage &addr, uint32_t &count);
 
 	protected:
 /*****************************************************************/
@@ -349,7 +355,7 @@ void    printPeerLists(std::ostream &out);
 
 	p3LinkMgrIMPL *mLinkMgr;
 	p3NetMgrIMPL  *mNetMgr;
-
+    
 private:
 	RsMutex mPeerMtx; /* protects below */
 
@@ -362,6 +368,8 @@ private:
 	std::map<RsPeerId, peerState> mFriendList;	// <SSLid , peerState>
 	std::map<RsPeerId, peerState> mOthersList;
 
+    	std::map<RsPeerId,sockaddr_storage> mReportedOwnAddresses ;
+        
 	std::list<RsPeerGroupItem *> groupList;
 	uint32_t lastGroupId;
 


### PR DESCRIPTION
- Removed DHT stunner from the pool of ext address providers
- added mPeerMgr instead, which vote is based on ext address most often reported by peer discovery (this is 100% reliable against traffic forwarding).
