### PR TITLE
Removed flawed logic samenet/samesubnet

### DIFF
--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -1710,7 +1710,7 @@ bool   p3LinkMgrIMPL::retryConnectTCP(const RsPeerId &id)
 
 #define MAX_TCP_ADDR_AGE	(3600 * 24 * 14) // two weeks in seconds.
 
-bool  p3LinkMgrIMPL::locked_CheckPotentialAddr(const struct sockaddr_storage &addr, time_t age)
+bool p3LinkMgrIMPL::locked_CheckPotentialAddr(const struct sockaddr_storage &addr, time_t age)
 {
 #ifdef LINKMGR_DEBUG
 	std::cerr << "p3LinkMgrIMPL::locked_CheckPotentialAddr("; 
@@ -1731,13 +1731,8 @@ bool  p3LinkMgrIMPL::locked_CheckPotentialAddr(const struct sockaddr_storage &ad
 		return false;
 	}
 
-	bool isValid = sockaddr_storage_isValidNet(addr);
-	bool isLoopback = sockaddr_storage_isLoopbackNet(addr);
-	//	bool isPrivate = sockaddr_storage_isPrivateNet(addr);
-	bool isExternal = sockaddr_storage_isExternalNet(addr);
-
 	/* if invalid - quick rejection */
-	if (!isValid)
+	if ( ! sockaddr_storage_isValidNet(addr) )
 	{
 #ifdef LINKMGR_DEBUG
 		std::cerr << "p3LinkMgrIMPL::locked_CheckPotentialAddr() REJECTING - INVALID";
@@ -1772,60 +1767,7 @@ bool  p3LinkMgrIMPL::locked_CheckPotentialAddr(const struct sockaddr_storage &ad
         return false ;
     }
 
-	/* if it is an external address, we'll accept it.
-	 * - even it is meant to be a local address.
-	 */
-	if (isExternal)
-	{
-#ifdef LINKMGR_DEBUG
-		std::cerr << "p3LinkMgrIMPL::locked_CheckPotentialAddr() ACCEPTING - EXTERNAL"; 
-		std::cerr << std::endl;
-#endif
-		return true;
-	}
-
-
-	/* if loopback, then okay - probably proxy connection (or local testing).
-	 */
-	if (isLoopback)
-	{
-#ifdef LINKMGR_DEBUG
-		std::cerr << "p3LinkMgrIMPL::locked_CheckPotentialAddr() ACCEPTING - LOOPBACK"; 
-		std::cerr << std::endl;
-#endif
-		return true;
-	}
-
-
-	/* get here, it is private or loopback 
-	 *  - can only connect to these addresses if we are on the same subnet.
-	    - check net against our local address.
-	 */
-
-#ifdef LINKMGR_DEBUG
-	std::cerr << "p3LinkMgrIMPL::locked_CheckPotentialAddr() Checking sameNet against: "; 
-	std::cerr << sockaddr_storage_iptostring(mLocalAddress);
-	std::cerr << ")";
-	std::cerr << std::endl;
-#endif
-
-	if (sockaddr_storage_samenet(mLocalAddress, addr))
-	{
-#ifdef LINKMGR_DEBUG
-		std::cerr << "p3LinkMgrIMPL::locked_CheckPotentialAddr() ACCEPTING - PRIVATE & sameNET"; 
-		std::cerr << std::endl;
-#endif
-		return true;
-	}
-
-#ifdef LINKMGR_DEBUG
-	std::cerr << "p3LinkMgrIMPL::locked_CheckPotentialAddr() REJECTING - PRIVATE & !sameNET"; 
-	std::cerr << std::endl;
-#endif
-
-	/* else it fails */
-	return false;
-
+	return true;
 }
 
 

--- a/libretroshare/src/pqi/pqinetwork.cc
+++ b/libretroshare/src/pqi/pqinetwork.cc
@@ -758,52 +758,6 @@ bool getLocalInterfaces(struct sockaddr_storage &existAddr, std::list<struct soc
 	return false;
 }
 
-
-
-
-bool    sameNet(const struct in_addr *addr, const struct in_addr *addr2)
-{
-#ifdef NET_DEBUG
-	std::cerr << "sameNet: " << rs_inet_ntoa(*addr);
-	std::cerr << " VS " << rs_inet_ntoa(*addr2);
-	std::cerr << std::endl;
-#endif
-	struct in_addr addrnet, addrnet2;
-
-	addrnet.s_addr = inet_netof(*addr);
-	addrnet2.s_addr = inet_netof(*addr2);
-
-#ifdef NET_DEBUG
-	std::cerr << " (" << rs_inet_ntoa(addrnet);
-	std::cerr << " =?= " << rs_inet_ntoa(addrnet2);
-	std::cerr << ")" << std::endl;
-#endif
-
-	in_addr_t address1 = htonl(addr->s_addr);
-	in_addr_t address2 = htonl(addr2->s_addr);
-
-	// handle case for private net: 172.16.0.0/12
-	if (address1>>20 == (172<<4 | 16>>4))
-	{
-		return (address1>>20 == address2>>20);
-	}
-
-	return (inet_netof(*addr) == inet_netof(*addr2));
-}
-
-
-bool 	isSameSubnet(struct in_addr *addr1, struct in_addr *addr2)
-{
-	/* 
-	 * check that the (addr1 & 255.255.255.0) == (addr2 & 255.255.255.0)
-	 */
-
-	unsigned long a1 = ntohl(addr1->s_addr);
-	unsigned long a2 = ntohl(addr2->s_addr);
-
-	return ((a1 & 0xffffff00) == (a2 & 0xffffff00));
-}
-
 /* This just might be portable!!! will see!!!
  * Unfortunately this is usable on winXP+, determined by: (_WIN32_WINNT >= 0x0501)
  * but not older platforms.... which must use gethostbyname.

--- a/libretroshare/src/pqi/pqinetwork.h
+++ b/libretroshare/src/pqi/pqinetwork.h
@@ -104,10 +104,6 @@ int inaddr_cmp(struct sockaddr_in addr1, unsigned long);
 bool getPreferredInterface(struct sockaddr_storage &existAddr, struct sockaddr_storage &prefAddr); // returns best addr.
 bool getLocalInterfaces(struct sockaddr_storage &existAddr, std::list<struct sockaddr_storage> &addrs); // returns all possible addrs.
 
-	// checks (addr1 & 255.255.255.0) == (addr2 & 255.255.255.0)
-bool    isSameSubnet(struct in_addr *addr1, struct in_addr *addr2);
-bool	sameNet(const struct in_addr *addr, const struct in_addr *addr2); 
-
 in_addr_t pqi_inet_netof(struct in_addr addr); // our implementation.
 
 bool LookupDNSAddr(std::string name, struct sockaddr_in &addr);

--- a/libretroshare/src/pqi/pqissl.cc
+++ b/libretroshare/src/pqi/pqissl.cc
@@ -103,7 +103,7 @@ pqissl::pqissl(pqissllistener *l, PQInterface *parent, p3LinkMgr *lm)
 	sslmode(PQISSL_ACTIVE), ssl_connection(NULL), sockfd(-1), 
 	readpkt(NULL), pktlen(0), total_len(0),
 	attempt_ts(0),
-	sameLAN(false), n_read_zero(0), mReadZeroTS(0), ssl_connect_timeout(0),
+	n_read_zero(0), mReadZeroTS(0), ssl_connect_timeout(0),
 	mConnectDelay(0), mConnectTS(0),
 	mConnectTimeout(0), mTimeoutTS(0)
 {
@@ -255,7 +255,6 @@ int 	pqissl::reset_locked()
 	sockfd = -1;
 	waiting = WAITING_NOT;
 	ssl_connection = NULL;
-	sameLAN = false;
 	n_read_zero = 0;
 	mReadZeroTS = 0;
 	total_len = 0 ;
@@ -1458,21 +1457,11 @@ int	pqissl::accept_locked(SSL *ssl, int fd, const struct sockaddr_storage &forei
 
 	struct sockaddr_storage localaddr;
 	mLinkMgr->getLocalAddress(localaddr);
-	sameLAN = sockaddr_storage_samesubnet(remote_addr, localaddr);
 
 	{
 		std::string out = "pqissl::accept() SUCCESSFUL connection to: " + PeerId().toStdString();
 		out += " localaddr: " + sockaddr_storage_iptostring(localaddr);
 		out += " remoteaddr: " + sockaddr_storage_iptostring(remote_addr);
-
-		if (sameLAN)
-		{
-			out += " SAME LAN";
-		}
-		else
-		{
-			out += " DIFF LANs";
-		}
 
 		rslog(RSL_WARNING, pqisslzone, out);
 	}

--- a/libretroshare/src/pqi/pqissl.h
+++ b/libretroshare/src/pqi/pqissl.h
@@ -196,8 +196,6 @@ virtual int net_internal_fcntl_nonblock(int fd);
 
 	int attempt_ts;
 
-	bool sameLAN; /* flag use to allow high-speed transfers */
-
 	int n_read_zero; /* a counter to determine if the connection is really dead */
 	time_t mReadZeroTS; /* timestamp of first READ_ZERO occurance */
 

--- a/libretroshare/src/tests/pqi/TestNotes.txt
+++ b/libretroshare/src/tests/pqi/TestNotes.txt
@@ -70,9 +70,7 @@ Description:
 (1) isExternalNet()
 (2) isPrivateNet()
 (3) isLoopbackNet()
-(4) sameNet()
 (5) isValidNet()
-(6) isSameSubnet()
 (7) pqi_inet_netof()
 
 ------------------------------------------------------------

--- a/libretroshare/src/tests/pqi/net_test.cc
+++ b/libretroshare/src/tests/pqi/net_test.cc
@@ -211,46 +211,6 @@ bool test_local_address_manipulation()
 	return true;
 }
 
-
-
-#if 0
-
-std::ostream &showSocketError(std::ostream &out);
-
-std::string socket_errorType(int err);
-int sockaddr_cmp(struct sockaddr_in &addr1, struct sockaddr_in &addr2 );
-int inaddr_cmp(struct sockaddr_in addr1, struct sockaddr_in addr1 );
-int inaddr_cmp(struct sockaddr_in addr1, unsigned long);
-
-std::list<std::string> getLocalInterfaces(); // returns all possible addrs.
-bool    isExternalNet(struct in_addr *addr); // if Valid & is not Private or Loopback.
-bool	isPrivateNet(struct in_addr *addr); // if inside 10.0.0.0 or 
-						// other then firewalled.
-bool	isLoopbackNet(struct in_addr *addr); 
-bool	sameNet(struct in_addr *addr, struct in_addr *addr2); 
-bool	isValidNet(struct in_addr *addr);
-
-	// checks (addr1 & 255.255.255.0) == (addr2 & 255.255.255.0)
-bool    isSameSubnet(struct in_addr *addr1, struct in_addr *addr2);
-					
-
-struct in_addr getPreferredInterface(); // returns best addr.
-
-in_addr_t pqi_inet_netof(struct in_addr addr); // our implementation.
-
-bool LookupDNSAddr(std::string name, struct sockaddr_in &addr);
-
-/* universal socket interface */
-
-int unix_close(int sockfd);
-int unix_socket(int domain, int type, int protocol);
-int unix_fcntl_nonblock(int sockfd);
-int unix_connect(int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen);
-int unix_getsockopt_error(int sockfd, int *err);
-
-#endif
-
-
 bool test_bind_addr(struct sockaddr_in addr);
 
 bool test_address_listen()

--- a/libretroshare/src/tests/pqi/net_test1.cc
+++ b/libretroshare/src/tests/pqi/net_test1.cc
@@ -53,9 +53,7 @@ const char * invalid_addrstr = "AAA.BBB.256.256";
 int test_isExternalNet();
 int test_isPrivateNet();
 int test_isLoopbackNet();
-int test_sameNet();
 int test_isValidNet();
-int test_isSameSubnet();
 int test_pqi_inet_netof();
 
 INITTEST();
@@ -67,9 +65,7 @@ int main(int argc, char **argv)
 	test_isExternalNet();
 	test_isPrivateNet();
 	test_isLoopbackNet();
-	test_sameNet();
 	test_isValidNet();
-	test_isSameSubnet();
 	test_pqi_inet_netof();
 
 	FINALREPORT("net_test1");
@@ -158,42 +154,6 @@ int test_isLoopbackNet()
 	return 1;
 }
 
-int test_sameNet()
-{
-	struct in_addr localnet1_addr;
-	struct in_addr localnet2_addr;
-	struct in_addr localnet3_addr;
-	struct in_addr localnet4_addr;
-	struct in_addr localnet5_addr;
-	struct in_addr localnet6_addr;
-	struct in_addr localnet7_addr;
-	struct in_addr localnet8_addr;
-	struct in_addr external_addr;
-
-	inet_aton(localnet1_addrstr, &localnet1_addr);
-	inet_aton(localnet2_addrstr, &localnet2_addr);
-	inet_aton(localnet3_addrstr, &localnet3_addr);
-	inet_aton(localnet4_addrstr, &localnet4_addr);
-	inet_aton(localnet5_addrstr, &localnet5_addr);
-	inet_aton(localnet6_addrstr, &localnet6_addr);
-	inet_aton(localnet7_addrstr, &localnet7_addr);
-	inet_aton(localnet8_addrstr, &localnet8_addr);
-	inet_aton(external_addrstr, &external_addr);
-
-	CHECK(sameNet(&localnet1_addr, &localnet5_addr)==true);
-	CHECK(sameNet(&localnet2_addr, &localnet6_addr)==true);
-	CHECK(sameNet(&localnet3_addr, &localnet7_addr)==true);
-	CHECK(sameNet(&localnet4_addr, &localnet8_addr)==true);
-	CHECK(sameNet(&localnet1_addr, &external_addr)==false);
-	CHECK(sameNet(&localnet2_addr, &external_addr)==false);
-	CHECK(sameNet(&localnet3_addr, &external_addr)==false);
-	CHECK(sameNet(&localnet4_addr, &external_addr)==false);
-
-	REPORT("sameNet()");
-
-	return 1;
-}
-
 int test_isValidNet()
 {
 	struct in_addr localnet1_addr;
@@ -207,25 +167,6 @@ int test_isValidNet()
 	//CHECK(isValidNet(&invalid_addr)==false);
 
 	REPORT("isValidNet()");
-
-	return 1;
-}
-
-int test_isSameSubnet()
-{
-	struct in_addr localnet1_addr;
-	struct in_addr classc1_addr;
-	struct in_addr classc2_addr;
-
-	inet_aton(localnet1_addrstr, &localnet1_addr);
-	//random class C addresses
-	inet_aton("197.67.28.93", &classc1_addr);
-	inet_aton("197.67.28.3", &classc2_addr);
-
-	CHECK(isSameSubnet(&localnet1_addr, &classc1_addr)==false);
-	CHECK(isSameSubnet(&classc1_addr, &classc2_addr)==true);
-
-	REPORT("isSameSubnet()");
 
 	return 1;
 }

--- a/libretroshare/src/util/rsnet.h
+++ b/libretroshare/src/util/rsnet.h
@@ -107,8 +107,6 @@ bool operator<(const struct sockaddr_storage &a, const struct sockaddr_storage &
 bool sockaddr_storage_same(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 bool sockaddr_storage_samefamily(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 bool sockaddr_storage_sameip(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
-bool sockaddr_storage_samenet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
-bool sockaddr_storage_samesubnet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 
 // string,
 std::string sockaddr_storage_tostring(const struct sockaddr_storage &addr);

--- a/libretroshare/src/util/rsnet_ss.cc
+++ b/libretroshare/src/util/rsnet_ss.cc
@@ -56,14 +56,10 @@ bool sockaddr_storage_ipv6_setport(struct sockaddr_storage &addr, uint16_t port)
 bool sockaddr_storage_ipv4_lessthan(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 bool sockaddr_storage_ipv4_same(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 bool sockaddr_storage_ipv4_sameip(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
-bool sockaddr_storage_ipv4_samenet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
-bool sockaddr_storage_ipv4_samesubnet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 
 bool sockaddr_storage_ipv6_lessthan(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 bool sockaddr_storage_ipv6_same(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 bool sockaddr_storage_ipv6_sameip(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
-bool sockaddr_storage_ipv6_samenet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
-bool sockaddr_storage_ipv6_samesubnet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2);
 
 
 /********************************* Output     ***********************************/
@@ -372,62 +368,6 @@ bool sockaddr_storage_sameip(const struct sockaddr_storage &addr, const struct s
 	}
 	return false;
 }
-
-
-bool sockaddr_storage_samenet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2)
-{
-#ifdef SS_DEBUG
-	std::cerr << "sockaddr_storage_samenet()";
-	std::cerr << std::endl;
-#endif
-
-	if (!sockaddr_storage_samefamily(addr, addr2))
-		return false;
-
-	switch(addr.ss_family)
-	{
-		case AF_INET:
-			return sockaddr_storage_ipv4_samenet(addr, addr2);
-			break;
-		case AF_INET6:
-			return sockaddr_storage_ipv6_samenet(addr, addr2);
-			break;
-		default:
-			std::cerr << "sockaddr_storage_samenet() INVALID Family - error";
-			std::cerr << std::endl;
-			break;
-	}
-	return false;
-}
-
-bool sockaddr_storage_samesubnet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2)
-{
-#ifdef SS_DEBUG
-	std::cerr << "sockaddr_storage_samesubnet()";
-	std::cerr << std::endl;
-#endif
-
-	if (!sockaddr_storage_samefamily(addr, addr2))
-		return false;
-
-	switch(addr.ss_family)
-	{
-		case AF_INET:
-			return sockaddr_storage_ipv4_samesubnet(addr, addr2);
-			break;
-		case AF_INET6:
-			return sockaddr_storage_ipv6_samesubnet(addr, addr2);
-			break;
-		default:
-#ifdef SS_DEBUG
-            std::cerr << "sockaddr_storage_samesubnet() INVALID Family - error";
-            std::cerr << std::endl;
-#endif
-			break;
-	}
-	return false;
-}
-
 
 /********************************* Output     ***********************************/
 
@@ -813,38 +753,6 @@ bool sockaddr_storage_ipv4_sameip(const struct sockaddr_storage &addr, const str
 	return (ptr1->sin_addr.s_addr == ptr2->sin_addr.s_addr);
 }
 
-
-bool sockaddr_storage_ipv4_samenet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2)
-{
-	(void) addr;
-	(void) addr2;
-		
-#ifdef SS_DEBUG
-	std::cerr << "sockaddr_storage_ipv4_samenet()";
-	std::cerr << std::endl;
-#endif
-
-
-	const struct sockaddr_in *ptr1 = to_const_ipv4_ptr(addr);
-	const struct sockaddr_in *ptr2 = to_const_ipv4_ptr(addr2);
-	return sameNet(&(ptr1->sin_addr),&(ptr2->sin_addr));
-}
-
-bool sockaddr_storage_ipv4_samesubnet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2)
-{
-	(void) addr;
-	(void) addr2;
-		
-#ifdef SS_DEBUG
-	std::cerr << "sockaddr_storage_ipv4_samesubnet() using pqinetwork::isSameSubnet()";
-	std::cerr << std::endl;
-#endif
-
-	const struct sockaddr_in *ptr1 = to_const_ipv4_ptr(addr);
-	const struct sockaddr_in *ptr2 = to_const_ipv4_ptr(addr2);
-	return isSameSubnet((struct in_addr *) &(ptr1->sin_addr),(struct in_addr *) &(ptr2->sin_addr));
-}
-
 // IPV6
 bool sockaddr_storage_ipv6_lessthan(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2)
 {
@@ -905,34 +813,6 @@ bool sockaddr_storage_ipv6_sameip(const struct sockaddr_storage &addr, const str
 	}
 	return true;
 }
-
-
-bool sockaddr_storage_ipv6_samenet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2)
-{
-	(void) addr;
-	(void) addr2;
-		
-#ifdef SS_DEBUG
-    std::cerr << "sockaddr_storage_ipv6_samenet() TODO";
-    std::cerr << std::endl;
-#endif
-
-	return false;
-}
-
-bool sockaddr_storage_ipv6_samesubnet(const struct sockaddr_storage &addr, const struct sockaddr_storage &addr2)
-{
-	(void) addr;
-	(void) addr2;
-	
-#ifdef SS_DEBUG
-    std::cerr << "sockaddr_storage_ipv6_samesubnet() TODO";
-    std::cerr << std::endl;
-#endif
-
-	return false;
-}
-
 
 /********************************* Output     ***********************************/
 std::string sockaddr_storage_ipv4_iptostring(const struct sockaddr_storage &addr)


### PR DESCRIPTION
Removed flawed logic samenet/samesubnet you cannot determine if two ip are in the same subnet just from ips as the internet is not just a bunch of /24 since year 1993.
