### PR TITLE
Respect passed parameters in unix_socket

### DIFF
--- a/libretroshare/src/pqi/pqinetwork.cc
+++ b/libretroshare/src/pqi/pqinetwork.cc
@@ -858,16 +858,14 @@ int unix_close(int fd)
 	return ret;
 }
 
-int unix_socket(int /*domain*/, int /*type*/, int /*protocol*/)
+int unix_socket(int domain, int type, int protocol)
 {
-	int osock = socket(PF_INET, SOCK_STREAM, 0);
+	int osock = socket(domain, type, protocol);
 
-/******************* WINDOWS SPECIFIC PART ******************/
-#ifdef WINDOWS_SYS  // WINDOWS
-
+#ifdef WINDOWS_SYS
 #ifdef NET_DEBUG
 	std::cerr << "unix_socket()" << std::endl;
-#endif
+#endif // NET_DEBUG
 
 	if ((unsigned) osock == INVALID_SOCKET)
 	{
@@ -875,8 +873,8 @@ int unix_socket(int /*domain*/, int /*type*/, int /*protocol*/)
 		osock = -1;
 		errno = WinToUnixError(WSAGetLastError());
 	}
-#endif
-/******************* WINDOWS SPECIFIC PART ******************/
+#endif // WINDOWS_SYS
+
 	return osock;
 }
 


### PR DESCRIPTION
This make this wrapper more reusable also for other kinds of NetBinInterface and not only for tcp+ipv4 ones like pqissl, it is also used in the old ipv6 branch to create ipv6 tcp sockets.
