### PR TITLE
Removed some cruft like mymethod(){return;} from pqi

### DIFF
--- a/libretroshare/src/pqi/pqi_base.h
+++ b/libretroshare/src/pqi/pqi_base.h
@@ -267,57 +267,57 @@ const uint32_t PQI_CONNECT_HIDDEN_I2P_TCP = 0x0008;
 class BinInterface
 {
 public:
-	BinInterface() { return; }
-virtual ~BinInterface() { return; }
+	BinInterface() {}
+	virtual ~BinInterface() {}
 
-/**
- * To be called loop, for updating state
- */
-virtual int     tick() = 0;
+	/**
+	 * To be called loop, for updating state
+	 */
+	virtual int tick() = 0;
 
-/**
- * Sends data to a prescribed location (implementation dependent)
- *@param data what will be sent
- *@param len the size of data pointed to in memory
- */
-virtual int	senddata(void *data, int len) = 0;
+	/**
+	 * Sends data to a prescribed location (implementation dependent)
+	 *@param data what will be sent
+	 *@param len the size of data pointed to in memory
+	 */
+	virtual int senddata(void *data, int len) = 0;
 
-/**
- * reads data from a prescribed location (implementation dependent)
- *@param data what will be sent
- *@param len the size of data pointed to in memory
- */
-virtual int	readdata(void *data, int len) = 0;
+	/**
+	 * reads data from a prescribed location (implementation dependent)
+	 *@param data what will be sent
+	 *@param len the size of data pointed to in memory
+	 */
+	virtual int readdata(void *data, int len) = 0;
 
-/**
- * Is more particular the case of the sending data through a socket (internet)
- * moretoread and candsend, take a microsec timeout argument.
- *
- */
-virtual int	netstatus() = 0;
-virtual int	isactive() = 0;
-virtual bool	moretoread(uint32_t usec) = 0;
-virtual bool 	cansend(uint32_t usec) = 0;
+	/**
+	 * Is more particular the case of the sending data through a socket (internet)
+	 * moretoread and candsend, take a microsec timeout argument.
+	 *
+	 */
+	virtual int netstatus() = 0;
+	virtual int isactive() = 0;
+	virtual bool moretoread(uint32_t usec) = 0;
+	virtual bool cansend(uint32_t usec) = 0;
 
-/**
- *  method for streamer to shutdown bininterface
- **/
-virtual int	close() = 0;
+	/**
+	 *  method for streamer to shutdown bininterface
+	 **/
+	virtual int close() = 0;
 
-/**
- * If hashing data
- **/
-virtual RsFileHash gethash() = 0;
+	/**
+	 * If hashing data
+	 **/
+	virtual RsFileHash gethash() = 0;
 
-/**
- * Number of bytes read/sent
- */
-virtual uint64_t bytecount() { return 0; }
+	/**
+	 * Number of bytes read/sent
+	 */
+	virtual uint64_t bytecount() { return 0; }
 
-/**
- *  used by pqistreamer to limit transfers
- **/
-virtual bool 	bandwidthLimited() { return true; }
+	/**
+	 *  used by pqistreamer to limit transfers
+	 **/
+	virtual bool bandwidthLimited() { return true; }
 };
 
 
@@ -360,26 +360,30 @@ public:
 	/**
 	 * @param p_in used to notify system of connect/disconnect events
 	 */
-	NetInterface(PQInterface *p_in, const RsPeerId& id)
-	:p(p_in), peerId(id) { return; }
+	NetInterface(PQInterface *p_in, const RsPeerId& id) : p(p_in), peerId(id) {}
 
-virtual ~NetInterface() 
-	{ return; }
+	virtual ~NetInterface() {}
 
-virtual int connect(const struct sockaddr_storage &raddr) = 0; 
-virtual int listen() = 0; 
-virtual int stoplistening() = 0; 
-virtual int disconnect() = 0;
-virtual int reset() = 0;
-virtual const RsPeerId& PeerId() { return peerId; }
-virtual int getConnectAddress(struct sockaddr_storage &raddr) = 0;
+	/* TODO
+	 * The data entrypoint is connect(const struct sockaddr_storage &raddr)
+	 * To generalize NetInterface we should have a more general type for raddr
+	 * As an example a string containing an url or encoded like a domain name
+	 */
+	virtual int connect(const struct sockaddr_storage &raddr) = 0;
 
-virtual bool connect_parameter(uint32_t type, uint32_t value) = 0;
-virtual bool connect_parameter(uint32_t /* type */ , const std::string & /* value */ ) { return false; } // not generally used.
-virtual bool connect_additional_address(uint32_t /*type*/, const struct sockaddr_storage & /*addr*/) { return false; } // only needed by udp.
+	virtual int listen() = 0;
+	virtual int stoplistening() = 0;
+	virtual int disconnect() = 0;
+	virtual int reset() = 0;
+	virtual const RsPeerId& PeerId() { return peerId; }
+	virtual int getConnectAddress(struct sockaddr_storage &raddr) = 0;
+
+	virtual bool connect_parameter(uint32_t type, uint32_t value) = 0;
+	virtual bool connect_parameter(uint32_t /* type */ , const std::string & /* value */ ) { return false; } // not generally used.
+	virtual bool connect_additional_address(uint32_t /*type*/, const struct sockaddr_storage & /*addr*/) { return false; } // only needed by udp.
 
 protected:
-PQInterface *parent() { return p; }
+	PQInterface *parent() { return p; }
 
 private:
 	PQInterface *p;
@@ -397,10 +401,9 @@ private:
 class NetBinInterface: public NetInterface, public BinInterface
 {
 public:
-	NetBinInterface(PQInterface *parent, const RsPeerId& id)
-	:NetInterface(parent, id)
-	{ return; }
-virtual ~NetBinInterface() { return; }
+	NetBinInterface(PQInterface *parent, const RsPeerId& id) :
+		NetInterface(parent, id) {}
+	virtual ~NetBinInterface() {}
 };
 
 #define CHAN_SIGN_SIZE 16

--- a/libretroshare/src/pqi/pqi_base.h
+++ b/libretroshare/src/pqi/pqi_base.h
@@ -225,18 +225,14 @@ class PQInterface: public RateInterface
 		/**
 		 * also there are  tick + person id  functions.
 		 */
-		virtual int     tick() { return 0; }
-		virtual int     status() { return 0; }
+		virtual int tick() { return 0; }
+		virtual int status() { return 0; }
 		virtual const RsPeerId& PeerId() { return peerId; }
 
 		// the callback from NetInterface Connection Events.
-		virtual int	notifyEvent(NetInterface *ni, int event, const struct sockaddr_storage &remote_peer_address) 
-		{ 
-			(void) ni; /* remove unused parameter warnings */
-			(void) event; /* remove unused parameter warnings */
-			(void) remote_peer_address;
-			return 0; 
-		}
+		virtual int	notifyEvent(NetInterface * /*ni*/, int /*event*/,
+								const sockaddr_storage & /*remote_peer_address*/)
+		{ return 0; }
 
 	private:
 

--- a/libretroshare/src/pqi/pqilistener.h
+++ b/libretroshare/src/pqi/pqilistener.h
@@ -31,21 +31,14 @@
 
 class pqilistener
 {
-	public:
-
-	pqilistener() 		{ return; }
-virtual ~pqilistener() 		{ return; }
-
-virtual int     tick()					{ return 1; }
-virtual int     status()				{ return 1; }
-virtual int     setListenAddr(const struct sockaddr_storage &addr)  
-	{ 
-		(void) addr; /* suppress unused parameter warning */
-		return 1; 
-	}
-virtual int	setuplisten() 				{ return 1; }
-virtual int     resetlisten() 				{ return 1; }
-
+public:
+	pqilistener() {}
+	virtual ~pqilistener() {}
+	virtual int tick() { return 1; }
+	virtual int status() { return 1; }
+	virtual int setListenAddr(const sockaddr_storage & /*addr*/) { return 1; }
+	virtual int setuplisten() { return 1; }
+	virtual int resetlisten() { return 1; }
 };
 
 

--- a/libretroshare/src/pqi/pqissl.cc
+++ b/libretroshare/src/pqi/pqissl.cc
@@ -1936,10 +1936,7 @@ bool 	pqissl::cansend(uint32_t usec)
 
 }
 
-RsFileHash pqissl::gethash()
-{
-	return RsFileHash() ;
-}
+RsFileHash pqissl::gethash() { return RsFileHash(); }
 
 /********** End of Implementation of BinInterface ******************/
 

--- a/libretroshare/src/pqi/pqissl.h
+++ b/libretroshare/src/pqi/pqissl.h
@@ -170,10 +170,13 @@ int Extract_Failed_SSL_Certificate(); // try to get cert anyway.
 bool  	CheckConnectionTimeout();
 
 
-	//protected internal fns that are overloaded for udp case.
-virtual int net_internal_close(int fd);
-virtual int net_internal_SSL_set_fd(SSL *ssl, int fd);
-virtual int net_internal_fcntl_nonblock(int fd);
+	/* Do we really need this ?
+	 * It is very specific TCP+SSL stuff and unlikely to be reused.
+	 * In fact we are overloading them in pqissludp case where they do different things or nothing.
+	 */
+	virtual int net_internal_close(int fd);
+	virtual int net_internal_SSL_set_fd(SSL *ssl, int fd);
+	virtual int net_internal_fcntl_nonblock(int fd);
 
 
 	/* data */
@@ -206,11 +209,9 @@ virtual int net_internal_fcntl_nonblock(int fd);
 	uint32_t mConnectTimeout;
 	time_t   mTimeoutTS;
 
-
 private:
 	// ssl only fns.
-int connectInterface(const struct sockaddr_storage &addr);
-
+	int connectInterface(const struct sockaddr_storage &addr);
 };
 
 

--- a/libretroshare/src/pqi/pqissllistener.cc
+++ b/libretroshare/src/pqi/pqissllistener.cc
@@ -56,19 +56,17 @@ const int pqissllistenzone = 49787;
  */
 
 
-pqissllistenbase::pqissllistenbase(const struct sockaddr_storage &addr, p3PeerMgr *pm)
-        :laddr(addr), active(false), mPeerMgr(pm)
-
+pqissllistenbase::pqissllistenbase(const sockaddr_storage &addr, p3PeerMgr *pm)
+	: laddr(addr), active(false), mPeerMgr(pm)
 {
-        if (!(AuthSSL::getAuthSSL()-> active())) {
-		pqioutput(PQL_ALERT, pqissllistenzone, 
-			"SSL-CTX-CERT-ROOT not initialised!");
-
+	if (!(AuthSSL::getAuthSSL()-> active()))
+	{
+		pqioutput(PQL_ALERT, pqissllistenzone,
+				  "SSL-CTX-CERT-ROOT not initialised!");
 		exit(1);
 	}
 
 	setuplisten();
-	return;
 }
 
 pqissllistenbase::~pqissllistenbase()
@@ -730,18 +728,7 @@ int pqissllistenbase::isSSLActive(int /*fd*/, SSL *ssl)
  *
  */
 
-pqissllistener::pqissllistener(const struct sockaddr_storage &addr, p3PeerMgr *lm)
-        :pqissllistenbase(addr, lm)
-{
-	return;
-}
-
-pqissllistener::~pqissllistener()
-{
-	return;
-}
-
-int 	pqissllistener::addlistenaddr(const RsPeerId& id, pqissl *acc)
+int pqissllistener::addlistenaddr(const RsPeerId& id, pqissl *acc)
 {
 	std::map<RsPeerId, pqissl *>::iterator it;
 
@@ -755,7 +742,6 @@ int 	pqissllistener::addlistenaddr(const RsPeerId& id, pqissl *acc)
 			
 			pqioutput(PQL_DEBUG_ALERT, pqissllistenzone, out);
 			return -1;
-
 		}
 	}
 
@@ -792,7 +778,7 @@ int	pqissllistener::removeListenPort(const RsPeerId& id)
 }
 
 
-int 	pqissllistener::status()
+int pqissllistener::status()
 {
 	pqissllistenbase::status();
 	// print certificates we are listening for.

--- a/libretroshare/src/pqi/pqissllistener.h
+++ b/libretroshare/src/pqi/pqissllistener.h
@@ -67,20 +67,18 @@ public:
 	pqissllistenbase(const struct sockaddr_storage &addr, p3PeerMgr *pm);
 	virtual ~pqissllistenbase();
 
-/*************************************/
-/*       LISTENER INTERFACE         **/
+	/*************************************/
+	/*       LISTENER INTERFACE          */
+	virtual int tick();
+	virtual int status();
+	virtual int setListenAddr(const struct sockaddr_storage &addr);
+	virtual int setuplisten();
+	virtual int resetlisten();
+	/*************************************/
 
-virtual int 	tick();
-virtual int 	status();
-virtual int     setListenAddr(const struct sockaddr_storage &addr);
-virtual int	setuplisten();
-virtual int     resetlisten();
-
-/*************************************/
-
-int	acceptconnection();
-int	continueaccepts();
-int	finaliseAccepts();
+	int acceptconnection();
+	int continueaccepts();
+	int finaliseAccepts();
 
 	struct IncomingSSLInfo
 	{
@@ -92,52 +90,44 @@ int	finaliseAccepts();
 	};
 
 	// fn to get cert, anyway
-int	continueSSL(IncomingSSLInfo&, bool);
-int 	closeConnection(int fd, SSL *ssl);
-int 	isSSLActive(int fd, SSL *ssl);
+	int	continueSSL(IncomingSSLInfo&, bool);
+	int closeConnection(int fd, SSL *ssl);
+	int isSSLActive(int fd, SSL *ssl);
 
-virtual int completeConnection(int sockfd, IncomingSSLInfo&) = 0;
-virtual int finaliseConnection(int fd, SSL *ssl, const RsPeerId& peerId, const struct sockaddr_storage &raddr) = 0;
-	protected:
+	virtual int completeConnection(int sockfd, IncomingSSLInfo&) = 0;
+	virtual int finaliseConnection(int fd, SSL *ssl, const RsPeerId& peerId,
+								   const sockaddr_storage &raddr) = 0;
 
+protected:
 	struct sockaddr_storage laddr;
 	std::list<AcceptedSSL> accepted_ssl;
-
-	private:
-
-	int Extract_Failed_SSL_Certificate(const IncomingSSLInfo&);
-
-	bool active;
-	int lsock;
-
-	std::list<IncomingSSLInfo> incoming_ssl ;
-
-	protected:
-
 	p3PeerMgr *mPeerMgr;
 
+private:
+	int Extract_Failed_SSL_Certificate(const IncomingSSLInfo&);
+	bool active;
+	int lsock;
+	std::list<IncomingSSLInfo> incoming_ssl ;
 };
 
 
 class pqissllistener: public pqissllistenbase
 {
-	public:
+public:
+	pqissllistener(const struct sockaddr_storage &addr, p3PeerMgr *pm) :
+		pqissllistenbase(addr, pm) {}
+	virtual ~pqissllistener() {}
 
-        pqissllistener(const struct sockaddr_storage &addr, p3PeerMgr *pm);
-virtual ~pqissllistener();
+	int addlistenaddr(const RsPeerId& id, pqissl *acc);
+	int removeListenPort(const RsPeerId& id);
 
-int 	addlistenaddr(const RsPeerId& id, pqissl *acc);
-int	removeListenPort(const RsPeerId& id);
+	virtual int status();
+	virtual int completeConnection(int sockfd, IncomingSSLInfo&);
+	virtual int finaliseConnection(int fd, SSL *ssl, const RsPeerId& peerId,
+								   const sockaddr_storage &raddr);
 
-//virtual int 	tick();
-virtual int 	status();
-
-virtual int completeConnection(int sockfd, IncomingSSLInfo&);
-virtual int finaliseConnection(int fd, SSL *ssl, const RsPeerId& peerId, const struct sockaddr_storage &raddr);
-
-	private:
-
-	std::map<RsPeerId, pqissl *> listenaddr;
+private:
+	std::map<RsPeerId, pqissl*> listenaddr;
 };
 
 

--- a/libretroshare/src/pqi/pqissllistener.h
+++ b/libretroshare/src/pqi/pqissllistener.h
@@ -49,13 +49,12 @@ class p3PeerMgr;
 
 class AcceptedSSL
 {
-	public:
-	
+public:
 	int mFd;
 	SSL *mSSL;
 	RsPeerId mPeerId;
-	
-	struct sockaddr_storage mAddr;
+
+	sockaddr_storage mAddr;
 	time_t mAcceptTS;
 };
 
@@ -64,11 +63,9 @@ class AcceptedSSL
 
 class pqissllistenbase: public pqilistener
 {
-	public:
-
-
-        pqissllistenbase(const struct sockaddr_storage &addr, p3PeerMgr *pm);
-virtual ~pqissllistenbase();
+public:
+	pqissllistenbase(const struct sockaddr_storage &addr, p3PeerMgr *pm);
+	virtual ~pqissllistenbase();
 
 /*************************************/
 /*       LISTENER INTERFACE         **/

--- a/libretroshare/src/pqi/pqissludp.cc
+++ b/libretroshare/src/pqi/pqissludp.cc
@@ -51,22 +51,22 @@ static const uint32_t PQI_SSLUDP_DEF_CONN_PERIOD = 300;  /* 5  minutes? */
 
 /********** PQI SSL UDP STUFF **************************************/
 
-pqissludp::pqissludp(PQInterface *parent, p3LinkMgr *lm)
-        :pqissl(NULL, parent, lm), tou_bio(NULL),
-	listen_checktime(0), mConnectPeriod(PQI_SSLUDP_DEF_CONN_PERIOD), mConnectFlags(0), mConnectBandwidth(0)
+pqissludp::pqissludp(PQInterface *parent, p3LinkMgr *lm) :
+	pqissl(NULL, parent, lm), tou_bio(NULL), listen_checktime(0),
+	mConnectPeriod(PQI_SSLUDP_DEF_CONN_PERIOD), mConnectFlags(0),
+	mConnectBandwidth(0)
 {
-	RsStackMutex stack(mSslMtx); /**** LOCKED MUTEX ****/
+	RS_STACK_MUTEX(mSslMtx);
 
 	sockaddr_storage_clear(remote_addr);
 	sockaddr_storage_clear(mConnectProxyAddr);
 	sockaddr_storage_clear(mConnectSrcAddr);
-	return;
 }
 
 
 pqissludp::~pqissludp()
 { 
-        rslog(RSL_ALERT, pqissludpzone,  
+	rslog(RSL_ALERT, pqissludpzone,
             "pqissludp::~pqissludp -> destroying pqissludp");
 
 	/* must call reset from here, so that the
@@ -76,16 +76,13 @@ pqissludp::~pqissludp()
 	 *  This means that reset() will be called twice, but this should
 	 *  be harmless.
 	 */
-        stoplistening(); /* remove from p3proxy listenqueue */
-	reset(); 
+	stoplistening(); /* remove from p3proxy listenqueue */
+	reset();
 
-	RsStackMutex stack(mSslMtx); /**** LOCKED MUTEX ****/
+	RS_STACK_MUTEX(mSslMtx);
 
 	if (tou_bio) // this should be in the reset?
-	{
 		BIO_free(tou_bio);
-	}
-	return;
 }
 
 int pqissludp::reset_locked()
@@ -153,7 +150,7 @@ int	pqissludp::attach()
 
 
 // The Address determination is done centrally
-int 	pqissludp::Initiate_Connection()
+int pqissludp::Initiate_Connection()
 {
 	int err;
 
@@ -349,7 +346,7 @@ int 	pqissludp::Initiate_Connection()
 }
 
 /********* VERY DIFFERENT **********/
-int 	pqissludp::Basic_Connection_Complete()
+int pqissludp::Basic_Connection_Complete()
 {
 	rslog(RSL_DEBUG_BASIC, pqissludpzone, 
 	  "pqissludp::Basic_Connection_Complete()...");
@@ -448,15 +445,6 @@ int pqissludp::net_internal_fcntl_nonblock(int /*fd*/)
 	return 0;
 }
 
-
-/* These are identical to pqinetssl version */
-//int 	pqissludp::status()
-
-int	pqissludp::tick()
-{
-	pqissl::tick();
-	return 1;
-}
 
         // listen fns call the udpproxy.
 int pqissludp::listen()

--- a/libretroshare/src/pqi/pqissludp.h
+++ b/libretroshare/src/pqi/pqissludp.h
@@ -45,7 +45,7 @@
 class pqissludp;
 class cert;
 
-/* This provides a NetBinInterface, which is 
+/* This provides a NetBinInterface, which is
  * primarily inherited from pqissl.
  * fns declared here are different -> all others are identical.
  */
@@ -53,48 +53,47 @@ class cert;
 class pqissludp: public pqissl
 {
 public:
-        pqissludp(PQInterface *parent, p3LinkMgr *lm);
+	pqissludp(PQInterface *parent, p3LinkMgr *lm);
 
-virtual ~pqissludp();
+	virtual ~pqissludp();
 
 	// NetInterface.
 	// listen fns call the udpproxy.
-virtual int listen();
-virtual int stoplistening();
-virtual int tick();
+	virtual int listen();
+	virtual int stoplistening();
 
-virtual bool connect_parameter(uint32_t type, uint32_t value);
-virtual bool connect_additional_address(uint32_t type, const struct sockaddr_storage &addr);
+	virtual bool connect_parameter(uint32_t type, uint32_t value);
+	virtual bool connect_additional_address(uint32_t type, const struct sockaddr_storage &addr);
 
 	// BinInterface.
 	// These are reimplemented.	
-virtual bool moretoread(uint32_t usec);
-virtual bool cansend(uint32_t usec);
+	virtual bool moretoread(uint32_t usec);
+	virtual bool cansend(uint32_t usec);
 	/* UDP always through firewalls -> always bandwidth Limited */
-virtual bool bandwidthLimited() { return true; } 
+	virtual bool bandwidthLimited() { return true; }
 
 protected:
 
 	// pqissludp specific.
 	// called to initiate a connection;
-int 	attach();
+	int attach();
 
-virtual int reset_locked();
+	virtual int reset_locked();
 
-virtual int Initiate_Connection(); 
-virtual int Basic_Connection_Complete();
+	virtual int Initiate_Connection();
+	virtual int Basic_Connection_Complete();
 
-//protected internal fns that are overloaded for udp case.
-virtual int net_internal_close(int fd);
-virtual int net_internal_SSL_set_fd(SSL *ssl, int fd);
-virtual int net_internal_fcntl_nonblock(int fd);
+	/* Do we really need this ?
+	 * It is very specific UDP+ToU+SSL stuff and unlikely to be reused.
+	 * In fact we are overloading them here becase they are very do different of pqissl.
+	 */
+	virtual int net_internal_close(int fd);
+	virtual int net_internal_SSL_set_fd(SSL *ssl, int fd);
+	virtual int net_internal_fcntl_nonblock(int fd);
 
 private:
 
 	BIO *tou_bio;  // specific to ssludp.
-
-	//int remote_timeout;
-	//int proxy_timeout;
 
 	long listen_checktime;
 


### PR DESCRIPTION
Removed cruft like not useful statements that made code less readable and some example of that:

```
// pqissludp::tick() overload  pqissl::tick(); that always return 1

int pqissludp::tick()
{
    pqissl::tick();
    return 1;
}

// return is not needed
virtual ~NetInterface() 
    { return; }
```
