### PR TITLE
Add missing return

### DIFF
--- a/libretroshare/src/util/smallobject.cc
+++ b/libretroshare/src/util/smallobject.cc
@@ -161,9 +161,11 @@ void FixedAllocator::deallocate(void *p)
 uint32_t FixedAllocator::currentSize() const
 {
     uint32_t res = 0 ;
-    
+
     for(uint32_t i=0;i<_chunks.size();++i)
-	    res += (_numBlocks - _chunks[i]->_blocksAvailable) * _blockSize ;
+        res += (_numBlocks - _chunks[i]->_blocksAvailable) * _blockSize ;
+
+    return res ;
 }
 void FixedAllocator::printStatistics() const
 {


### PR DESCRIPTION
Was detected by the openSUSE build on the openBuilService:

```
[ 1581s] I: Program returns random data in a function
[ 1581s] E: retroshare06-git no-return-in-nonvoid-function util/smallobject.cc:167
```

https://build.opensuse.org/package/live_build_log/home:AsamK:RetroShare/RetroShare06-git/openSUSE_13.1/x86_64
