### PR TITLE
show or hide ID chooser in message box depending on destination of msg

### DIFF
--- a/retroshare-gui/src/gui/msgs/MessageComposer.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageComposer.cpp
@@ -136,8 +136,8 @@ MessageComposer::MessageComposer(QWidget *parent, Qt::WindowFlags flags)
     m_completer = NULL;
     
     ui.distantFrame->hide();
-    ui.respond_to_CB->setEnabled(false) ;
-    ui.fromLabel->setEnabled(false) ;
+    ui.respond_to_CB->hide();
+    ui.fromLabel->hide();
 
     Settings->loadWidgetInformation(this);
 
@@ -389,15 +389,15 @@ void MessageComposer::updateCells(int,int)
     }
     if(has_gxs)
     {
-        ui.respond_to_CB->setEnabled(true) ;
+        ui.respond_to_CB->show();
         ui.distantFrame->show();
-        ui.fromLabel->setEnabled(true);
+        ui.fromLabel->show();
     }
     else
     {
-        ui.respond_to_CB->setEnabled(false) ;
+        ui.respond_to_CB->hide();
         ui.distantFrame->hide() ;
-        ui.fromLabel->setEnabled(false);
+        ui.fromLabel->hide();
     }
 }
 


### PR DESCRIPTION
This should solve the ambiguous situation caused when an identity is required to send a message that is not intended to another identity. Hope it helps.
