### PR TITLE
Fixed a small spelling error

### DIFF
--- a/libresapi/src/api/RsControlModule.cpp
+++ b/libresapi/src/api/RsControlModule.cpp
@@ -408,7 +408,7 @@ void RsControlModule::handleCreateLocation(Request &req, Response &resp)
         std::string err_string;
         if(!RsAccounts::GeneratePGPCertificate(pgp_name, "", pgp_password, pgp_id, 2048, err_string))
         {
-            resp.setFail("could not cerate pgp key: "+err_string);
+            resp.setFail("could not create pgp key: "+err_string);
             return;
         }
     }


### PR DESCRIPTION
Changed resp.setFail("could not **cerate** pgp key: "+err_string); to resp.setFail("could not _create_ pgp key: "+err_string);
