### PR TITLE
Fix MacOSX 10.10 Yosemite Compilation

### DIFF
--- a/MacOS_X_InstallGuide.txt
+++ b/MacOS_X_InstallGuide.txt
@@ -1,0 +1,63 @@
+#############################
+###--- QT INSTALLATION ---###
+#############################
+
+###Install Qt via:
+http://www.qt.io/download/
+
+###Use default options.
+###Add to the PATH environment variable with this temporary solution.
+export PATH=/users/$USER/Qt/5.5/clang_64/bin:$PATH
+###Depends on wich version of Qt you use.
+
+##################################
+###--- MACPORT INSTALLATION ---###
+##################################
+
+###Install MacPort and XCode following this guide:
+http://guide.macports.org/#installing.xcode
+
+###Start XCode to get it updated and to able C compiler to create executables.
+
+###Install libraries
+$sudo port -v selfupdate
+$sudo port install openssl
+$sudo port install miniupnpc
+
+###Get Your OSX SDK if missing:
+https://github.com/phracker/MacOSX-SDKs
+
+###########################
+###--- LAST SETTINGS ---###
+###########################
+
+###In QtCreator Option Git add its path:
+C:\Program Files\Git\bin
+### and select "Pull" with "Rebase"
+
+###Compil missing libraries
+###SQLCipher
+cd <your development directory>
+git clone https://github.com/sqlcipher/sqlcipher.git
+cd sqlcipher
+./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" LDFLAGS="-lcrypto"
+make 
+sudo make install
+#NOTE, might be necessary to chmod 000 /usr/local/ssl temporarily during ./configure if 
+#homebrew uses newer, non-stock ssl dependencies found there. configure might get confused.
+
+### libMicroHTTPD: The one with port don't have good support.
+cd <your development directory>
+wget http://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.46.tar.gz
+tar zxvf libmicrohttpd-0.9.46.tar.gz
+cd libmicrohttpd-0.9.46
+bash ./configure
+sudo make install
+
+###You can now compile RS into Qt Creator or with terminal
+cd <your development directory>
+git clone https://github.com/RetroShare/RetroShare.git retroshare
+cd retroshare
+qmake;make
+
+###You can find compiled application on ./retroshare/retroshare-gui/src/RetroShare06.app

--- a/libresapi/src/libresapi.pro
+++ b/libresapi/src/libresapi.pro
@@ -33,8 +33,8 @@ libmicrohttpd{
 		PKGCONFIG *= libmicrohttpd
 	} else {
 		mac {
-		INCLUDEPATH += /usr/local/include
-		LIBS *= /usr/local/lib/libmicrohttpd.a
+			INCLUDEPATH += . $$INC_DIR
+			for(lib, LIB_DIR):exists($$lib/libmicrohttpd.a){ LIBS *= $$lib/libmicrohttpd.a}
 		} else {
 			LIBS *= -lmicrohttpd
 		}

--- a/libretroshare/src/dbase/findex.cc
+++ b/libretroshare/src/dbase/findex.cc
@@ -33,7 +33,11 @@
 #include <stdlib.h>
 #include <algorithm>
 #include <iostream>
+#ifdef __MAC_10_10
+#include <unordered_set>
+#else
 #include <tr1/unordered_set>
+#endif
 #include <iomanip>
 #include <fstream>
 #include <sys/stat.h>
@@ -54,8 +58,11 @@ static const char FILE_CACHE_SEPARATOR_CHAR = '|' ;
  ****/
 
 static RsMutex FIndexPtrMtx("FIndexPtrMtx") ;
+#ifdef __MAC_10_10
+std::unordered_set<void*> FileIndex::_pointers ;
+#else
 std::tr1::unordered_set<void*> FileIndex::_pointers ;
-
+#endif
 void FileIndex::registerEntry(void*p)
 {
 	RsStackMutex m(FIndexPtrMtx) ;

--- a/libretroshare/src/dbase/findex.h
+++ b/libretroshare/src/dbase/findex.h
@@ -27,7 +27,11 @@
 #include <string>
 #include <map>
 #include <set>
+#if __MAC_10_10
+#include <unordered_set>
+#else
 #include <tr1/unordered_set>
+#endif
 #include <list>
 #include <vector>
 #include <stdint.h>
@@ -246,7 +250,11 @@ class FileIndex
 
 		PersonEntry *root;
 
+#ifdef __MAC_10_10
+		static std::unordered_set<void*> _pointers ;
+#else
 		static std::tr1::unordered_set<void*> _pointers ;
+#endif
 		static void registerEntry(void*p) ; 
 		static void unregisterEntry(void*p) ; 
 		static bool isValid(void*p)  ;

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -266,6 +266,7 @@ mac {
                 DEFINES *= MINIUPNPC_VERSION=13
 
 		CONFIG += upnp_miniupnpc
+		CONFIG += c+11
 
 		# zeroconf disabled at the end of libretroshare.pro (but need the code)
 		#CONFIG += zeroconf
@@ -274,13 +275,14 @@ mac {
 		# Beautiful Hack to fix 64bit file access.
                 QMAKE_CXXFLAGS *= -Dfseeko64=fseeko -Dftello64=ftello -Dfopen64=fopen -Dvstatfs64=vstatfs
 
-                UPNPC_DIR = /usr/local/include
 		#GPG_ERROR_DIR = ../../../../libgpg-error-1.7
 		#GPGME_DIR  = ../../../../gpgme-1.1.8
 
-		INCLUDEPATH += . $${UPNPC_DIR} 
+		for(lib, LIB_DIR):LIBS += -L"$$lib"
+		for(bin, BIN_DIR):LIBS += -L"$$bin"
 
-		#INCLUDEPATH += . $${UPNPC_DIR} $${GPGME_DIR}/src $${GPG_ERROR_DIR}/src
+		DEPENDPATH += . $$INC_DIR
+		INCLUDEPATH += . $$INC_DIR
 
 		# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
 		LIBS += /usr/local/lib/libsqlcipher.a

--- a/libretroshare/src/retroshare/rsflags.h
+++ b/libretroshare/src/retroshare/rsflags.h
@@ -47,7 +47,12 @@ template<int n> class t_RsFlags32
 
 		friend std::ostream& operator<<(std::ostream& o,const t_RsFlags32<n>& f) 	// friendly print with 0 and I
 		{
-			for(int i=31;i>=0;--i) { o << ( (f._bits&(1<<i))?"I":"0") ; if(i%8==0) o << " " ; }
+			for(int i=31;i>=0;--i) {
+				std::string res = f._bits&(1<<i)?"I":"0" ;
+				std::string blank = " " ;
+				o << res ;
+				if(i%8==0) o << blank ;
+			}
 			return o ;
 		}
 	private:

--- a/libretroshare/src/util/rsnet.cc
+++ b/libretroshare/src/util/rsnet.cc
@@ -40,6 +40,7 @@
 	#define BIG_ENDIAN  4321
 #endif
 
+#ifndef ntohll
 uint64_t ntohll(uint64_t x)
 {
 #ifdef BYTE_ORDER
@@ -61,11 +62,13 @@ uint64_t ntohll(uint64_t x)
 #endif
 
 }
-
+#endif
+#ifndef htonll
 uint64_t htonll(uint64_t x)
 {
         return ntohll(x);
 }
+#endif
 
 void sockaddr_clear(struct sockaddr_in *addr)
 {

--- a/libretroshare/src/util/rsnet.h
+++ b/libretroshare/src/util/rsnet.h
@@ -58,8 +58,12 @@ int inet_aton(const char *name, struct in_addr *addr);
 /********************************** WINDOWS/UNIX SPECIFIC PART ******************/
 
 /* 64 bit conversions */
+#ifndef ntohll
 uint64_t ntohll(uint64_t x);
+#endif
+#ifndef htonll
 uint64_t htonll(uint64_t x);
+#endif
 
 /* blank a network address */
 void sockaddr_clear(struct sockaddr_in *addr);

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -212,11 +212,17 @@ macx {
 	CONFIG += version_detail_bash_script
         LIBS += -lssl -lcrypto -lz 
         #LIBS += -lssl -lcrypto -lz -lgpgme -lgpg-error -lassuan
-	LIBS += /usr/local/lib/libminiupnpc.a
+	for(lib, LIB_DIR):exists($$lib/libminiupnpc.a){ LIBS += $$lib/libminiupnpc.a}
 	LIBS += -framework CoreFoundation
 	LIBS += -framework Security
 	LIBS += -framework Carbon
-	INCLUDEPATH += . /usr/local/include
+
+	for(lib, LIB_DIR):LIBS += -L"$$lib"
+	for(bin, BIN_DIR):LIBS += -L"$$bin"
+
+	DEPENDPATH += . $$INC_DIR
+	INCLUDEPATH += . $$INC_DIR
+
 	#DEFINES *= MAC_IDLE # for idle feature
 	CONFIG -= uitools
 }

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -95,11 +95,15 @@ macx {
     # CONFIG += ppc x86 
 
 	LIBS += -Wl,-search_paths_first
-        LIBS += -lssl -lcrypto -lz 
-	LIBS += /usr/local/lib/libminiupnpc.a
+        LIBS += -lssl -lcrypto -lz
+	for(lib, LIB_DIR):exists($$lib/libminiupnpc.a){ LIBS += $$lib/libminiupnpc.a}
 	LIBS += -framework CoreFoundation
 	LIBS += -framework Security
-	INCLUDEPATH += /usr/local/include
+	for(lib, LIB_DIR):LIBS += -L"$$lib"
+	for(bin, BIN_DIR):LIBS += -L"$$bin"
+
+	DEPENDPATH += . $$INC_DIR
+	INCLUDEPATH += . $$INC_DIR
 
 	sshserver {
 		LIBS += -L../../../lib

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -35,6 +35,18 @@ win32 {
 	}
 }
 
+macx {
+	message(***retroshare.pri:MacOSX)
+	BIN_DIR += "/usr/bin"
+	INC_DIR += "/usr/include"
+	INC_DIR += "/usr/local/include"
+	INC_DIR += "/opt/local/include"
+	LIB_DIR += "/usr/local/lib"
+	LIB_DIR += "/opt/local/lib"
+	QMAKE_MACOSX_DEPLOYMENT_TARGET=10.10
+	QMAKE_MAC_SDK = macosx10.10
+}
+
 unfinished {
 	CONFIG += gxscircles
 	CONFIG += gxsthewire


### PR DESCRIPTION
by using retroshare.pri file like linux or windows,
 fixing namespace for unordered_set,
 fixing c++11 for ostream& operator<<,
 checking if ntohll and htonll already defined.
