### PR TITLE
Fix SIGSEGV in BinToHex:

### DIFF
--- a/libretroshare/src/serialiser/rsserial.cc
+++ b/libretroshare/src/serialiser/rsserial.cc
@@ -438,8 +438,9 @@ RsItem *    RsSerialiser::deserialise(void *data, uint32_t *size)
 		std::cerr << " Class: " << std::hex << (uint32_t) getRsItemClass(failedtype) << std::dec;
 		std::cerr << " Type: " << std::hex << (uint32_t) getRsItemType(failedtype) << std::dec;
 		std::cerr << " SubType: " << std::hex << (uint32_t) getRsItemSubType(failedtype) << std::dec;
-        std::cerr << " Data: " << RsUtil::BinToHex((char*)data,pkt_size).substr(0,300) << std::endl;
-        std::cerr << std::endl;
+		if (pkt_size>300) pkt_size=300;
+		std::cerr << " Data: " << RsUtil::BinToHex((char*)data,pkt_size) << std::endl;
+		std::cerr << std::endl;
 #endif
 		return NULL;
 	}


### PR DESCRIPTION
2015-12-26:
/libretroshare/src/util/rsprint.cc:53 in std::string
RsUtil::BinToHex(const char *arr, const uint32_t len)
len==3630841259
from
/libretroshare/src/serialiser/rsserial.cc::441 in RsItem *
RsSerialiser::deserialise(void *data, uint32_t *size)
Errors reported :
RsSerialiser::deserialise() ERROR deserialiser
missing!RsSerialiser::deserialise() PacketId: 1102
RsSerialiser::deserialise() ERROR Failed!
RsSerialiser::deserialise() pkt_size: 3630841259 vs *size: 3630841259
RsSerialiser::deserialise() FAILED PACKET Size: 3630841259 ID:
2455fe2RsSerialiser::deserialise() FAILED PACKET: Version: 2 Class: 45
Type: 5f SubType:
