### PR TITLE
Fix default Identity on Chat

### DIFF
--- a/libretroshare/src/chat/distributedchat.cc
+++ b/libretroshare/src/chat/distributedchat.cc
@@ -1898,7 +1898,6 @@ void DistributedChatService::addToSaveList(std::list<RsItem*>& list) const
 bool DistributedChatService::processLoadListItem(const RsItem *item)
 {
     const RsConfigKeyValueSet *vitem = NULL ;
-    _default_identity.clear() ;
 
 	if(NULL != (vitem = dynamic_cast<const RsConfigKeyValueSet*>(item)))
 		for(std::list<RsTlvKeyValue>::const_iterator kit = vitem->tlvkvs.pairs.begin(); kit != vitem->tlvkvs.pairs.end(); ++kit) 


### PR DESCRIPTION
This was reseted by a new listitem after it was restored.
