### PR TITLE
Check sockaddr_storage is not null before using it and call sockaddr_storage_port

### DIFF
--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -494,7 +494,8 @@ HEADERS +=	util/folderiterator.h \
 			util/rsmemcache.h \
 			util/rstickevent.h \
 			util/rsrecogn.h \
-			util/rsscopetimer.h
+			util/rsscopetimer.h \
+			util/stacktrace.h
 
 SOURCES +=	dbase/cachestrapper.cc \
 			dbase/fimonitor.cc \

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -379,9 +379,9 @@ bool    p3PeerMgrIMPL::getGpgId(const RsPeerId &ssl_id, RsPgpId &gpgId)
 
 /**** HIDDEN STUFF ****/
 
-bool    p3PeerMgrIMPL::isHidden()
+bool p3PeerMgrIMPL::isHidden()
 {
-	RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
+	RS_STACK_MUTEX(mPeerMtx);
 	return mOwnState.hiddenNode;
 }
 

--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -35,12 +35,16 @@
 #include <retroshare/rsids.h>
 
 /* The Main Interface Class - for information about your Peers
-* A peer is another RS instance, means associated with an SSL certificate
-* A same GPG person can have multiple peer running with different SSL certs signed by the same GPG key
-* Thus a peer have SSL cert details, and also the parent GPG details
-*/
+ * A peer is another RS instance, means associated with an SSL certificate
+ * A same GPG person can have multiple peer running with different SSL certs signed by the same GPG key
+ * Thus a peer have SSL cert details, and also the parent GPG details
+ */
 class RsPeers;
-extern RsPeers   *rsPeers;
+extern RsPeers *rsPeers;
+
+/* TODO: 2015/12/31 As for type safetyness all those constant must be declared as enum!
+ * C++ now supports typed enum so there is no ambiguity in serialization size
+ */
 
 /* Trust Levels. Should be the same values than what is declared in PGPHandler.h */
 
@@ -216,7 +220,7 @@ class RsPeerDetails
 	RsPgpId issuer;
 
 	PGPFingerprintType fpr; /* pgp fingerprint */
-	std::string authcode; 	// (cyril) what is this used for ?????
+	std::string authcode; 	// TODO: 2015/12/31 (cyril) what is this used for ?????
 	std::list<RsPgpId> gpgSigners;
 
 	uint32_t trustLvl;
@@ -231,58 +235,59 @@ class RsPeerDetails
     ServicePermissionFlags service_perm_flags ;
 
     /* Network details (only valid if friend) */
-	uint32_t	state;
-	bool		actAsServer;
+	uint32_t state;
+	bool actAsServer;
 
-	std::string				connectAddr ; // current address if connected.
-	uint16_t				connectPort ;
+	// TODO: 2015/12/31 to take advantage of multiple connection this must be
+	// replaced by a set of addresses
+	std::string connectAddr ; // current address if connected.
+	uint16_t connectPort ;
 
 	// Hidden Node details.
-	bool 			isHiddenNode;
-	std::string		hiddenNodeAddress;
-	uint16_t		hiddenNodePort;
-	uint32_t        hiddenType;
+	bool isHiddenNode;
+	std::string hiddenNodeAddress;
+	uint16_t hiddenNodePort;
+	uint32_t hiddenType;
 
 	// Filled in for Standard Node.
-	std::string             localAddr;
-	uint16_t                localPort;
-	std::string             extAddr;
-	uint16_t                extPort;
-	std::string             dyndns;
-	std::list<std::string>  ipAddressList;
+	std::string localAddr;
+	uint16_t localPort;
+	std::string extAddr;
+	uint16_t extPort;
+	std::string dyndns;
+	std::list<std::string> ipAddressList;
 
-	uint32_t		netMode;
+	uint32_t netMode;
 	/* vis State */
-	uint16_t		vs_disc;
-	uint16_t		vs_dht;
+	uint16_t vs_disc;
+	uint16_t vs_dht;
 
 	/* basic stats */
-	uint32_t		lastConnect;           /* how long ago */
-	uint32_t		lastUsed;              /* how long ago since last used: signature verif, connect attempt, etc */
-	uint32_t		connectState;          /* RS_PEER_CONNECTSTATE_... */
-	std::string		connectStateString; /* Additional string like ip address */
-	uint32_t		connectPeriod;
-	bool			foundDHT;
+	uint32_t lastConnect;           /* how long ago */
+	uint32_t lastUsed;              /* how long ago since last used: signature verif, connect attempt, etc */
+	uint32_t connectState;          /* RS_PEER_CONNECTSTATE_... */
+	std::string connectStateString; /* Additional string like ip address */
+	uint32_t connectPeriod;
+	bool foundDHT;
 
 	/* have we been denied */
-	bool			wasDeniedConnection;
-	time_t			deniedTS;
+	bool wasDeniedConnection;
+	time_t deniedTS;
 
 	/* linkType */
-	uint32_t		linkType;
+	uint32_t linkType;
 };
 
 // This class is used to get info about crytographic algorithms used with a
 // particular peer.
-//
 class RsPeerCryptoParams
 {
-	public:
-		int         connexion_state ;
-		std::string cipher_name ; 
-		int         cipher_bits_1 ; 
-		int         cipher_bits_2 ; 
-		std::string cipher_version ; 
+public:
+	int connexion_state;
+	std::string cipher_name;
+	int cipher_bits_1;
+	int cipher_bits_2;
+	std::string cipher_version;
 };
 
 class RsGroupInfo
@@ -292,131 +297,137 @@ public:
 
 	std::string id;
 	std::string name;
-	uint32_t    flag;
+	uint32_t flag;
 
-    std::set<RsPgpId> peerIds;
+	std::set<RsPgpId> peerIds;
 };
 
 std::ostream &operator<<(std::ostream &out, const RsPeerDetails &detail);
 
+/* TODO: 2015/12/31 this class seems foundamental for RetroShare code
+ * understanding must document it as soon as possible
+ */
 class RsPeers 
 {
-	public:
+public:
 
-		RsPeers()  { return; }
-		virtual ~RsPeers() { return; }
+	RsPeers() {}
+	virtual ~RsPeers() {}
 
-		/* Updates ... */
-        // not implemented
-        //virtual bool FriendsChanged() 					= 0;
-        //virtual bool OthersChanged() 					= 0;
+	// TODO: 2015/12/31 is this dead code?
+	/* Updates ... */
+	// not implemented
+	//virtual bool FriendsChanged() 					= 0;
+	//virtual bool OthersChanged() 					= 0;
 
-		/* Peer Details (Net & Auth) */
-		virtual const RsPeerId& getOwnId()					= 0;
+	/* Peer Details (Net & Auth) */
+	virtual const RsPeerId& getOwnId() = 0;
 
-		virtual bool   haveSecretKey(const RsPgpId& gpg_id) = 0 ;
+	virtual bool haveSecretKey(const RsPgpId& gpg_id) = 0 ;
 
-		virtual bool	getOnlineList(std::list<RsPeerId> &ssl_ids)	= 0;
-		virtual bool	getFriendList(std::list<RsPeerId> &ssl_ids)	= 0;
-		virtual bool    getPeerCount (unsigned int *pnFriendCount, unsigned int *pnnOnlineCount, bool ssl) = 0;
+	virtual bool getOnlineList(std::list<RsPeerId> &ssl_ids) = 0;
+	virtual bool getFriendList(std::list<RsPeerId> &ssl_ids) = 0;
+	virtual bool getPeerCount (unsigned int *pnFriendCount, unsigned int *pnnOnlineCount, bool ssl) = 0;
 
-		virtual bool    isOnline(const RsPeerId &ssl_id)			= 0;
-		virtual bool    isFriend(const RsPeerId &ssl_id)			= 0;
-		virtual bool    isGPGAccepted(const RsPgpId &gpg_id_is_friend)			= 0; //
-		virtual std::string getPeerName(const RsPeerId &ssl_id)			= 0;
-		virtual std::string getGPGName(const RsPgpId& gpg_id)	= 0;
-		virtual bool	 getPeerDetails(const RsPeerId& ssl_id, RsPeerDetails &d) = 0; 
-		virtual bool	 getGPGDetails(const RsPgpId& gpg_id, RsPeerDetails &d) = 0;
+	virtual bool isOnline(const RsPeerId &ssl_id) = 0;
+	virtual bool isFriend(const RsPeerId &ssl_id) = 0;
+	virtual bool isGPGAccepted(const RsPgpId &gpg_id_is_friend) = 0;
+	virtual std::string getPeerName(const RsPeerId &ssl_id) = 0;
+	virtual std::string getGPGName(const RsPgpId& gpg_id) = 0;
+	virtual bool getPeerDetails(const RsPeerId& ssl_id, RsPeerDetails &d) = 0;
+	virtual bool getGPGDetails(const RsPgpId& gpg_id, RsPeerDetails &d) = 0;
 
-		/* Using PGP Ids */
-		virtual const RsPgpId& getGPGOwnId()				= 0;
-		virtual RsPgpId getGPGId(const RsPeerId& sslid)	= 0; //return the gpg id of the given ssl id
-		virtual bool    isKeySupported(const RsPgpId& gpg_ids)   = 0;
-		virtual bool    getGPGAcceptedList(std::list<RsPgpId> &gpg_ids)   = 0;
-		virtual bool    getGPGSignedList(std::list<RsPgpId> &gpg_ids)   = 0;//friends that we accpet to connect with but we don't want to sign their gpg key
-		virtual bool    getGPGValidList(std::list<RsPgpId> &gpg_ids)   = 0;
-		virtual bool    getGPGAllList(std::list<RsPgpId> &gpg_ids) 	= 0;
-        virtual bool    getAssociatedSSLIds(const RsPgpId& gpg_id, std::list<RsPeerId>& ids) = 0;
-        virtual bool    gpgSignData(const void *data, const uint32_t len, unsigned char *sign, unsigned int *signlen) = 0;
+	/* Using PGP Ids */
+	virtual const RsPgpId& getGPGOwnId() = 0;
+	virtual RsPgpId getGPGId(const RsPeerId& sslid)	= 0; //return the gpg id of the given ssl id
+	virtual bool isKeySupported(const RsPgpId& gpg_ids) = 0;
+	virtual bool getGPGAcceptedList(std::list<RsPgpId> &gpg_ids) = 0;
+	virtual bool getGPGSignedList(std::list<RsPgpId> &gpg_ids) = 0;//friends that we accpet to connect with but we don't want to sign their gpg key
+	virtual bool getGPGValidList(std::list<RsPgpId> &gpg_ids) = 0;
+	virtual bool getGPGAllList(std::list<RsPgpId> &gpg_ids) = 0;
+	virtual bool getAssociatedSSLIds(const RsPgpId& gpg_id, std::list<RsPeerId>& ids) = 0;
+	virtual bool gpgSignData(const void *data, const uint32_t len, unsigned char *sign, unsigned int *signlen) = 0;
 
-		/* Add/Remove Friends */
-        virtual	bool addFriend(const RsPeerId &ssl_id, const RsPgpId &gpg_id,ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT)    = 0;
-		virtual	bool removeFriend(const RsPgpId& pgp_id)  			= 0;
-		virtual bool removeFriendLocation(const RsPeerId& sslId) 			= 0;
+	/* Add/Remove Friends */
+	virtual	bool addFriend(const RsPeerId &ssl_id, const RsPgpId &gpg_id,ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT) = 0;
+	virtual	bool removeFriend(const RsPgpId& pgp_id) = 0;
+	virtual bool removeFriendLocation(const RsPeerId& sslId) = 0;
 
-		/* keyring management */
-        virtual bool removeKeysFromPGPKeyring(const std::set<RsPgpId>& pgp_ids,std::string& backup_file,uint32_t& error_code)=0 ;
+	/* keyring management */
+	virtual bool removeKeysFromPGPKeyring(const std::set<RsPgpId>& pgp_ids,std::string& backup_file,uint32_t& error_code) = 0;
 
-		/* Network Stuff */
-		virtual	bool connectAttempt(const RsPeerId& ssl_id)			= 0;
-		virtual bool setLocation(const RsPeerId &ssl_id, const std::string &location) = 0;//location is shown in the gui to differentiate ssl certs
+	/* Network Stuff */
+	virtual	bool connectAttempt(const RsPeerId& ssl_id) = 0;
+	virtual bool setLocation(const RsPeerId &ssl_id, const std::string &location) = 0; // location is shown in the gui to differentiate ssl certs
 
-		virtual bool setHiddenNode(const RsPeerId &id, const std::string &hidden_node_address) = 0;
-		virtual bool setHiddenNode(const RsPeerId &id, const std::string &address, uint16_t port) = 0;
+	virtual bool setHiddenNode(const RsPeerId &id, const std::string &hidden_node_address) = 0;
+	virtual bool setHiddenNode(const RsPeerId &id, const std::string &address, uint16_t port) = 0;
 
-		virtual	bool setLocalAddress(const RsPeerId &ssl_id, const std::string &addr, uint16_t port) = 0;
-		virtual	bool setExtAddress(  const RsPeerId &ssl_id, const std::string &addr, uint16_t port) = 0;
-		virtual	bool setDynDNS(const RsPeerId &id, const std::string &addr) = 0;
-		virtual	bool setNetworkMode(const RsPeerId &ssl_id, uint32_t netMode) 	= 0;
-		virtual bool setVisState(const RsPeerId &ssl_id, uint16_t vs_disc, uint16_t vs_dht)	= 0;
+	virtual	bool setLocalAddress(const RsPeerId &ssl_id, const std::string &addr, uint16_t port) = 0;
+	virtual	bool setExtAddress(  const RsPeerId &ssl_id, const std::string &addr, uint16_t port) = 0;
+	virtual	bool setDynDNS(const RsPeerId &id, const std::string &addr) = 0;
+	virtual	bool setNetworkMode(const RsPeerId &ssl_id, uint32_t netMode) = 0;
+	virtual bool setVisState(const RsPeerId &ssl_id, uint16_t vs_disc, uint16_t vs_dht)	= 0;
 
-		virtual bool getProxyServer(const uint32_t type, std::string &addr, uint16_t &port,uint32_t& status_flags) = 0;
-		virtual bool setProxyServer(const uint32_t type, const std::string &addr, const uint16_t port) = 0;
+	virtual bool getProxyServer(const uint32_t type, std::string &addr, uint16_t &port,uint32_t& status_flags) = 0;
+	virtual bool setProxyServer(const uint32_t type, const std::string &addr, const uint16_t port) = 0;
 
-		virtual void getIPServersList(std::list<std::string>& ip_servers) = 0;
-		virtual void allowServerIPDetermination(bool) = 0;
-        virtual bool resetOwnExternalAddressList() = 0;
-        virtual bool getAllowServerIPDetermination() = 0 ;
+	virtual void getIPServersList(std::list<std::string>& ip_servers) = 0;
+	virtual void allowServerIPDetermination(bool) = 0;
+	virtual bool resetOwnExternalAddressList() = 0;
+	virtual bool getAllowServerIPDetermination() = 0 ;
 
-		/* Auth Stuff */
-		virtual	std::string GetRetroshareInvite(const RsPeerId& ssl_id,bool include_signatures) 			= 0;
-		virtual	std::string getPGPKey(const RsPgpId& pgp_id,bool include_signatures) 			= 0;
-		virtual bool GetPGPBase64StringAndCheckSum(const RsPgpId& gpg_id,std::string& gpg_base64_string,std::string& gpg_base64_checksum) = 0 ;
-		virtual	std::string GetRetroshareInvite(bool include_signatures) 			= 0;
-		virtual  bool hasExportMinimal() = 0 ;
+	/* Auth Stuff */
+	virtual	std::string GetRetroshareInvite(const RsPeerId& ssl_id,bool include_signatures) = 0;
+	virtual	std::string getPGPKey(const RsPgpId& pgp_id,bool include_signatures) = 0;
+	virtual bool GetPGPBase64StringAndCheckSum(const RsPgpId& gpg_id,std::string& gpg_base64_string,std::string& gpg_base64_checksum) = 0;
+	virtual	std::string GetRetroshareInvite(bool include_signatures) = 0;
+	virtual  bool hasExportMinimal() = 0;
 
-		// Add keys to the keyring
-		virtual	bool loadCertificateFromString(const std::string& cert, RsPeerId& ssl_id,RsPgpId& pgp_id, std::string& error_string)  = 0;
+	// Add keys to the keyring
+	virtual	bool loadCertificateFromString(const std::string& cert, RsPeerId& ssl_id,RsPgpId& pgp_id, std::string& error_string) = 0;
 
-		// Gets the GPG details, but does not add the key to the keyring.
-		virtual	bool loadDetailsFromStringCert(const std::string& certGPG, RsPeerDetails &pd,uint32_t& error_code) = 0;
+	// Gets the GPG details, but does not add the key to the keyring.
+	virtual	bool loadDetailsFromStringCert(const std::string& certGPG, RsPeerDetails &pd,uint32_t& error_code) = 0;
 
-		// Certificate utils
-		virtual	bool cleanCertificate(const std::string &certstr, std::string &cleanCert,int& error_code) = 0;
-		virtual	bool saveCertificateToFile(const RsPeerId& id, const std::string &fname)  = 0;
-		virtual	std::string saveCertificateToString(const RsPeerId &id)  	= 0;
+	// Certificate utils
+	virtual	bool cleanCertificate(const std::string &certstr, std::string &cleanCert,int& error_code) = 0;
+	virtual	bool saveCertificateToFile(const RsPeerId& id, const std::string &fname) = 0;
+	virtual	std::string saveCertificateToString(const RsPeerId &id) = 0;
 
-		virtual	bool signGPGCertificate(const RsPgpId &gpg_id)                   	= 0;
-		virtual	bool trustGPGCertificate(const RsPgpId &gpg_id, uint32_t trustlvl) 	= 0;
+	virtual	bool signGPGCertificate(const RsPgpId &gpg_id) = 0;
+	virtual	bool trustGPGCertificate(const RsPgpId &gpg_id, uint32_t trustlvl) = 0;
 
-		/* Group Stuff */
-		virtual bool    addGroup(RsGroupInfo &groupInfo) = 0;
-		virtual bool    editGroup(const std::string &groupId, RsGroupInfo &groupInfo) = 0;
-		virtual bool    removeGroup(const std::string &groupId) = 0;
-		virtual bool    getGroupInfo(const std::string &groupId, RsGroupInfo &groupInfo) = 0;
-		virtual bool    getGroupInfoList(std::list<RsGroupInfo> &groupInfoList) = 0;
-		// groupId == "" && assign == false -> remove from all groups
-		virtual bool    assignPeerToGroup(const std::string &groupId, const RsPgpId& peerId, bool assign) = 0;
-		virtual bool    assignPeersToGroup(const std::string &groupId, const std::list<RsPgpId> &peerIds, bool assign) = 0;
+	/* Group Stuff */
+	virtual bool addGroup(RsGroupInfo &groupInfo) = 0;
+	virtual bool editGroup(const std::string &groupId, RsGroupInfo &groupInfo) = 0;
+	virtual bool removeGroup(const std::string &groupId) = 0;
+	virtual bool getGroupInfo(const std::string &groupId, RsGroupInfo &groupInfo) = 0;
+	virtual bool getGroupInfoList(std::list<RsGroupInfo> &groupInfoList) = 0;
+	// groupId == "" && assign == false -> remove from all groups
+	virtual bool assignPeerToGroup(const std::string &groupId, const RsPgpId& peerId, bool assign) = 0;
+	virtual bool assignPeersToGroup(const std::string &groupId, const std::list<RsPgpId> &peerIds, bool assign) = 0;
 
-		/* Group sharing permission */
+	/* Group sharing permission */
 
-		// Given 
-		// 	- the peer id
-		// 	- the permission flags of a given hash, e.g. a combination of 
-		// 			RS_DIR_FLAGS_NETWORK_WIDE_OTHERS, RS_DIR_FLAGS_NETWORK_WIDE_GROUPS, RS_DIR_FLAGS_BROWSABLE_OTHERS and RS_DIR_FLAGS_BROWSABLE_GROUPS
-		// 	- the parent groups of the file
-		//
-		// ... computes the sharing file permission hint flags set for this peer, that is a combination of 
-		// 		RS_FILE_HINTS_NETWORK_WIDE and RS_FILE_HINTS_BROWSABLE.
-		//
-		virtual FileSearchFlags computePeerPermissionFlags(const RsPeerId& peer_id,FileStorageFlags file_sharing_flags,const std::list<std::string>& file_parent_groups) = 0;
+	// Given
+	// 	- the peer id
+	// 	- the permission flags of a given hash, e.g. a combination of
+	// 			RS_DIR_FLAGS_NETWORK_WIDE_OTHERS, RS_DIR_FLAGS_NETWORK_WIDE_GROUPS, RS_DIR_FLAGS_BROWSABLE_OTHERS and RS_DIR_FLAGS_BROWSABLE_GROUPS
+	// 	- the parent groups of the file
+	//
+	// ... computes the sharing file permission hint flags set for this peer, that is a combination of
+	// 		RS_FILE_HINTS_NETWORK_WIDE and RS_FILE_HINTS_BROWSABLE.
+	//
+	virtual FileSearchFlags computePeerPermissionFlags(
+			const RsPeerId& peer_id, FileStorageFlags file_sharing_flags,
+			const std::list<std::string>& file_parent_groups) = 0;
 
-        /* Service permission flags */
+	/* Service permission flags */
 
-        virtual ServicePermissionFlags servicePermissionFlags(const RsPgpId& gpg_id) = 0;
-        virtual ServicePermissionFlags servicePermissionFlags(const RsPeerId& ssl_id) = 0;
-        virtual void setServicePermissionFlags(const RsPgpId& gpg_id,const ServicePermissionFlags& flags) = 0;
+	virtual ServicePermissionFlags servicePermissionFlags(const RsPgpId& gpg_id) = 0;
+	virtual ServicePermissionFlags servicePermissionFlags(const RsPeerId& ssl_id) = 0;
+	virtual void setServicePermissionFlags(const RsPgpId& gpg_id,const ServicePermissionFlags& flags) = 0;
 };
 
 #endif

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -243,20 +243,18 @@ bool    p3Peers::isFriend(const RsPeerId &ssl_id)
 
 bool p3Peers::haveSecretKey(const RsPgpId& id)
 {
-	return AuthGPG::getAuthGPG()->haveSecretKey(id) ;
+	return AuthGPG::getAuthGPG()->haveSecretKey(id);
 }
 
 /* There are too many dependancies of this function
  * to shift it immeidately
  */
 
-bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
+bool p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 {
 #ifdef P3PEERS_DEBUG
 	std::cerr << "p3Peers::getPeerDetails() called for id : " << id << std::endl;
 #endif
-
-	// NOW Only for SSL Details.
 
 	RsPeerId sOwnId = AuthSSL::getAuthSSL()->OwnId();
 	peerState ps;
@@ -271,27 +269,11 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 #ifdef P3PEERS_DEBUG
 		std::cerr << "p3Peers::getPeerDetails() ERROR not an SSL Id: " << id << std::endl;
 #endif
-		return false ;
+		return false;
 	}
 
-//			bool res = getGPGDetails(id, d);
-//
-//			d.isOnlyGPGdetail = true;
-//
-//			if(id.length() == 16)
-//				d.service_perm_flags = mPeerMgr->servicePermissionFlags(id) ;
-//			else if(id.length() == 32)
-//				d.service_perm_flags = mPeerMgr->servicePermissionFlags(id) ;
-//			else
-//			{
-//				std::cerr << "p3Peers::getPeerDetails() ERROR not an correct Id: " << id << std::endl;
-//				d.service_perm_flags = RS_SERVICE_PERM_NONE ;
-//			}
-//
-//			return res ;
-
 	/* get from gpg (first), to fill in the sign and trust details */
-	/* don't retrun now, we've got fill in the ssl and connection info */
+	/* don't return now, we've got fill in the ssl and connection info */
 	getGPGDetails(ps.gpg_id, d);
 	d.isOnlyGPGdetail = false;
 
@@ -299,7 +281,7 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 	d.id 		= id;
 	d.location 	= ps.location;
 
-	d.service_perm_flags = mPeerMgr->servicePermissionFlags(ps.gpg_id) ;
+	d.service_perm_flags = mPeerMgr->servicePermissionFlags(ps.gpg_id);
 
 	/* generate */
 	d.authcode  	= "AUTHCODE";
@@ -327,10 +309,28 @@ bool	p3Peers::getPeerDetails(const RsPeerId& id, RsPeerDetails &d)
 		d.hiddenNodePort = 0;
 		d.hiddenType = RS_HIDDEN_TYPE_NONE;
 
-		d.localAddr	= sockaddr_storage_iptostring(ps.localaddr);
-		d.localPort	= sockaddr_storage_port(ps.localaddr);
-		d.extAddr	= sockaddr_storage_iptostring(ps.serveraddr);
-		d.extPort	= sockaddr_storage_port(ps.serveraddr);
+		if (sockaddr_storage_isnull(ps.localaddr))
+		{
+			d.localAddr	= "INVALID_IP";
+			d.localPort	= 0;
+		}
+		else
+		{
+			d.localAddr	= sockaddr_storage_iptostring(ps.localaddr);
+			d.localPort	= sockaddr_storage_port(ps.localaddr);
+		}
+
+		if (sockaddr_storage_isnull(ps.serveraddr))
+		{
+			d.extAddr = "INVALID_IP";
+			d.extPort = 0;
+		}
+		else
+		{
+			d.extAddr = sockaddr_storage_iptostring(ps.serveraddr);
+			d.extPort = sockaddr_storage_port(ps.serveraddr);
+		}
+
 		d.dyndns        = ps.dyndns;
 	
 		std::list<pqiIpAddress>::iterator it;

--- a/libretroshare/src/rsserver/p3peers.h
+++ b/libretroshare/src/rsserver/p3peers.h
@@ -35,118 +35,115 @@ struct sockaddr_storage;
 
 class p3Peers: public RsPeers 
 {
-	public:
+public:
 
-        p3Peers(p3LinkMgr *lm, p3PeerMgr *pm, p3NetMgr *nm);
-virtual ~p3Peers() { return; }
+	p3Peers(p3LinkMgr *lm, p3PeerMgr *pm, p3NetMgr *nm);
+	virtual ~p3Peers() {}
 
 	/* Updates ... */
-virtual bool FriendsChanged();
-virtual bool OthersChanged();
+	virtual bool FriendsChanged();
+	virtual bool OthersChanged();
 
 	/* Peer Details (Net & Auth) */
-virtual const RsPeerId& getOwnId();
+	virtual const RsPeerId& getOwnId();
 
-		virtual bool   haveSecretKey(const RsPgpId& gpg_id) ;
+	virtual bool haveSecretKey(const RsPgpId& gpg_id) ;
 
+	virtual bool getOnlineList(std::list<RsPeerId> &ids);
+	virtual bool getFriendList(std::list<RsPeerId> &ids);
+	virtual bool getPeerCount (unsigned int *friendCount, unsigned int *onlineCount, bool ssl);
 
-virtual bool	getOnlineList(std::list<RsPeerId> &ids);
-virtual bool	getFriendList(std::list<RsPeerId> &ids);
-//virtual bool	getOthersList(std::list<std::string> &ids);
-virtual bool    getPeerCount (unsigned int *friendCount, unsigned int *onlineCount, bool ssl);
+	virtual bool isOnline(const RsPeerId &id);
+	virtual bool isFriend(const RsPeerId &id);
+	virtual bool isGPGAccepted(const RsPgpId &gpg_id_is_friend);
+	virtual std::string getGPGName(const RsPgpId &gpg_id);
+	virtual std::string getPeerName(const RsPeerId& ssl_or_gpg_id);
+	virtual bool getPeerDetails(const RsPeerId& ssl_or_gpg_id, RsPeerDetails &d);
 
-virtual bool    isOnline(const RsPeerId &id);
-virtual bool    isFriend(const RsPeerId &id);
-virtual bool    isGPGAccepted(const RsPgpId &gpg_id_is_friend); //
-virtual std::string getGPGName(const RsPgpId &gpg_id);
-virtual std::string getPeerName(const RsPeerId& ssl_or_gpg_id);
-virtual bool	getPeerDetails(const RsPeerId& ssl_or_gpg_id, RsPeerDetails &d);
-
-                /* Using PGP Ids */
-virtual const RsPgpId& getGPGOwnId();
-virtual RsPgpId getGPGId(const RsPeerId &ssl_id);
-virtual bool    isKeySupported(const RsPgpId& ids);
-virtual bool    getGPGAcceptedList(std::list<RsPgpId> &ids);
-virtual bool    getGPGSignedList(std::list<RsPgpId> &ids);
-virtual bool    getGPGValidList(std::list<RsPgpId> &ids);
-virtual bool    getGPGAllList(std::list<RsPgpId> &ids);
-virtual bool	getGPGDetails(const RsPgpId &id, RsPeerDetails &d);
-virtual bool	getAssociatedSSLIds(const RsPgpId& gpg_id, std::list<RsPeerId> &ids);
-virtual bool    gpgSignData(const void *data, const uint32_t len, unsigned char *sign, unsigned int *signlen) ;
+	/* Using PGP Ids */
+	virtual const RsPgpId& getGPGOwnId();
+	virtual RsPgpId getGPGId(const RsPeerId &ssl_id);
+	virtual bool isKeySupported(const RsPgpId& ids);
+	virtual bool getGPGAcceptedList(std::list<RsPgpId> &ids);
+	virtual bool getGPGSignedList(std::list<RsPgpId> &ids);
+	virtual bool getGPGValidList(std::list<RsPgpId> &ids);
+	virtual bool getGPGAllList(std::list<RsPgpId> &ids);
+	virtual bool getGPGDetails(const RsPgpId &id, RsPeerDetails &d);
+	virtual bool getAssociatedSSLIds(const RsPgpId& gpg_id, std::list<RsPeerId> &ids);
+	virtual bool gpgSignData(const void *data, const uint32_t len, unsigned char *sign, unsigned int *signlen) ;
 
 	/* Add/Remove Friends */
-virtual	bool addFriend(const RsPeerId &ssl_id, const RsPgpId &gpg_id,ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT);
-virtual	bool removeFriend(const RsPgpId& gpgid);
-virtual bool removeFriendLocation(const RsPeerId& sslId);
+	virtual	bool addFriend(const RsPeerId &ssl_id, const RsPgpId &gpg_id,ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT);
+	virtual	bool removeFriend(const RsPgpId& gpgid);
+	virtual bool removeFriendLocation(const RsPeerId& sslId);
 
-		/* keyring management */
-        virtual bool removeKeysFromPGPKeyring(const std::set<RsPgpId> &pgp_ids,std::string& backup_file,uint32_t& error_code);
+	/* keyring management */
+	virtual bool removeKeysFromPGPKeyring(const std::set<RsPgpId> &pgp_ids,std::string& backup_file,uint32_t& error_code);
 
 	/* Network Stuff */
-virtual	bool connectAttempt(const RsPeerId &id);
-virtual bool setLocation(const RsPeerId &ssl_id, const std::string &location);//location is shown in the gui to differentiate ssl certs
-virtual bool setHiddenNode(const RsPeerId &id, const std::string &hidden_node_address);
-virtual bool setHiddenNode(const RsPeerId &id, const std::string &address, uint16_t port);
+	virtual	bool connectAttempt(const RsPeerId &id);
+	virtual bool setLocation(const RsPeerId &ssl_id, const std::string &location);//location is shown in the gui to differentiate ssl certs
+	virtual bool setHiddenNode(const RsPeerId &id, const std::string &hidden_node_address);
+	virtual bool setHiddenNode(const RsPeerId &id, const std::string &address, uint16_t port);
 
-virtual	bool setLocalAddress(const RsPeerId &id, const std::string &addr, uint16_t port);
-virtual	bool setExtAddress(const RsPeerId &id, const std::string &addr, uint16_t port);
-virtual	bool setDynDNS(const RsPeerId &id, const std::string &dyndns);
-virtual	bool setNetworkMode(const RsPeerId &id, uint32_t netMode);
-virtual bool setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_t vs_dht);
+	virtual	bool setLocalAddress(const RsPeerId &id, const std::string &addr, uint16_t port);
+	virtual	bool setExtAddress(const RsPeerId &id, const std::string &addr, uint16_t port);
+	virtual	bool setDynDNS(const RsPeerId &id, const std::string &dyndns);
+	virtual	bool setNetworkMode(const RsPeerId &id, uint32_t netMode);
+	virtual bool setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_t vs_dht);
 
-virtual bool getProxyServer(const uint32_t type, std::string &addr, uint16_t &port,uint32_t& status);
-virtual bool setProxyServer(const uint32_t type,const std::string &addr, const uint16_t port);
-virtual bool isProxyAddress(const uint32_t type,const sockaddr_storage&);
+	virtual bool getProxyServer(const uint32_t type, std::string &addr, uint16_t &port,uint32_t& status);
+	virtual bool setProxyServer(const uint32_t type, const std::string &addr, const uint16_t port);
+	virtual bool isProxyAddress(const uint32_t type, const sockaddr_storage &addr);
 
-virtual void getIPServersList(std::list<std::string>& ip_servers) ;
-virtual void allowServerIPDetermination(bool) ;
-virtual bool getAllowServerIPDetermination() ;
-    virtual bool resetOwnExternalAddressList() ;
+	virtual void getIPServersList(std::list<std::string>& ip_servers);
+	virtual void allowServerIPDetermination(bool);
+	virtual bool getAllowServerIPDetermination();
+	virtual bool resetOwnExternalAddressList();
 
 	/* Auth Stuff */
-// Get the invitation (GPG cert + local/ext address + SSL id for the given peer)
-virtual	std::string GetRetroshareInvite(const RsPeerId& ssl_id,bool include_signatures);
-virtual	std::string getPGPKey(const RsPgpId& pgp_id,bool include_signatures) ;
+	// Get the invitation (GPG cert + local/ext address + SSL id for the given peer)
+	virtual	std::string GetRetroshareInvite(const RsPeerId& ssl_id,bool include_signatures);
+	virtual	std::string getPGPKey(const RsPgpId& pgp_id,bool include_signatures) ;
 
-// same but for own id
-virtual	std::string GetRetroshareInvite(bool include_signatures);
-virtual bool GetPGPBase64StringAndCheckSum(const RsPgpId& gpg_id,std::string& gpg_base64_string,std::string& gpg_base64_checksum) ;
+	// same but for own id
+	virtual	std::string GetRetroshareInvite(bool include_signatures);
+	virtual bool GetPGPBase64StringAndCheckSum(const RsPgpId& gpg_id,std::string& gpg_base64_string,std::string& gpg_base64_checksum);
 
-virtual bool hasExportMinimal() ;
+	virtual bool hasExportMinimal();
 
-virtual	bool loadCertificateFromString(const std::string& cert, RsPeerId& ssl_id,RsPgpId& pgp_id, std::string& error_string);
-virtual	bool loadDetailsFromStringCert(const std::string &cert, RsPeerDetails &pd, uint32_t& error_code);
+	virtual	bool loadCertificateFromString(const std::string& cert, RsPeerId& ssl_id,RsPgpId& pgp_id, std::string& error_string);
+	virtual	bool loadDetailsFromStringCert(const std::string &cert, RsPeerDetails &pd, uint32_t& error_code);
 
-virtual	bool cleanCertificate(const std::string &certstr, std::string &cleanCert,int& error_code);
-virtual	bool saveCertificateToFile(const RsPeerId &id, const std::string &fname);
-virtual	std::string saveCertificateToString(const RsPeerId &id);
+	virtual	bool cleanCertificate(const std::string &certstr, std::string &cleanCert,int& error_code);
+	virtual	bool saveCertificateToFile(const RsPeerId &id, const std::string &fname);
+	virtual	std::string saveCertificateToString(const RsPeerId &id);
 
-virtual	bool signGPGCertificate(const RsPgpId &id);
-virtual	bool trustGPGCertificate(const RsPgpId &id, uint32_t trustlvl);
+	virtual	bool signGPGCertificate(const RsPgpId &id);
+	virtual	bool trustGPGCertificate(const RsPgpId &id, uint32_t trustlvl);
 
 	/* Group Stuff */
-virtual bool addGroup(RsGroupInfo &groupInfo);
-virtual bool editGroup(const std::string &groupId, RsGroupInfo &groupInfo);
-virtual bool removeGroup(const std::string &groupId);
-virtual bool getGroupInfo(const std::string &groupId, RsGroupInfo &groupInfo);
-virtual bool getGroupInfoList(std::list<RsGroupInfo> &groupInfoList);
-virtual bool assignPeerToGroup(const std::string &groupId, const RsPgpId &peerId, bool assign);
-virtual bool assignPeersToGroup(const std::string &groupId, const std::list<RsPgpId>& peerIds, bool assign);
+	virtual bool addGroup(RsGroupInfo &groupInfo);
+	virtual bool editGroup(const std::string &groupId, RsGroupInfo &groupInfo);
+	virtual bool removeGroup(const std::string &groupId);
+	virtual bool getGroupInfo(const std::string &groupId, RsGroupInfo &groupInfo);
+	virtual bool getGroupInfoList(std::list<RsGroupInfo> &groupInfoList);
+	virtual bool assignPeerToGroup(const std::string &groupId, const RsPgpId &peerId, bool assign);
+	virtual bool assignPeersToGroup(const std::string &groupId, const std::list<RsPgpId>& peerIds, bool assign);
 
-virtual FileSearchFlags computePeerPermissionFlags(const RsPeerId& peer_id,FileStorageFlags share_flags,const std::list<std::string>& parent_groups) ;
+	virtual FileSearchFlags computePeerPermissionFlags(const RsPeerId& peer_id,FileStorageFlags share_flags,const std::list<std::string>& parent_groups);
 
-// service permission stuff
+	// service permission stuff
 
-	virtual ServicePermissionFlags servicePermissionFlags(const RsPgpId& gpg_id) ;
-	virtual ServicePermissionFlags servicePermissionFlags(const RsPeerId & ssl_id) ;
-	virtual void setServicePermissionFlags(const RsPgpId& gpg_id,const ServicePermissionFlags& flags) ;
+	virtual ServicePermissionFlags servicePermissionFlags(const RsPgpId& gpg_id);
+	virtual ServicePermissionFlags servicePermissionFlags(const RsPeerId & ssl_id);
+	virtual void setServicePermissionFlags(const RsPgpId& gpg_id,const ServicePermissionFlags& flags);
 
-	private:
+private:
 
 	p3LinkMgr *mLinkMgr;
 	p3PeerMgr *mPeerMgr;
 	p3NetMgr *mNetMgr;
-	
 };
 
 #endif

--- a/libretroshare/src/util/rsnet_ss.cc
+++ b/libretroshare/src/util/rsnet_ss.cc
@@ -29,6 +29,7 @@
 #include "util/rsnet.h"
 #include "util/rsstring.h"
 #include "pqi/pqinetwork.h"
+#include "util/stacktrace.h"
 
 /***************************** Internal Helper Fns ******************************/
 
@@ -186,13 +187,12 @@ uint16_t sockaddr_storage_port(const struct sockaddr_storage &addr)
 	{
 		case AF_INET:
 			return sockaddr_storage_ipv4_port(addr);
-			break;
 		case AF_INET6:
 			return sockaddr_storage_ipv6_port(addr);
-			break;
 		default:
 			std::cerr << "sockaddr_storage_port() invalid addr.ss_family" << std::endl;
 			sockaddr_storage_dump(addr);
+			print_stacktrace();
 			break;
 	}
 	return 0;
@@ -508,22 +508,19 @@ bool sockaddr_storage_isnull(const struct sockaddr_storage &addr)
 bool sockaddr_storage_isValidNet(const struct sockaddr_storage &addr)
 {
 #ifdef SS_DEBUG
-	std::cerr << "sockaddr_storage_isValidNet()";
-	std::cerr << std::endl;
+	std::cerr << "sockaddr_storage_isValidNet()" << std::endl;
 #endif
 
 	switch(addr.ss_family)
 	{
 		case AF_INET:
 			return sockaddr_storage_ipv4_isValidNet(addr);
-			break;
 		case AF_INET6:
 			return sockaddr_storage_ipv6_isValidNet(addr);
-			break;
 		default:
 #ifdef SS_DEBUG
-            std::cerr << "sockaddr_storage_isValidNet() INVALID Family - error: " << sockaddr_storage_iptostring(addr);
-            std::cerr << std::endl;
+			std::cerr << "sockaddr_storage_isValidNet() INVALID Family" << std::endl;
+			sockaddr_storage_dump(addr);
 #endif
 			break;
 	}

--- a/libretroshare/src/util/stacktrace.h
+++ b/libretroshare/src/util/stacktrace.h
@@ -1,0 +1,93 @@
+// stacktrace.h (c) 2008, Timo Bingmann from http://idlebox.net/
+// published under the WTFPL v2.0
+
+#ifndef _STACKTRACE_H_
+#define _STACKTRACE_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <execinfo.h>
+#include <cxxabi.h>
+
+/** Print a demangled stack backtrace of the caller function to FILE* out. */
+static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
+{
+    fprintf(out, "stack trace:\n");
+
+    // storage array for stack trace address data
+    void* addrlist[max_frames+1];
+
+    // retrieve current stack addresses
+    int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
+
+    if (addrlen == 0) {
+	fprintf(out, "  <empty, possibly corrupt>\n");
+	return;
+    }
+
+    // resolve addresses into strings containing "filename(function+address)",
+    // this array must be free()-ed
+    char** symbollist = backtrace_symbols(addrlist, addrlen);
+
+    // allocate string which will be filled with the demangled function name
+    size_t funcnamesize = 256;
+    char* funcname = (char*)malloc(funcnamesize);
+
+    // iterate over the returned symbol lines. skip the first, it is the
+    // address of this function.
+    for (int i = 1; i < addrlen; i++)
+    {
+	char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
+
+	// find parentheses and +address offset surrounding the mangled name:
+	// ./module(function+0x15c) [0x8048a6d]
+	for (char *p = symbollist[i]; *p; ++p)
+	{
+	    if (*p == '(')
+		begin_name = p;
+	    else if (*p == '+')
+		begin_offset = p;
+	    else if (*p == ')' && begin_offset) {
+		end_offset = p;
+		break;
+	    }
+	}
+
+	if (begin_name && begin_offset && end_offset
+	    && begin_name < begin_offset)
+	{
+	    *begin_name++ = '\0';
+	    *begin_offset++ = '\0';
+	    *end_offset = '\0';
+
+	    // mangled name is now in [begin_name, begin_offset) and caller
+	    // offset in [begin_offset, end_offset). now apply
+	    // __cxa_demangle():
+
+	    int status;
+	    char* ret = abi::__cxa_demangle(begin_name,
+					    funcname, &funcnamesize, &status);
+	    if (status == 0) {
+		funcname = ret; // use possibly realloc()-ed string
+		fprintf(out, "  %s : %s+%s\n",
+			symbollist[i], funcname, begin_offset);
+	    }
+	    else {
+		// demangling failed. Output function name as a C function with
+		// no arguments.
+		fprintf(out, "  %s : %s()+%s\n",
+			symbollist[i], begin_name, begin_offset);
+	    }
+	}
+	else
+	{
+	    // couldn't parse the line? print the whole line.
+	    fprintf(out, "  %s\n", symbollist[i]);
+	}
+    }
+
+    free(funcname);
+    free(symbollist);
+}
+
+#endif // _STACKTRACE_H_


### PR DESCRIPTION
This avoid on relying on low level function to report problems and catch them in the right place, debug output is not flooded anymore
