### PR TITLE
p3ServiceControl: Optimize checkFilter(...), solve memory leak removi…

### DIFF
--- a/libretroshare/src/pqi/p3servicecontrol.cc
+++ b/libretroshare/src/pqi/p3servicecontrol.cc
@@ -3,7 +3,7 @@
  *
  * 3P/PQI network interface for RetroShare.
  *
- * Copyright 2014 by Robert Fernie.
+ * Copyright (C) 2014 Robert Fernie
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -40,220 +40,211 @@ static const uint8_t RS_PKT_SUBTYPE_SERVICE_CONTROL_SERVICE_PERMISSIONS = 0x01 ;
 class RsServiceControlItem: public RsItem
 {
 public:
-    RsServiceControlItem(uint8_t item_subtype) : RsItem(RS_PKT_VERSION_SERVICE,RS_SERVICE_TYPE_SERVICE_CONTROL,item_subtype) {}
+	RsServiceControlItem(uint8_t item_subtype) : RsItem(RS_PKT_VERSION_SERVICE,RS_SERVICE_TYPE_SERVICE_CONTROL,item_subtype) {}
 
-    virtual uint32_t serial_size() const =0;
-    virtual bool serialise(uint8_t *data,uint32_t size) const =0;
+	virtual uint32_t serial_size() const =0;
+	virtual bool serialise(uint8_t *data,uint32_t size) const =0;
 
-        bool serialise_header(void *data,uint32_t& pktsize,uint32_t& tlvsize, uint32_t& offset) const
-        {
-            tlvsize = serial_size() ;
-            offset = 0;
+	bool serialise_header(void *data,uint32_t& pktsize,uint32_t& tlvsize, uint32_t& offset) const
+	{
+		tlvsize = serial_size();
+		offset = 0;
 
-            if (pktsize < tlvsize)
-                return false; /* not enough space */
+		if (pktsize < tlvsize) return false; // not enough space
 
-            pktsize = tlvsize;
+		pktsize = tlvsize;
 
-            if(!setRsItemHeader(data, tlvsize, PacketId(), tlvsize))
-            {
-                std::cerr << "RsFileTransferItem::serialise_header(): ERROR. Not enough size!" << std::endl;
-                return false ;
-            }
-        #ifdef RSSERIAL_DEBUG
-            std::cerr << "RsFileItemSerialiser::serialiseData() Header: " << ok << std::endl;
-        #endif
-            offset += 8;
+		if(!setRsItemHeader(data, tlvsize, PacketId(), tlvsize))
+		{
+			std::cerr << "RsFileTransferItem::serialise_header(): ERROR. Not enough size!" << std::endl;
+			return false;
+		}
+#ifdef RSSERIAL_DEBUG
+		std::cerr << "RsFileItemSerialiser::serialiseData() Header: " << ok << std::endl;
+#endif
+		offset += 8;
 
-            return true ;
-        }
+		return true ;
+	}
 };
+
 class RsServicePermissionItem: public RsServiceControlItem, public RsServicePermissions
 {
 public:
-    RsServicePermissionItem()
-            : RsServiceControlItem(RS_PKT_SUBTYPE_SERVICE_CONTROL_SERVICE_PERMISSIONS) {}
-    RsServicePermissionItem(const RsServicePermissions& perms)
-            : RsServiceControlItem(RS_PKT_SUBTYPE_SERVICE_CONTROL_SERVICE_PERMISSIONS),
-              RsServicePermissions(perms) {}
+	RsServicePermissionItem() :
+		RsServiceControlItem(RS_PKT_SUBTYPE_SERVICE_CONTROL_SERVICE_PERMISSIONS) {}
+	RsServicePermissionItem(const RsServicePermissions& perms) :
+		RsServiceControlItem(RS_PKT_SUBTYPE_SERVICE_CONTROL_SERVICE_PERMISSIONS),
+		RsServicePermissions(perms) {}
 
-    virtual uint32_t serial_size() const
-    {
-        uint32_t s = 8 ; // header
+	virtual uint32_t serial_size() const
+	{
+		uint32_t s = 8 ; // header
 
-        s += 4 ; // mServiceId
-        s += GetTlvStringSize(mServiceName) ;
-        s += 1 ; // mDefaultAllowed
-        s += 4 ; // mPeersAllowed.size()
-        s += mPeersAllowed.size() * RsPeerId::serial_size() ;
-        s += 4 ; // mPeersAllowed.size()
-        s += mPeersDenied.size() * RsPeerId::serial_size() ;
+		s += 4 ; // mServiceId
+		s += GetTlvStringSize(mServiceName) ;
+		s += 1 ; // mDefaultAllowed
+		s += 4 ; // mPeersAllowed.size()
+		s += mPeersAllowed.size() * RsPeerId::serial_size() ;
+		s += 4 ; // mPeersAllowed.size()
+		s += mPeersDenied.size() * RsPeerId::serial_size() ;
 
-    return s ;
-    }
-    virtual bool serialise(uint8_t *data,uint32_t size) const
-    {
-        uint32_t tlvsize,offset=0;
-        bool ok = true;
+		return s ;
+	}
 
-        if(!serialise_header(data,size,tlvsize,offset))
-            return false ;
+	virtual bool serialise(uint8_t *data,uint32_t size) const
+	{
+		uint32_t tlvsize,offset=0;
+		bool ok = true;
 
-        /* add mandatory parts first */
-        ok &= setRawUInt32(data, tlvsize, &offset, mServiceId);
-        ok &= SetTlvString(data, tlvsize, &offset, TLV_TYPE_STR_NAME, mServiceName);
-        ok &= setRawUInt8(data, tlvsize, &offset, mDefaultAllowed);
-        ok &= setRawUInt32(data, tlvsize, &offset, mPeersAllowed.size());
+		if(!serialise_header(data,size,tlvsize,offset))
+			return false ;
 
-        for(std::set<RsPeerId>::const_iterator it(mPeersAllowed.begin());it!=mPeersAllowed.end();++it)
-            (*it).serialise(data,tlvsize,offset) ;
+		/* add mandatory parts first */
+		ok &= setRawUInt32(data, tlvsize, &offset, mServiceId);
+		ok &= SetTlvString(data, tlvsize, &offset, TLV_TYPE_STR_NAME, mServiceName);
+		ok &= setRawUInt8(data, tlvsize, &offset, mDefaultAllowed);
+		ok &= setRawUInt32(data, tlvsize, &offset, mPeersAllowed.size());
 
-        ok &= setRawUInt32(data, tlvsize, &offset, mPeersDenied.size());
+		for(std::set<RsPeerId>::const_iterator it(mPeersAllowed.begin());it!=mPeersAllowed.end();++it)
+			(*it).serialise(data,tlvsize,offset);
 
-        for(std::set<RsPeerId>::const_iterator it(mPeersDenied.begin());it!=mPeersDenied.end();++it)
-            (*it).serialise(data,tlvsize,offset) ;
+		ok &= setRawUInt32(data, tlvsize, &offset, mPeersDenied.size());
 
-        if(offset != tlvsize)
-        {
-            std::cerr << "RsGxsChannelSerialiser::serialiseGxsChannelGroupItem() FAIL Size Error! " << std::endl;
-            ok = false;
-        }
+		for(std::set<RsPeerId>::const_iterator it(mPeersDenied.begin());it!=mPeersDenied.end();++it)
+			(*it).serialise(data,tlvsize,offset) ;
 
-        if (!ok)
-            std::cerr << "RsGxsChannelSerialiser::serialiseGxsChannelGroupItem() NOK" << std::endl;
+		if(offset != tlvsize)
+		{
+			std::cerr << "RsGxsChannelSerialiser::serialiseGxsChannelGroupItem() FAIL Size Error! " << std::endl;
+			ok = false;
+		}
 
-        return ok;
-    }
+		if (!ok)
+			std::cerr << "RsGxsChannelSerialiser::serialiseGxsChannelGroupItem() NOK" << std::endl;
 
-    static RsServicePermissionItem *deserialise(uint8_t *data,uint32_t size)
-    {
-        RsServicePermissionItem *item = new RsServicePermissionItem ;
+		return ok;
+	}
 
-        uint32_t offset = 8; // skip the header
-        uint32_t rssize = getRsItemSize(data);
-        bool ok = true ;
+	static RsServicePermissionItem *deserialise(uint8_t *data,uint32_t /*size*/)
+	{
+		RsServicePermissionItem *item = new RsServicePermissionItem ;
 
-        /* add mandatory parts first */
-        ok &= getRawUInt32(data, rssize, &offset, &item->mServiceId);
-        ok &= GetTlvString(data, rssize, &offset, TLV_TYPE_STR_NAME, item->mServiceName);
+		uint32_t offset = 8; // skip the header
+		uint32_t rssize = getRsItemSize(data);
+		bool ok = true ;
 
-    uint8_t v ;
-        ok &= getRawUInt8(data, rssize, &offset, &v) ;
+		/* add mandatory parts first */
+		ok &= getRawUInt32(data, rssize, &offset, &item->mServiceId);
+		ok &= GetTlvString(data, rssize, &offset, TLV_TYPE_STR_NAME, item->mServiceName);
 
-    if(v != 0 && v != 1)
-        ok = false ;
-    else
-        item->mDefaultAllowed = (bool)v;
+		uint8_t v;
+		ok &= getRawUInt8(data, rssize, &offset, &v);
 
-        uint32_t tmp ;
-        ok &= getRawUInt32(data, rssize, &offset, &tmp);
+		if(v != 0 && v != 1) ok = false;
+		else item->mDefaultAllowed = (bool)v;
 
-        for(uint32_t i=0;i<tmp && offset < rssize;++i)
-        {
-            RsPeerId peer_id ;
-            ok &= peer_id.deserialise(data,rssize,offset) ;
-            item->mPeersAllowed.insert(peer_id) ;
-        }
+		uint32_t tmp;
+		ok &= getRawUInt32(data, rssize, &offset, &tmp);
 
-        ok &= getRawUInt32(data, rssize, &offset, &tmp);
+		for(uint32_t i=0;i<tmp && offset < rssize;++i)
+		{
+			RsPeerId peer_id;
+			ok &= peer_id.deserialise(data,rssize,offset);
+			item->mPeersAllowed.insert(peer_id);
+		}
 
-        for(uint32_t i=0;i<tmp && offset < rssize;++i)
-        {
-            RsPeerId peer_id ;
-            ok &= peer_id.deserialise(data,rssize,offset) ;
-            item->mPeersDenied.insert(peer_id) ;
-        }
-        if (offset != rssize || !ok)
-        {
-            std::cerr << __PRETTY_FUNCTION__ << ": error while deserialising! Item will be dropped." << std::endl;
-            delete(item);
-            return NULL ;
-        }
+		ok &= getRawUInt32(data, rssize, &offset, &tmp);
 
-        return item;
-    }
+		for(uint32_t i=0;i<tmp && offset < rssize;++i)
+		{
+			RsPeerId peer_id;
+			ok &= peer_id.deserialise(data,rssize,offset) ;
+			item->mPeersDenied.insert(peer_id) ;
+		}
+		if (offset != rssize || !ok)
+		{
+			std::cerr << __PRETTY_FUNCTION__ << ": error while deserialising! Item will be dropped." << std::endl;
+			delete(item);
+			return NULL ;
+		}
 
-    virtual void clear() {}
-    virtual std::ostream& print(std::ostream& out,uint16_t)
-    {
-        std::cerr << __PRETTY_FUNCTION__ << ": not implemented!" << std::endl;
-    return out ;
-    }
+		return item;
+	}
+
+	virtual void clear() {}
+	virtual std::ostream& print(std::ostream& out,uint16_t)
+	{
+		std::cerr << __PRETTY_FUNCTION__ << ": not implemented!" << std::endl;
+		return out ;
+	}
 };
 
 class ServiceControlSerialiser: public RsSerialType
 {
 public:
-    ServiceControlSerialiser() : RsSerialType(RS_PKT_VERSION_SERVICE, RS_SERVICE_TYPE_SERVICE_CONTROL) {}
+	ServiceControlSerialiser() :
+		RsSerialType(RS_PKT_VERSION_SERVICE, RS_SERVICE_TYPE_SERVICE_CONTROL) {}
 
-    virtual uint32_t size (RsItem *item)
-    {
-        RsServiceControlItem *scitem = dynamic_cast<RsServiceControlItem *>(item);
-        if (!scitem)
-        {
-            return 0;
-        }
-        return scitem->serial_size() ;
-    }
-    virtual bool serialise(RsItem *item, void *data, uint32_t *size)
-    {
-        RsServiceControlItem *scitem = dynamic_cast<RsServiceControlItem *>(item);
-        if (!scitem)
-        {
-            return false;
-        }
-        return scitem->serialise((uint8_t*)data,*size) ;
-    }
-    virtual RsItem *deserialise (void *data, uint32_t *size)
-    {
-                uint32_t rstype = getRsItemId(data);
+	virtual uint32_t size (RsItem *item)
+	{
+		RsServiceControlItem *scitem = dynamic_cast<RsServiceControlItem *>(item);
+		if (!scitem) return 0;
+		return scitem->serial_size();
+	}
 
-                if(RS_PKT_VERSION_SERVICE != getRsItemVersion(rstype) || RS_SERVICE_TYPE_SERVICE_CONTROL != getRsItemService(rstype))  { return NULL; /* wrong type */ }
+	virtual bool serialise(RsItem *item, void *data, uint32_t *size)
+	{
+		RsServiceControlItem *scitem = dynamic_cast<RsServiceControlItem *>(item);
+		if (!scitem) return false;
+		return scitem->serialise((uint8_t*)data,*size);
+	}
 
-                switch(getRsItemSubType(rstype))
-        {
-        case RS_PKT_SUBTYPE_SERVICE_CONTROL_SERVICE_PERMISSIONS:return RsServicePermissionItem::deserialise((uint8_t*)data, *size);
-        default:
-            return NULL ;
-        }
-    }
+	virtual RsItem *deserialise (void *data, uint32_t *size)
+	{
+		uint32_t rstype = getRsItemId(data);
+
+		if( RS_PKT_VERSION_SERVICE != getRsItemVersion(rstype) ||
+				RS_SERVICE_TYPE_SERVICE_CONTROL != getRsItemService(rstype))
+		{ return NULL; } // wrong type
+
+		switch(getRsItemSubType(rstype))
+		{
+		case RS_PKT_SUBTYPE_SERVICE_CONTROL_SERVICE_PERMISSIONS:
+			return RsServicePermissionItem::deserialise((uint8_t*)data, *size);
+		default:
+			return NULL;
+		}
+	}
 };
 
-RsServiceControl *rsServiceControl = NULL;
+	RsServiceControl *rsServiceControl = NULL;
 
-p3ServiceControl::p3ServiceControl(p3LinkMgr *linkMgr)
-    :RsServiceControl(), p3Config(),
-          mLinkMgr(linkMgr), mOwnPeerId(linkMgr->getOwnId()),
-	mCtrlMtx("p3ServiceControl"), mMonitorMtx("P3ServiceControl::Monitor")
-{
-    mSerialiser = new ServiceControlSerialiser ;
-}
+p3ServiceControl::p3ServiceControl(p3LinkMgr *linkMgr) :
+	RsServiceControl(), p3Config(), mLinkMgr(linkMgr),
+	mOwnPeerId(linkMgr->getOwnId()), mCtrlMtx("p3ServiceControl"),
+	mMonitorMtx("P3ServiceControl::Monitor") {}
 
 RsSerialiser *p3ServiceControl::setupSerialiser()
 {
-    RsSerialiser *serial = new RsSerialiser;
-    serial->addSerialType(new ServiceControlSerialiser) ;
+	RsSerialiser *serial = new RsSerialiser;
+	serial->addSerialType(new ServiceControlSerialiser);
 
-    return serial ;
+	return serial;
 }
 
-const 	RsPeerId& p3ServiceControl::getOwnId()
-{
-	return mOwnPeerId;
-}
-
+const RsPeerId& p3ServiceControl::getOwnId() { return mOwnPeerId; }
 
 /* Interface for Services */
 bool p3ServiceControl::registerService(const RsServiceInfo &info, bool defaultOn)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 	std::map<uint32_t, RsServiceInfo>::iterator it;
 	it = mOwnServices.find(info.mServiceType);
 	if (it != mOwnServices.end())
 	{
-		std::cerr << "p3ServiceControl::registerService() ERROR Duplicate Service ID";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::registerService() ERROR Duplicate Service ID" << std::endl;
 		return false;
 	}
 
@@ -261,10 +252,8 @@ bool p3ServiceControl::registerService(const RsServiceInfo &info, bool defaultOn
 	mOwnServices[info.mServiceType] = info;
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::registerService() Registered ServiceID: " << info.mServiceType;
-	std::cerr << std::endl;
-	std::cerr << "p3ServiceControl::registerService() ServiceName: " << info.mServiceName;
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::registerService() Registered ServiceID: " << info.mServiceType << std::endl
+			  << "p3ServiceControl::registerService() ServiceName: " << info.mServiceName << std::endl;
 #endif
 
 
@@ -278,20 +267,18 @@ bool p3ServiceControl::registerService(const RsServiceInfo &info, bool defaultOn
 
 bool p3ServiceControl::deregisterService(uint32_t serviceId)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 	std::map<uint32_t, RsServiceInfo>::iterator it;
 	it = mOwnServices.find(serviceId);
 	if (it == mOwnServices.end())
 	{
-		std::cerr << "p3ServiceControl::deregisterService() ERROR No matching Service ID";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::deregisterService() ERROR No matching Service ID" << std::endl;
 		return false;
 	}
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::deregisterService() Removed ServiceID: " << serviceId;
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::deregisterService() Removed ServiceID: " << serviceId << std::endl;
 #endif
 	mOwnServices.erase(it);
 	return true;
@@ -301,12 +288,11 @@ bool p3ServiceControl::deregisterService(uint32_t serviceId)
 /* Interface for Services */
 bool p3ServiceControl::registerServiceMonitor(pqiServiceMonitor *monitor, uint32_t serviceId)
 {
-	RsStackMutex stack(mMonitorMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mMonitorMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::registerServiceMonitor() for ServiceId: ";
-	std::cerr << serviceId;
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::registerServiceMonitor() for ServiceId: "
+			  << serviceId << std::endl;
 #endif
 
 	mMonitors.insert(std::make_pair(serviceId, monitor));
@@ -316,42 +302,33 @@ bool p3ServiceControl::registerServiceMonitor(pqiServiceMonitor *monitor, uint32
 
 bool p3ServiceControl::deregisterServiceMonitor(pqiServiceMonitor *monitor)
 {
-	RsStackMutex stack(mMonitorMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mMonitorMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::deregisterServiceMonitor()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::deregisterServiceMonitor()" << std::endl;
 #endif
 
 	std::multimap<uint32_t, pqiServiceMonitor *>::iterator it;
 	for(it = mMonitors.begin(); it != mMonitors.end(); )
 	{
-		if (it->second == monitor)
-		{
-			mMonitors.erase(it++);
-		}
-		else
-		{
-			++it;
-		}
+		if (it->second == monitor) mMonitors.erase(it++);
+		else ++it;
 	}
 	return true;
 }
 
-/* Interface to p3ServiceInfo */
+// Interface to p3ServiceInfo
 void p3ServiceControl::getServiceChanges(std::set<RsPeerId> &updateSet)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
+
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::getServiceChanges()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::getServiceChanges()" << std::endl;
 #endif
 
 	std::set<RsPeerId>::iterator it;
 	for (it = mUpdatedSet.begin(); it != mUpdatedSet.end(); ++it)
-	{
 		updateSet.insert(*it);
-	}
 
 	mUpdatedSet.clear();
 }
@@ -359,14 +336,13 @@ void p3ServiceControl::getServiceChanges(std::set<RsPeerId> &updateSet)
 
 bool p3ServiceControl::getOwnServices(RsPeerServiceInfo &info)
 {
+	RS_STACK_MUTEX(mCtrlMtx);
+
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::getOwnServices()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::getOwnServices()" << std::endl;
 #endif
 
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
-
-	info.mPeerId.clear() ;
+	info.mPeerId.clear();
 	info.mServiceList = mOwnServices;
 	return true;
 }
@@ -374,59 +350,48 @@ bool p3ServiceControl::getOwnServices(RsPeerServiceInfo &info)
 
 bool p3ServiceControl::getServicesAllowed(const RsPeerId &peerId, RsPeerServiceInfo &info)
 {
-#ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::getServicesAllowed(" << peerId.toStdString() << ")";
-	std::cerr << std::endl;
-#endif
+	RS_STACK_MUTEX(mCtrlMtx);
 
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+#ifdef SERVICECONTROL_DEBUG
+	std::cerr << "p3ServiceControl::getServicesAllowed(" << peerId.toStdString() << ")" << std::endl;
+#endif
 
 	info.mPeerId = peerId;
 
 	// For each registered Service.. check if peer has permissions.
 	std::map<uint32_t, RsServiceInfo>::iterator it;
 	for(it = mOwnServices.begin(); it != mOwnServices.end(); ++it)
-	{
 		if (peerHasPermissionForService_locked(peerId, it->first))
-		{
 			info.mServiceList[it->first] = it->second;
-		}
-	}
+
 	return true;
 }
 
 bool p3ServiceControl::peerHasPermissionForService_locked(const RsPeerId &peerId, uint32_t serviceId)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::peerHasPermissionForService_locked()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::peerHasPermissionForService_locked()" << std::endl;
 #endif
 
 	std::map<uint32_t, RsServicePermissions>::iterator it;
 	it = mServicePermissionMap.find(serviceId);
-	if (it == mServicePermissionMap.end())
-	{
-		return false;
-	}
+	if (it == mServicePermissionMap.end()) return false;
+
 	return it->second.peerHasPermission(peerId);
 }
 
 // This is used by both RsServiceControl and p3ServiceInfo.
 bool p3ServiceControl::getServicesProvided(const RsPeerId &peerId, RsPeerServiceInfo &info)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::getServicesProvided()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::getServicesProvided()" << std::endl;
 #endif
 
 	std::map<RsPeerId, RsPeerServiceInfo>::iterator it;
 	it = mServicesProvided.find(peerId);
-	if (it == mServicesProvided.end())
-	{
-		return false;
-	}
+	if (it == mServicesProvided.end()) return false;
 
 	info = it->second;
 	return true;
@@ -434,44 +399,41 @@ bool p3ServiceControl::getServicesProvided(const RsPeerId &peerId, RsPeerService
 
 bool p3ServiceControl::updateServicesProvided(const RsPeerId &peerId, const RsPeerServiceInfo &info)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updateServicesProvided() from: " << peerId.toStdString();
-	std::cerr << std::endl;
-	std::cerr << info;
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updateServicesProvided() from: "
+			  << peerId.toStdString() << std::endl << info << std::endl;
 #endif
 
 	mServicesProvided[peerId] = info;
-    updateFilterByPeer_locked(peerId);
+	updateFilterByPeer_locked(peerId);
 
-    IndicateConfigChanged() ;
-    return true;
+	IndicateConfigChanged() ;
+	return true;
 }
 
 /* External Interface to RsServiceControl */
 bool p3ServiceControl::getServicePermissions(uint32_t serviceId, RsServicePermissions &permissions)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::getServicePermissions()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::getServicePermissions()" << std::endl;
 #endif
 
 	std::map<uint32_t, RsServicePermissions>::iterator it;
 
 	it = mServicePermissionMap.find(serviceId);
-	if (it == mServicePermissionMap.end())
-	{
-		return false;
-	}
+	if (it == mServicePermissionMap.end()) return false;
+
 	permissions = it->second;
 	return true;
 }
 
-bool p3ServiceControl::createDefaultPermissions_locked(uint32_t serviceId, std::string serviceName, bool defaultOn)
+bool p3ServiceControl::createDefaultPermissions_locked(uint32_t serviceId,
+													   std::string serviceName,
+													   bool defaultOn)
 {
 	std::map<uint32_t, RsServicePermissions>::iterator it;
 	it = mServicePermissionMap.find(serviceId);
@@ -483,30 +445,28 @@ bool p3ServiceControl::createDefaultPermissions_locked(uint32_t serviceId, std::
 		perms.mDefaultAllowed = defaultOn;
 
 		mServicePermissionMap[serviceId] = perms;
-        IndicateConfigChanged() ;
-        return true;
+		IndicateConfigChanged();
+		return true;
 	}
 	return false;
 }
 
 
-bool p3ServiceControl::updateServicePermissions(uint32_t serviceId, const RsServicePermissions &permissions)
+bool p3ServiceControl::updateServicePermissions(uint32_t serviceId,
+												const RsServicePermissions &permissions)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updateServicePermissions()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updateServicePermissions()" << std::endl;
 #endif
 
 	std::map<uint32_t, RsServicePermissions>::iterator it;
 	it = mServicePermissionMap.find(serviceId);
 	if (it == mServicePermissionMap.end())
 	{
-		std::cerr << "p3ServiceControl::updateServicePermissions()";
-		std::cerr << " ERROR missing previous permissions";
-		std::cerr << std::endl;
-		// ERROR.
+		std::cerr << "p3ServiceControl::updateServicePermissions()"
+				  << " ERROR missing previous permissions" << std::endl;
 		return false;
 	}
 
@@ -514,24 +474,18 @@ bool p3ServiceControl::updateServicePermissions(uint32_t serviceId, const RsServ
 	mLinkMgr->getOnlineList(onlinePeers);
 	std::list<RsPeerId>::const_iterator pit;
 	if (it != mServicePermissionMap.end())
-	{
 		for(pit = onlinePeers.begin(); pit != onlinePeers.end(); ++pit)
-		{
-			if (it->second.peerHasPermission(*pit) != 
-				permissions.peerHasPermission(*pit))
-			{
+			if (it->second.peerHasPermission(*pit) !=
+					permissions.peerHasPermission(*pit))
 				mUpdatedSet.insert(*pit);
-			}
-		}
-	}
 
- 	it->second = permissions;
+	it->second = permissions;
 	it->second.mServiceId = serviceId; // just to make sure!
 
 	// This is overkill - but will update everything.
 	updateAllFilters_locked();
-    IndicateConfigChanged() ;
-    return true;
+	IndicateConfigChanged() ;
+	return true;
 }
 
 
@@ -547,56 +501,38 @@ bool p3ServiceControl::updateServicePermissions(uint32_t serviceId, const RsServ
 // to the pqiStreamer, (when items have been sorted by peers already!).
 // but we will do this later.
 
-bool	p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId &peerId)
+bool p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId &peerId)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::checkFilter() ";
-	std::cerr << " ServiceId: " << serviceId;
-#endif
-
-	std::map<uint32_t, RsServiceInfo>::iterator it;
-	it = mOwnServices.find(serviceId);
+	std::cerr << "p3ServiceControl::checkFilter() "
+			  << " ServiceId: " << serviceId;
+	std::map<uint32_t, RsServiceInfo>::iterator it = mOwnServices.find(serviceId);
 	if (it != mOwnServices.end())
-	{
-#ifdef SERVICECONTROL_DEBUG
 		std::cerr << " ServiceName: " << it->second.mServiceName;
-#endif
-	}
-	else
-	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << " ServiceName: Unknown! ";
-#endif
-	}
+	else std::cerr << " ServiceName: Unknown! ";
 
-#ifdef SERVICECONTROL_DEBUG
-	std::cerr << " PeerId: " << peerId.toStdString();
-	std::cerr << std::endl;
+	std::cerr << " PeerId: " << peerId.toStdString() << std::endl;
 #endif
 
 	// must allow ServiceInfo through, or we have nothing!
 #define FULLID_SERVICEINFO ((((uint32_t) RS_PKT_VERSION_SERVICE) << 24) + ((RS_SERVICE_TYPE_SERVICEINFO) << 8)) 
 
-	//if (serviceId == RS_SERVICE_TYPE_SERVICEINFO)
 	if (serviceId == FULLID_SERVICEINFO)
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Allowed SERVICEINFO";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::checkFilter() Allowed SERVICEINFO" << std::endl;
 #endif
 		return true;
 	}
-
 
 	std::map<RsPeerId, ServicePeerFilter>::const_iterator pit;
 	pit = mPeerFilterMap.find(peerId);
 	if (pit == mPeerFilterMap.end())
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Denied No PeerId";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::checkFilter() Denied No PeerId" << std::endl;
 #endif
 		return false;
 	}
@@ -604,8 +540,7 @@ bool	p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId &peerId)
 	if (pit->second.mDenyAll)
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Denied Peer.DenyAll";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::checkFilter() Denied Peer.DenyAll" << std::endl;
 #endif
 		return false;
 	}
@@ -613,8 +548,7 @@ bool	p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId &peerId)
 	if (pit->second.mAllowAll)
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Allowed Peer.AllowAll";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::checkFilter() Allowed Peer.AllowAll" << std::endl;
 #endif
 		return true;
 	}
@@ -624,99 +558,84 @@ bool	p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId &peerId)
 	if (sit == pit->second.mAllowedServices.end())
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Denied !Peer.find(serviceId)";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::checkFilter() Denied !Peer.find(serviceId)" << std::endl;
 #endif
 		return false;
 	}
+
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::checkFilter() Allowed Peer.find(serviceId)";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::checkFilter() Allowed Peer.find(serviceId)" << std::endl;
 #endif
 	return true;
 }
 
 bool versionOkay(uint16_t version_major, uint16_t version_minor,
-	uint16_t min_version_major, uint16_t min_version_minor)
+				 uint16_t min_version_major, uint16_t min_version_minor)
 {
-	if (version_major > min_version_major)
-	{
-		return true;
-	}
+	if (version_major > min_version_major) return true;
 	if (version_major == min_version_major)
-	{
 		return (version_minor >= min_version_minor);
-	}
+
 	return false;
 }
-
 
 bool ServiceInfoCompatible(const RsServiceInfo &info1, const RsServiceInfo &info2)
 {
 	// Id, or Name mismatch.
 	if ((info1.mServiceType != info2.mServiceType) ||
-		(info1.mServiceName != info2.mServiceName))
+			(info1.mServiceName != info2.mServiceName))
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "servicesCompatible: Type/Name mismatch";
-		std::cerr << std::endl;
-		std::cerr << "Info1 ID: " << info1.mServiceType;
-		std::cerr << " " << info1.mServiceName;
-		std::cerr << std::endl;
-		std::cerr << "Info2 ID: " << info2.mServiceType;
-		std::cerr << " " << info2.mServiceName;
-		std::cerr << std::endl;
+		std::cerr << "servicesCompatible: Type/Name mismatch" << std::endl
+				  << "Info1 ID: " << info1.mServiceType << " "
+				  << info1.mServiceName << std::endl << "Info2 ID: "
+				  << info2.mServiceType << " " << info2.mServiceName << std::endl;
 #endif
 		return false;
 	}
 
 	// ensure that info1 meets minimum requirements for info2
-	if (!versionOkay(info1.mVersionMajor, info1.mVersionMinor, 
-		info2.mMinVersionMajor, info2.mMinVersionMinor))
-	{
+	if (!versionOkay(info1.mVersionMajor, info1.mVersionMinor,
+					 info2.mMinVersionMajor, info2.mMinVersionMinor))
 		return false;
-	}
 
 	// ensure that info2 meets minimum requirements for info1
-	if (!versionOkay(info2.mVersionMajor, info2.mVersionMinor, 
-		info1.mMinVersionMajor, info1.mMinVersionMinor))
-	{
+	if (!versionOkay(info2.mVersionMajor, info2.mVersionMinor,
+					 info1.mMinVersionMajor, info1.mMinVersionMinor))
 		return false;
-	}
+
 	return true;
 }
 	
 
-bool	p3ServiceControl::updateFilterByPeer(const RsPeerId &peerId)
+bool p3ServiceControl::updateFilterByPeer(const RsPeerId &peerId)
 {
+	RS_STACK_MUTEX(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updateFilterByPeer()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updateFilterByPeer()" << std::endl;
 #endif
 
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
 	return updateFilterByPeer_locked(peerId);
 }
 
 
-bool	p3ServiceControl::updateAllFilters()
+bool p3ServiceControl::updateAllFilters()
 {
-#ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updateAllFilters()";
-	std::cerr << std::endl;
-#endif
+	RS_STACK_MUTEX(mCtrlMtx);
 
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+#ifdef SERVICECONTROL_DEBUG
+	std::cerr << "p3ServiceControl::updateAllFilters()" << std::endl;
+#endif
 
 	return updateAllFilters_locked();
 }
 
 
-bool	p3ServiceControl::updateAllFilters_locked()
+bool p3ServiceControl::updateAllFilters_locked()
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updateAllFilters_locked()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updateAllFilters_locked()" << std::endl;
 #endif
 
 	// Create a peerSet from ServicesProvided + PeerFilters.
@@ -726,30 +645,24 @@ bool	p3ServiceControl::updateAllFilters_locked()
 
 	std::map<RsPeerId, RsPeerServiceInfo>::const_iterator it;
 	for(it = mServicesProvided.begin(); it != mServicesProvided.end(); ++it)
-	{
 		peerSet.insert(it->first);
-	}
 
 	std::map<RsPeerId, ServicePeerFilter>::const_iterator fit;
 	for(fit = mPeerFilterMap.begin(); fit != mPeerFilterMap.end(); ++fit)
-	{
 		peerSet.insert(fit->first);
-	}
 
 	for(pit = peerSet.begin(); pit != peerSet.end(); ++pit)
-	{
 		updateFilterByPeer_locked(*pit);
-	}
+
 	return true;
 }
 
 
 // create filter. (the easy way).
-bool	p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
+bool p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updateFilterByPeer_locked() : " << peerId.toStdString();
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updateFilterByPeer_locked() : " << peerId.toStdString() << std::endl;
 #endif
 
 	ServicePeerFilter originalFilter;
@@ -757,27 +670,21 @@ bool	p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
 
 	std::map<RsPeerId, ServicePeerFilter>::iterator fit;
 	fit = mPeerFilterMap.find(peerId);
-	if (fit != mPeerFilterMap.end())
-	{
-		originalFilter = fit->second;
-	}
+	if (fit != mPeerFilterMap.end()) originalFilter = fit->second;
 
 	std::map<RsPeerId, RsPeerServiceInfo>::iterator it;
 	it = mServicesProvided.find(peerId);
 	if (it == mServicesProvided.end())
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Empty ... Clearing";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Empty "
+				  << "... Clearing" << std::endl;
 #endif
-	
-		// empty, remove... 
+
+		// empty, remove...
 		recordFilterChanges_locked(peerId, originalFilter, peerFilter);
-		if (fit != mPeerFilterMap.end())
-		{
-			std::cerr << std::endl;
-			mPeerFilterMap.erase(fit);
-		}
+		if (fit != mPeerFilterMap.end()) mPeerFilterMap.erase(fit);
+
 		return true;
 	}
 
@@ -791,32 +698,27 @@ bool	p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
 	std::map<uint32_t, RsServiceInfo>::const_iterator etit = it->second.mServiceList.end();
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Comparing lists";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Comparing lists" << std::endl;
 #endif
-
 
 	while((oit != eoit) && (tit != etit))
 	{
 		if (oit->first == tit->first)
 		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "\tChecking Matching Service ID: " << oit->first;
-			std::cerr << std::endl;
+			std::cerr << "\tChecking Matching Service ID: " << oit->first << std::endl;
 #endif
 			/* match of service IDs */
 			/* check if compatible */
-			if (ServiceInfoCompatible(oit->second, tit->second))
-			{
-				if (peerHasPermissionForService_locked(peerId, oit->first))
+			if (ServiceInfoCompatible(oit->second, tit->second) &&
+					peerHasPermissionForService_locked(peerId, oit->first))
 				{
 #ifdef SERVICECONTROL_DEBUG
-					std::cerr << "\t\tMatched Service ID: " << oit->first;
-					std::cerr << std::endl;
+					std::cerr << "\t\tMatched Service ID: " << oit->first << std::endl;
 #endif
 					peerFilter.mAllowedServices.insert(oit->first);
 				}
-			}
+
 			++oit;
 			++tit;
 		}
@@ -825,16 +727,14 @@ bool	p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
 			if (oit->first < tit->first)
 			{
 #ifdef SERVICECONTROL_DEBUG
-				std::cerr << "\tSkipping Only Own Service ID: " << oit->first;
-				std::cerr << std::endl;
+				std::cerr << "\tSkipping Only Own Service ID: " << oit->first << std::endl;
 #endif
 				++oit;
 			}
 			else
 			{
 #ifdef SERVICECONTROL_DEBUG
-				std::cerr << "\tSkipping Only Peer Service ID: " << tit->first;
-				std::cerr << std::endl;
+				std::cerr << "\tSkipping Only Peer Service ID: " << tit->first << std::endl;
 #endif
 				++tit;
 			}
@@ -842,37 +742,26 @@ bool	p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
 	}
 
 	// small optimisations.
-	if (peerFilter.mAllowedServices.empty())
-	{
-		peerFilter.mDenyAll = true;
-	}
+	if (peerFilter.mAllowedServices.empty()) peerFilter.mDenyAll = true;
 	else
 	{
 		peerFilter.mDenyAll = false;
 		if (peerFilter.mAllowedServices.size() == mOwnServices.size())
-		{
 			peerFilter.mAllowAll = true;
-		}
 	}
 
 	// update or remove.
 	if (peerFilter.mDenyAll)
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Empty(2) ... Clearing";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Empty(2) ... Clearing" << std::endl;
 #endif
-	
-		if (fit != mPeerFilterMap.end())
-		{
-			mPeerFilterMap.erase(fit);
-		}
+		if (fit != mPeerFilterMap.end()) mPeerFilterMap.erase(fit);
 	}
 	else
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Installing PeerFilter";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::updateFilterByPeer_locked() Installing PeerFilter" << std::endl;
 #endif
 		mPeerFilterMap[peerId] = peerFilter;
 	}
@@ -880,18 +769,15 @@ bool	p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
 	return true;
 }
 
-void	p3ServiceControl::recordFilterChanges_locked(const RsPeerId &peerId, 
-	ServicePeerFilter &originalFilter, ServicePeerFilter &updatedFilter)
+void p3ServiceControl::recordFilterChanges_locked(const RsPeerId &peerId,
+												  ServicePeerFilter &originalFilter,
+												  ServicePeerFilter &updatedFilter)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::recordFilterChanges_locked()";
-	std::cerr << std::endl;
-	std::cerr << "PeerId: " << peerId.toStdString();
-	std::cerr << std::endl;
-	std::cerr << "OriginalFilter: " << originalFilter;
-	std::cerr << std::endl;
-	std::cerr << "UpdatedFilter: " << updatedFilter;
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::recordFilterChanges_locked()" << std::endl
+			  << "PeerId: " << peerId.toStdString() << std::endl
+			  << "OriginalFilter: " << originalFilter << std::endl
+			  << "UpdatedFilter: " << updatedFilter << std::endl;
 #endif
 
 	/* find differences */
@@ -907,8 +793,7 @@ void	p3ServiceControl::recordFilterChanges_locked(const RsPeerId &peerId,
 		if (*it1 < *it2)
 		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "Removed Service: " << *it1;
-			std::cerr << std::endl;
+			std::cerr << "Removed Service: " << *it1 << std::endl;
 #endif
 			// removal
 			changes[*it1] = false;
@@ -918,8 +803,7 @@ void	p3ServiceControl::recordFilterChanges_locked(const RsPeerId &peerId,
 		else if (*it2 < *it1)
 		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "Added Service: " << *it2;
-			std::cerr << std::endl;
+			std::cerr << "Added Service: " << *it2 << std::endl;
 #endif
 			// addition.
 			filterChangeAdded_locked(peerId, *it2);
@@ -937,8 +821,7 @@ void	p3ServiceControl::recordFilterChanges_locked(const RsPeerId &peerId,
 	for(; it1 != eit1; ++it1)
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "Removed Service: " << *it1;
-		std::cerr << std::endl;
+		std::cerr << "Removed Service: " << *it1 << std::endl;
 #endif
 		// removal
 		changes[*it1] = false;
@@ -948,16 +831,16 @@ void	p3ServiceControl::recordFilterChanges_locked(const RsPeerId &peerId,
 	for(; it2 != eit2; ++it2)
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "Added Service: " << *it2;
-		std::cerr << std::endl;
+		std::cerr << "Added Service: " << *it2 << std::endl;
 #endif
 		// addition.
 		changes[*it2] = true;
 		filterChangeAdded_locked(peerId, *it2);
 	}
 
+
+#if 0 // TODO: 2016/01/03 Dead Code?
 	// Can remove changes map... as only used below.
-#if 0
 	// now we to store for later notifications.
 	std::map<uint32_t, bool>::const_iterator cit;
 	for(cit = changes.begin(); cit != changes.end(); ++cit)
@@ -978,13 +861,12 @@ void	p3ServiceControl::recordFilterChanges_locked(const RsPeerId &peerId,
 
 
 // when they go offline, etc.
-void	p3ServiceControl::removePeer(const RsPeerId &peerId)
+void p3ServiceControl::removePeer(const RsPeerId &peerId)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::removePeer() : " << peerId.toStdString();
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::removePeer() : " << peerId.toStdString() << std::endl;
 #endif
 
 	ServicePeerFilter originalFilter;
@@ -995,8 +877,7 @@ void	p3ServiceControl::removePeer(const RsPeerId &peerId)
 		if (fit != mPeerFilterMap.end())
 		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "p3ServiceControl::removePeer() clearing mPeerFilterMap";
-			std::cerr << std::endl;
+			std::cerr << "p3ServiceControl::removePeer() clearing mPeerFilterMap" << std::endl;
 #endif
 
 			hadFilter = true;
@@ -1006,8 +887,7 @@ void	p3ServiceControl::removePeer(const RsPeerId &peerId)
 		else
 		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "p3ServiceControl::removePeer() Nothing in mPeerFilterMap";
-			std::cerr << std::endl;
+			std::cerr << "p3ServiceControl::removePeer() Nothing in mPeerFilterMap" << std::endl;
 #endif
 		}
 	}
@@ -1018,19 +898,13 @@ void	p3ServiceControl::removePeer(const RsPeerId &peerId)
 		if (sit != mServicesProvided.end())
 		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "p3ServiceControl::removePeer() clearing mServicesProvided";
-			std::cerr << std::endl;
+			std::cerr << "p3ServiceControl::removePeer() clearing mServicesProvided" << std::endl;
 #endif
-
 			mServicesProvided.erase(sit);
 		}
-		else
-		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "p3ServiceControl::removePeer() Nothing in mServicesProvided";
-			std::cerr << std::endl;
+		else std::cerr << "p3ServiceControl::removePeer() Nothing in mServicesProvided" << std::endl;
 #endif
-		}
 	}
 
 	if (hadFilter)
@@ -1048,26 +922,17 @@ void	p3ServiceControl::removePeer(const RsPeerId &peerId)
 void p3ServiceControl::filterChangeRemoved_locked(const RsPeerId &peerId, uint32_t serviceId)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::filterChangeRemoved_locked(" << peerId.toStdString();
-	std::cerr << ", " << serviceId << ")";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::filterChangeRemoved_locked("
+			  << peerId.toStdString() << ", " << serviceId << ")" << std::endl;
 #endif
 
-	std::map<uint32_t, std::set<RsPeerId> >::iterator mit;
-
 	std::set<RsPeerId> &peerSet = mServicePeerMap[serviceId];
-	std::set<RsPeerId>::iterator sit;
-
-	sit = peerSet.find(peerId);
-	if (sit != peerSet.end())
-	{
-		peerSet.erase(sit);
-	}
+	std::set<RsPeerId>::iterator sit = peerSet.find(peerId);
+	if (sit != peerSet.end()) peerSet.erase(sit);
 	else
 	{
-		// ERROR
-		std::cerr << "p3ServiceControl::filterChangeRemoved_locked() ERROR NOT FOUND";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::filterChangeRemoved_locked() "
+				  << "ERROR NOT FOUND" << std::endl;
 	}
 
 	// Add to Notifications too.
@@ -1079,23 +944,18 @@ void p3ServiceControl::filterChangeRemoved_locked(const RsPeerId &peerId, uint32
 void p3ServiceControl::filterChangeAdded_locked(const RsPeerId &peerId, uint32_t serviceId)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::filterChangeAdded_locked(" << peerId.toStdString();
-	std::cerr << ", " << serviceId << ")";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::filterChangeAdded_locked("
+			  << peerId.toStdString() << ", " << serviceId << ")" << std::endl;
 #endif
 
-	std::map<uint32_t, std::set<RsPeerId> >::iterator mit;
-
 	std::set<RsPeerId> &peerSet = mServicePeerMap[serviceId];
-
 	// This bit is only for error checking.
 	std::set<RsPeerId>::iterator sit = peerSet.find(peerId);
+
 	if (sit != peerSet.end())
-	{
-		// ERROR.
-		std::cerr << "p3ServiceControl::filterChangeAdded_locked() ERROR NOT FOUND";
-		std::cerr << std::endl;
-	}
+		std::cerr << "p3ServiceControl::filterChangeAdded_locked()"
+				  << "ERROR NOT FOUND" << std::endl;
+
 	peerSet.insert(peerId);
 
 	// Add to Notifications too.
@@ -1104,27 +964,20 @@ void p3ServiceControl::filterChangeAdded_locked(const RsPeerId &peerId, uint32_t
 }
 
 
-
 void p3ServiceControl::getPeersConnected(const uint32_t serviceId, std::set<RsPeerId> &peerSet)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 	std::map<uint32_t, std::set<RsPeerId> >::iterator mit;
 	mit = mServicePeerMap.find(serviceId);
-	if (mit != mServicePeerMap.end())
-	{
-		peerSet = mit->second;
-	}
-	else
-	{
-		peerSet.clear();
-	}
+	if (mit != mServicePeerMap.end()) peerSet = mit->second;
+	else peerSet.clear();
 }
 
 
 bool p3ServiceControl::isPeerConnected(const uint32_t serviceId, const RsPeerId &peerId)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 	std::map<uint32_t, std::set<RsPeerId> >::iterator mit;
 	mit = mServicePeerMap.find(serviceId);
@@ -1142,14 +995,13 @@ bool p3ServiceControl::isPeerConnected(const uint32_t serviceId, const RsPeerId 
 /****************************************************************************/
 /****************************************************************************/
 
-void	p3ServiceControl::tick()
+void p3ServiceControl::tick()
 {
 	notifyAboutFriends();
 	notifyServices();
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::tick()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::tick()" << std::endl;
 #endif
 }
 
@@ -1157,36 +1009,34 @@ void	p3ServiceControl::tick()
 bool p3ServiceControl::saveList(bool &cleanup, std::list<RsItem *> &saveList)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::saveList()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::saveList()" << std::endl;
 #endif
-    cleanup = true ;
+	cleanup = true;
 
-    for(std::map<uint32_t, RsServicePermissions>::iterator it(mServicePermissionMap.begin());it!=mServicePermissionMap.end();++it)
+	for(std::map<uint32_t, RsServicePermissions>::iterator it(mServicePermissionMap.begin());it!=mServicePermissionMap.end();++it)
     {
-        RsServicePermissionItem *item = new RsServicePermissionItem(it->second) ;
-        saveList.push_back(item) ;
-    }
+		RsServicePermissionItem *item = new RsServicePermissionItem(it->second) ;
+		saveList.push_back(item);
+	}
 	return true;
 }
 
 bool p3ServiceControl::loadList(std::list<RsItem *>& loadList)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::loadList()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::loadList()" << std::endl;
 #endif
-    for(std::list<RsItem*>::const_iterator it(loadList.begin());it!=loadList.end();++it)
-    {
-        RsServicePermissionItem *item = dynamic_cast<RsServicePermissionItem*>(*it) ;
+	for(std::list<RsItem*>::const_iterator it(loadList.begin());it!=loadList.end();++it)
+	{
+		RsServicePermissionItem *item = dynamic_cast<RsServicePermissionItem*>(*it);
 
-        if(item != NULL)
-		mServicePermissionMap[item->mServiceId] = *item ;
+		if(item != NULL)
+			mServicePermissionMap[item->mServiceId] = *item;
         
-        delete *it ;
-    }
+		delete *it;
+	}
 
-    loadList.clear() ;
+	loadList.clear();
 	return true;
 }
 
@@ -1194,193 +1044,159 @@ bool p3ServiceControl::loadList(std::list<RsItem *>& loadList)
 /****************************************************************************/
 /****************************************************************************/
 
-	// pqiMonitor.
-void    p3ServiceControl::statusChange(const std::list<pqipeer> &plist)
+// pqiMonitor.
+void p3ServiceControl::statusChange(const std::list<pqipeer> &plist)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::statusChange()";
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::statusChange()" << std::endl;
 #endif
 
 	std::list<pqipeer>::const_iterator pit;
 	for(pit =  plist.begin(); pit != plist.end(); ++pit)
 	{
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::statusChange() for peer: ";
-		std::cerr << " peer: " << (pit->id).toStdString();
-		std::cerr << " state: " << pit->state;
-		std::cerr << " actions: " << pit->actions;
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::statusChange() for peer: " << " peer: "
+				  << (pit->id).toStdString() << " state: " << pit->state
+				  << " actions: " << pit->actions << std::endl;
 #endif
 		if (pit->state & RS_PEER_S_FRIEND)
 		{
 			// Connected / Disconnected. (interal actions).
-			if (pit->actions & RS_PEER_CONNECTED)
-			{
-				updatePeerConnect(pit->id);
-			}
+			if (pit->actions & RS_PEER_CONNECTED) updatePeerConnect(pit->id);
 			else if (pit->actions & RS_PEER_DISCONNECTED)
-			{
 				updatePeerDisconnect(pit->id);
-			}
 
 			// Added / Removed. (pass on notifications).
-			if (pit->actions & RS_PEER_NEW)
-			{
-				updatePeerNew(pit->id);
-			}
+			if (pit->actions & RS_PEER_NEW) updatePeerNew(pit->id);
 		}
-		else
-		{
-			if (pit->actions & RS_PEER_MOVED)
-			{
-				updatePeerRemoved(pit->id);
-			}
-		}
+		else if (pit->actions & RS_PEER_MOVED) updatePeerRemoved(pit->id);
 	}
-	return;
 }
 
 // Update Peer status.
-void    p3ServiceControl::updatePeerConnect(const RsPeerId &peerId)
+void p3ServiceControl::updatePeerConnect(const RsPeerId & /*peerId*/)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updatePeerConnect(): " << peerId.toStdString();
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updatePeerConnect()" << std::endl;
 #endif
-	return;
 }
 
-void    p3ServiceControl::updatePeerDisconnect(const RsPeerId &peerId)
+void p3ServiceControl::updatePeerDisconnect(const RsPeerId &peerId)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updatePeerDisconnect(): " << peerId.toStdString();
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updatePeerDisconnect(): "
+			  << peerId.toStdString() << std::endl;
 #endif
 
 	removePeer(peerId);
-	return;
 }
 
 
 // Update Peer status.
-void    p3ServiceControl::updatePeerNew(const RsPeerId &peerId)
+void p3ServiceControl::updatePeerNew(const RsPeerId &peerId)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updatePeerNew(): " << peerId.toStdString();
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updatePeerNew(): "
+			  << peerId.toStdString() << std::endl;
 #endif
 
 	pqiServicePeer peer;
 	peer.id = peerId;
 	peer.actions = RS_SERVICE_PEER_NEW;
 	mFriendNotifications.push_back(peer);
-
-	return;
 }
 
-void    p3ServiceControl::updatePeerRemoved(const RsPeerId &peerId)
+void p3ServiceControl::updatePeerRemoved(const RsPeerId &peerId)
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::updatePeerRemoved(): " << peerId.toStdString();
-	std::cerr << std::endl;
+	std::cerr << "p3ServiceControl::updatePeerRemoved(): "
+			  << peerId.toStdString() << std::endl;
 #endif
 
 	removePeer(peerId);
 
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	RS_STACK_MUTEX(mCtrlMtx);
 
 	pqiServicePeer peer;
 	peer.id = peerId;
 	peer.actions = RS_SERVICE_PEER_REMOVED;
 	mFriendNotifications.push_back(peer);
-
-	return;
 }
 
 /****************************************************************************/
 /****************************************************************************/
 
 
-void	p3ServiceControl::notifyAboutFriends()
+void p3ServiceControl::notifyAboutFriends()
 {
 	std::list<pqiServicePeer> friendNotifications;
-	{
-		RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
 
-		if (mFriendNotifications.empty())
-		{
-			return;
-		}
+	{
+		RS_STACK_MUTEX(mCtrlMtx);
+
+		if (mFriendNotifications.empty()) return;
+
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::notifyAboutFriends(): Something has changed!";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::notifyAboutFriends():"
+				  << "Something has changed!" << std::endl;
 #endif
 
 		mFriendNotifications.swap(friendNotifications);
 	}
 
 	{
-		RsStackMutex stack(mMonitorMtx); /***** LOCK STACK MUTEX ****/
+		RS_STACK_MUTEX(mMonitorMtx);
 
 		std::multimap<uint32_t, pqiServiceMonitor *>::const_iterator sit;
 		for(sit = mMonitors.begin(); sit != mMonitors.end(); ++sit)
-		{
 			sit->second->statusChange(friendNotifications);
-		}
 	}
 }
 
 
-void	p3ServiceControl::notifyServices()
+void p3ServiceControl::notifyServices()
 {
 	std::map<uint32_t, ServiceNotifications> notifications;
-	{
-		RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
 
-		if (mNotifications.empty())
-		{
-			return;
-		}
+	{
+		RS_STACK_MUTEX(mCtrlMtx);
+		if (mNotifications.empty()) return;
 
 #ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::notifyServices()";
-		std::cerr << std::endl;
+		std::cerr << "p3ServiceControl::notifyServices()" << std::endl;
 #endif
 
 		mNotifications.swap(notifications);
 	}
 
 	{
-		RsStackMutex stack(mMonitorMtx); /***** LOCK STACK MUTEX ****/
+		RS_STACK_MUTEX(mMonitorMtx);
 
 		std::map<uint32_t, ServiceNotifications>::const_iterator it;
 		std::multimap<uint32_t, pqiServiceMonitor *>::const_iterator sit, eit;
 		for(it = notifications.begin(); it != notifications.end(); ++it)
 		{
 #ifdef SERVICECONTROL_DEBUG
-			std::cerr << "p3ServiceControl::notifyServices(): Notifications for Service: " << it->first;
-			std::cerr << std::endl;
+			std::cerr << "p3ServiceControl::notifyServices(): Notifications"
+					  << "for Service: " << it->first << std::endl;
 #endif
 
 			sit = mMonitors.lower_bound(it->first);
 			eit = mMonitors.upper_bound(it->first);
 			if (sit == eit)
 			{
-				/* nothing to notify - skip */
 #ifdef SERVICECONTROL_DEBUG
-				std::cerr << "p3ServiceControl::notifyServices(): Noone Monitoring ... skipping";
-				std::cerr << std::endl;
+				std::cerr << "p3ServiceControl::notifyServices(): "
+						  << "Noone Monitoring ... skipping" << std::endl;
 #endif
-	
 				continue;
 			}
-	
+
 			std::list<pqiServicePeer> peers;
 			std::set<RsPeerId>::const_iterator pit;
-			for(pit = it->second.mAdded.begin(); 
+			for(pit = it->second.mAdded.begin();
 				pit != it->second.mAdded.end(); ++pit)
 			{
 				pqiServicePeer peer;
@@ -1390,12 +1206,12 @@ void	p3ServiceControl::notifyServices()
 				peers.push_back(peer);
 	
 #ifdef SERVICECONTROL_DEBUG
-				std::cerr << "p3ServiceControl::notifyServices(): Peer: " << *pit << " CONNECTED";
-				std::cerr << std::endl;
+				std::cerr << "p3ServiceControl::notifyServices(): Peer: "
+						  << *pit << " CONNECTED" << std::endl;
 #endif
 			}
 	
-			for(pit = it->second.mRemoved.begin(); 
+			for(pit = it->second.mRemoved.begin();
 				pit != it->second.mRemoved.end(); ++pit)
 			{
 				pqiServicePeer peer;
@@ -1405,18 +1221,17 @@ void	p3ServiceControl::notifyServices()
 				peers.push_back(peer);
 	
 #ifdef SERVICECONTROL_DEBUG
-				std::cerr << "p3ServiceControl::notifyServices(): Peer: " << *pit << " DISCONNECTED";
-				std::cerr << std::endl;
+				std::cerr << "p3ServiceControl::notifyServices(): Peer: "
+						  << *pit << " DISCONNECTED" << std::endl;
 #endif
 			}
 	
 			for(; sit != eit; ++sit)
 			{
 #ifdef SERVICECONTROL_DEBUG
-				std::cerr << "p3ServiceControl::notifyServices(): Sending to Monitoring Service";
-				std::cerr << std::endl;
+				std::cerr << "p3ServiceControl::notifyServices():"
+						  << "Sending to Monitoring Service" << std::endl;
 #endif
-	
 				sit->second->statusChange(peers);
 			}
 		}
@@ -1428,119 +1243,76 @@ void	p3ServiceControl::notifyServices()
 /****************************************************************************/
 
 
-RsServicePermissions::RsServicePermissions()
-:mServiceId(0), mServiceName(), mDefaultAllowed(false)
-{
-	return;
-}
+RsServicePermissions::RsServicePermissions() : mServiceId(0), mServiceName(),
+	mDefaultAllowed(false) {}
 
 bool RsServicePermissions::peerHasPermission(const RsPeerId &peerId) const
 {
 #ifdef SERVICECONTROL_DEBUG
-	std::cerr << "RsServicePermissions::peerHasPermission()";
-	std::cerr << std::endl;
+	std::cerr << "RsServicePermissions::peerHasPermission()" << std::endl;
 #endif
 
-	std::set<RsPeerId>::const_iterator it;
-	if (mDefaultAllowed)
-	{
-		it = mPeersDenied.find(peerId);
-		return (it == mPeersDenied.end());
-	}
-	else
-	{
-		it = mPeersAllowed.find(peerId);
-		return (it != mPeersAllowed.end());
-	}
+	if (mDefaultAllowed) return (mPeersDenied.find(peerId) == mPeersDenied.end());
+	return (mPeersAllowed.find(peerId) != mPeersAllowed.end());
 }
 
 void RsServicePermissions::setPermission(const RsPeerId& peerId)
 {
-    std::set<RsPeerId>::const_iterator it;
-    if (mDefaultAllowed)
-    {
-        it = mPeersDenied.find(peerId);
-        mPeersDenied.erase(it) ;
-    }
-    else
-        mPeersAllowed.insert(peerId);
+	if (mDefaultAllowed) mPeersDenied.erase(mPeersDenied.find(peerId));
+	else mPeersAllowed.insert(peerId);
 }
+
 void RsServicePermissions::resetPermission(const RsPeerId& peerId)
 {
-    std::set<RsPeerId>::const_iterator it;
-    if (!mDefaultAllowed)
-    {
-        it = mPeersAllowed.find(peerId);
-        mPeersAllowed.erase(it) ;
-    }
-    else
-        mPeersDenied.insert(peerId);
+	if (!mDefaultAllowed) mPeersAllowed.erase(mPeersAllowed.find(peerId));
+	else mPeersDenied.insert(peerId);
 }
 
 RsServiceInfo::RsServiceInfo(
-		const uint16_t service_type, 
-		const std::string service_name, 
+		const uint16_t service_type,
+		const std::string service_name,
 		const uint16_t version_major,
 		const uint16_t version_minor,
 		const uint16_t min_version_major,
-		const uint16_t min_version_minor)
- :mServiceName(service_name), 
-  mServiceType((((uint32_t) RS_PKT_VERSION_SERVICE) << 24) + (((uint32_t) service_type) << 8)), 
-  mVersionMajor(version_major), 
-  mVersionMinor(version_minor),
-  mMinVersionMajor(min_version_major), 
-  mMinVersionMinor(min_version_minor)
-{
-	return;
-}
+		const uint16_t min_version_minor) :
+	mServiceName(service_name),
+	mServiceType((((uint32_t) RS_PKT_VERSION_SERVICE) << 24) + (((uint32_t) service_type) << 8)),
+	mVersionMajor(version_major), mVersionMinor(version_minor),
+	mMinVersionMajor(min_version_major), mMinVersionMinor(min_version_minor) {}
 
-
-RsServiceInfo::RsServiceInfo()
- :mServiceName("unknown"), 
-  mServiceType(0),
-  mVersionMajor(0),
-  mVersionMinor(0),
-  mMinVersionMajor(0),
-  mMinVersionMinor(0)
-{
-	return;
-}
+RsServiceInfo::RsServiceInfo() : mServiceName("unknown"), mServiceType(0),
+	mVersionMajor(0), mVersionMinor(0), mMinVersionMajor(0),
+	mMinVersionMinor(0) {}
 
 std::ostream &operator<<(std::ostream &out, const RsPeerServiceInfo &info)
 {
-	out << "RsPeerServiceInfo(" << info.mPeerId << ")";
-	out << std::endl;
+	out << "RsPeerServiceInfo(" << info.mPeerId << ")" << std::endl;
+
 	std::map<uint32_t, RsServiceInfo>::const_iterator it;
 	for(it = info.mServiceList.begin(); it != info.mServiceList.end(); ++it)
-	{
-		out << "\t Service:" << it->first << " : ";
-		out << it->second;
-		out << std::endl;
-	}
+		out << "\t Service:" << it->first << " : " << it->second << std::endl;
 	return out;
 }
 
 
 std::ostream &operator<<(std::ostream &out, const RsServiceInfo &info)
 {
-	out << "RsServiceInfo(" << info.mServiceType << "): " << info.mServiceName;
-	out << " Version(" << info.mVersionMajor << "," << info.mVersionMinor << ")";
-	out << " MinVersion(" << info.mMinVersionMajor << "," << info.mMinVersionMinor << ")";
+	out << "RsServiceInfo(" << info.mServiceType << "): " << info.mServiceName
+		<< " Version(" << info.mVersionMajor << "," << info.mVersionMinor << ")"
+		<< " MinVersion(" << info.mMinVersionMajor << "," << info.mMinVersionMinor << ")";
 	return out;
 }
 
 std::ostream &operator<<(std::ostream &out, const ServicePeerFilter &filter)
 {
-	out << "ServicePeerFilter DenyAll: " << filter.mDenyAll;
-	out << " AllowAll: " << filter.mAllowAll;
-	out << " Matched Services: ";
+	out << "ServicePeerFilter DenyAll: " << filter.mDenyAll << " AllowAll: "
+		<< filter.mAllowAll << " Matched Services: ";
+
 	std::set<uint32_t>::const_iterator it;
-	for(it = filter.mAllowedServices.begin(); it != filter.mAllowedServices.end(); ++it)
-	{
-	 	out << *it << " ";
-	}
+	for(it = filter.mAllowedServices.begin();
+		it != filter.mAllowedServices.end(); ++it)
+		out << *it << " ";
+
 	out << std::endl;
 	return out;
 }
-
-

--- a/libretroshare/src/pqi/p3servicecontrol.h
+++ b/libretroshare/src/pqi/p3servicecontrol.h
@@ -38,133 +38,121 @@
 
 class ServiceNotifications
 {
-	public:
+public:
 	std::set<RsPeerId> mAdded;
 	std::set<RsPeerId> mRemoved;
 };
 
 class ServicePeerFilter
 {
-        public:
-        ServicePeerFilter()
-        :mDenyAll(true), mAllowAll(false) {}
+public:
+	ServicePeerFilter() : mDenyAll(true), mAllowAll(false) {}
 
-        bool mDenyAll;
-        bool mAllowAll;
-        std::set<uint32_t> mAllowedServices;
+	bool mDenyAll;
+	bool mAllowAll;
+	std::set<uint32_t> mAllowedServices;
 };
 
 std::ostream &operator<<(std::ostream &out, const ServicePeerFilter &filter);
 
-class ServiceControlSerialiser ;
+class ServiceControlSerialiser;
 
 class p3ServiceControl: public RsServiceControl, public pqiMonitor, public p3Config
 {
 public:
+	p3ServiceControl(p3LinkMgr *linkMgr);
 
 	/**
+	 * checks and update all added configurations
+	 * @see rsserver
 	 */
-        p3ServiceControl(p3LinkMgr *linkMgr);
+	void tick();
 
-        /**
-         * checks and update all added configurations
-         * @see rsserver
-         */
-        void	tick();
-
-        /**
-         * provided so that services don't need linkMgr, and can get all info
+	/**
+	 * provided so that services don't need linkMgr, and can get all info
 	 * from ServiceControl.
-         * @see rsserver
-         */
-
-virtual const 	RsPeerId& getOwnId();
+	 * @see rsserver
+	 */
+	virtual const RsPeerId& getOwnId();
 
 	/**
 	 * External Interface (RsServiceControl).
 	 */
-
-virtual bool getOwnServices(RsPeerServiceInfo &info);
+	virtual bool getOwnServices(RsPeerServiceInfo &info);
 
 	// This is what is passed to peers, can be displayed by GUI too.
-virtual bool getServicesAllowed(const RsPeerId &peerId, RsPeerServiceInfo &info);
+	virtual bool getServicesAllowed(const RsPeerId &peerId, RsPeerServiceInfo &info);
 
 	// Information provided by peer.
-virtual bool getServicesProvided(const RsPeerId &peerId, RsPeerServiceInfo &info);
+	virtual bool getServicesProvided(const RsPeerId &peerId, RsPeerServiceInfo &info);
 
 	// Main Permission Interface.
-virtual bool getServicePermissions(uint32_t serviceId, RsServicePermissions &permissions);
-virtual bool updateServicePermissions(uint32_t serviceId, const RsServicePermissions &permissions);
+	virtual bool getServicePermissions(uint32_t serviceId, RsServicePermissions &permissions);
+	virtual bool updateServicePermissions(uint32_t serviceId, const RsServicePermissions &permissions);
 
 	// Get List of Peers using this Service.
-virtual void getPeersConnected(const uint32_t serviceId, std::set<RsPeerId> &peerSet);
-virtual bool isPeerConnected(const uint32_t serviceId, const RsPeerId &peerId);
+	virtual void getPeersConnected(const uint32_t serviceId, std::set<RsPeerId> &peerSet);
+	virtual bool isPeerConnected(const uint32_t serviceId, const RsPeerId &peerId);
 
 	/**
 	 * Registration for all Services.
 	 */
+	virtual	bool registerService(const RsServiceInfo &info, bool defaultOn);
+	virtual	bool deregisterService(uint32_t serviceId);
 
-virtual	bool registerService(const RsServiceInfo &info, bool defaultOn);
-virtual	bool deregisterService(uint32_t serviceId);
-
-virtual	bool registerServiceMonitor(pqiServiceMonitor *monitor, uint32_t serviceId);
-virtual	bool deregisterServiceMonitor(pqiServiceMonitor *monitor);
-
-	/**
-	 *
-	 */
-
+	virtual	bool registerServiceMonitor(pqiServiceMonitor *monitor, uint32_t serviceId);
+	virtual	bool deregisterServiceMonitor(pqiServiceMonitor *monitor);
 
 	// Filter for services.
-virtual bool checkFilter(uint32_t serviceId, const RsPeerId &peerId);
+	virtual bool checkFilter(uint32_t serviceId, const RsPeerId &peerId);
 
-	/**
+	/*
 	 * Interface for ServiceInfo service.
 	 */
 
 	// ServicesAllowed have changed for these peers.
-virtual void getServiceChanges(std::set<RsPeerId> &updateSet);
+	virtual void getServiceChanges(std::set<RsPeerId> &updateSet);
 
-	// Input from peers.	
-virtual bool updateServicesProvided(const RsPeerId &peerId, const RsPeerServiceInfo &info);
+	// Input from peers.
+	virtual bool updateServicesProvided(const RsPeerId &peerId, const RsPeerServiceInfo &info);
 
 	// pqiMonitor.
-virtual void    statusChange(const std::list<pqipeer> &plist);
+	virtual void statusChange(const std::list<pqipeer> &plist);
 
 protected:
 	// configuration.
-virtual bool saveList(bool &cleanup, std::list<RsItem *>&);
-virtual bool loadList(std::list<RsItem *>& load);
-virtual RsSerialiser *setupSerialiser() ;
+	virtual bool saveList(bool &cleanup, std::list<RsItem *>&);
+	virtual bool loadList(std::list<RsItem *>& load);
+	virtual RsSerialiser *setupSerialiser() ;
 
 private:
+	void notifyServices();
+	void notifyAboutFriends();
 
-void    notifyServices();
-void    notifyAboutFriends();
+	void updatePeerConnect(const RsPeerId &peerId);
+	void updatePeerDisconnect(const RsPeerId &peerId);
+	void updatePeerNew(const RsPeerId &peerId);
+	void updatePeerRemoved(const RsPeerId &peerId);
 
-void    updatePeerConnect(const RsPeerId &peerId);
-void    updatePeerDisconnect(const RsPeerId &peerId);
-void    updatePeerNew(const RsPeerId &peerId);
-void    updatePeerRemoved(const RsPeerId &peerId);
-
-void 	removePeer(const RsPeerId &peerId);
-
-
-bool 	updateAllFilters();
-bool 	updateAllFilters_locked();
-bool 	updateFilterByPeer(const RsPeerId &peerId);
-bool 	updateFilterByPeer_locked(const RsPeerId &peerId);
+	void removePeer(const RsPeerId &peerId);
 
 
-	void    recordFilterChanges_locked(const RsPeerId &peerId,
-        	ServicePeerFilter &originalFilter, ServicePeerFilter &updatedFilter);
+	bool updateAllFilters();
+	bool updateAllFilters_locked();
+	bool updateFilterByPeer(const RsPeerId &peerId);
+	bool updateFilterByPeer_locked(const RsPeerId &peerId);
+
+
+	void recordFilterChanges_locked(const RsPeerId &peerId,
+									ServicePeerFilter &originalFilter,
+									ServicePeerFilter &updatedFilter);
 
 	// Called from recordFilterChanges.
 	void filterChangeAdded_locked(const RsPeerId &peerId, uint32_t serviceId);
 	void filterChangeRemoved_locked(const RsPeerId &peerId, uint32_t serviceId);
 
-bool createDefaultPermissions_locked(uint32_t serviceId, std::string serviceName, bool defaultOn);
-bool peerHasPermissionForService_locked(const RsPeerId &peerId, uint32_t serviceId);
+	bool createDefaultPermissions_locked(uint32_t serviceId, std::string serviceName, bool defaultOn);
+	bool peerHasPermissionForService_locked(const RsPeerId &peerId, uint32_t serviceId);
 
 	p3LinkMgr *mLinkMgr;
 	const RsPeerId mOwnPeerId; // const from constructor
@@ -176,25 +164,22 @@ bool peerHasPermissionForService_locked(const RsPeerId &peerId, uint32_t service
 	// From registration / deregistration.
 	std::map<uint32_t, RsServiceInfo> mOwnServices;
 	// From peers.
-        std::map<RsPeerId, RsPeerServiceInfo> mServicesProvided;
+	std::map<RsPeerId, RsPeerServiceInfo> mServicesProvided;
 	// derived from all the others.
-        std::map<RsPeerId, ServicePeerFilter> mPeerFilterMap;
+	std::map<RsPeerId, ServicePeerFilter> mPeerFilterMap;
 
-        std::map<uint32_t, ServiceNotifications> mNotifications;
-        std::list<pqiServicePeer> mFriendNotifications;
+	std::map<uint32_t, ServiceNotifications> mNotifications;
+	std::list<pqiServicePeer> mFriendNotifications;
 
 	// Map of Connected Peers per Service.
 	std::map<uint32_t, std::set<RsPeerId> > mServicePeerMap;
 
 	// Separate mutex here - must not hold both at the same time!
 	RsMutex mMonitorMtx; /* below is protected */
-    std::multimap<uint32_t, pqiServiceMonitor *> mMonitors;
+	std::multimap<uint32_t, pqiServiceMonitor *> mMonitors;
 
-    ServiceControlSerialiser *mSerialiser ;
-
-    // Below here is saved in Configuration.
-    std::map<uint32_t, RsServicePermissions> mServicePermissionMap;
-
+	// Below here is saved in Configuration.
+	std::map<uint32_t, RsServicePermissions> mServicePermissionMap;
 };
 
 


### PR DESCRIPTION
p3ServiceControl:

Optimize checkFilter(...) there was a map lookup which result was used only for debugging, moved the map loockup inside debug guard

solve memory leak removing mSerialiser which was allocated but never used or deleted

code cleanup solved a bunch of compiler warning plus very long lines plus indentation
