### PR TITLE
Add whitespaces around smileys.

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -1391,7 +1391,13 @@ void ChatWidget::smileyWidget()
 
 void ChatWidget::addSmiley()
 {
-	ui->chatTextEdit->textCursor().insertText(qobject_cast<QPushButton*>(sender())->toolTip().split("|").first());
+	QString smiley = qobject_cast<QPushButton*>(sender())->toolTip().split("|").first();
+	// add trailing space
+	smiley += QString(" ");
+	// add preceding space when needed (not at start of text or preceding space already exists)
+	if(!ui->chatTextEdit->textCursor().atStart() && ui->chatTextEdit->toPlainText()[ui->chatTextEdit->textCursor().position() - 1] != QChar(' '))
+		smiley = QString(" ") + smiley;
+	ui->chatTextEdit->textCursor().insertText(smiley);
 }
 
 void ChatWidget::clearChatHistory()

--- a/retroshare-gui/src/util/HandleRichText.cpp
+++ b/retroshare-gui/src/util/HandleRichText.cpp
@@ -105,7 +105,33 @@ void RsHtml::initEmoticons(const QHash< QString, QString >& hash)
 				continue;
 			}
 			defEmbedImg.smileys.insert(smile, it.value());
-			newRE += "(" + QRegExp::escape(smile) + ")|";
+			// add space around smileys
+			newRE += "(?:^|\\s)(" + QRegExp::escape(smile) + ")(?:$|\\s)|";
+			// explanations:
+			//	(?:^|\s)(*smiley*)(?:$|\s)
+			//
+			//	(?:^|\s) Non-capturing group
+			//		1st Alternative: ^
+			//			^ assert position at start of the string
+			//		2nd Alternative: \s
+			//			\s match any white space character [\r\n\t\f ]
+			//
+			//	1st Capturing group (*smiley*)
+			//		*smiley* matches the characters *smiley* literally (case sensitive)
+			//
+			//	(?:$|\s) Non-capturing group
+			//		1st Alternative: $
+			//			$ assert position at end of the string
+			//		2nd Alternative: \s
+			//			\s match any white space character [\r\n\t\f ]
+
+			/*
+			 * TODO
+			 * a better version is:
+			 * (?<=^|\s)(*smile*)(?=$|\s) using the lookbehind/lookahead operator instead of non-capturing groups.
+			 * This solves the problem that spaces are matched, too (see workaround in RsHtml::embedHtml)
+			 * This is not supported by Qt4!
+			 */
 		}
 	newRE.chop(1);	// remove last |
 	defEmbedImg.myRE.setPattern(newRE);
@@ -312,7 +338,21 @@ void RsHtml::embedHtml(QTextDocument *textDocument, QDomDocument& doc, QDomEleme
 							{
 								insertedTag = doc.createElement("img");
 								const EmbedInHtmlImg& embedImg = static_cast<const EmbedInHtmlImg&>(embedInfos);
-								insertedTag.setAttribute("src", embedImg.smileys[embedInfos.myRE.cap(0)]);
+								// embedInfos.myRE.cap(0) may include spaces at the end/beginning -> trim!
+								insertedTag.setAttribute("src", embedImg.smileys[embedInfos.myRE.cap(0).trimmed()]);
+								/*
+								 * NOTE
+								 * Trailing spaces are matched, too. This leads to embedInfos.myRE.matchedLength() being incorrect.
+								 * This hack reduces nextPos by one so that the new value of currentPos is calculated corretly.
+								 * This is needed to match multiple smileys since the leading whitespace in front of a smiley is required!
+								 *
+								 * This can be avoided by using Qt5 (see comment in RsHtml::initEmoticons)
+								 *
+								 * NOTE
+								 * Preceding spaces are also matched and removed.
+								 */
+								if(embedInfos.myRE.cap(0).endsWith(' '))
+									nextPos--;
 							}
 							break;
 				}


### PR DESCRIPTION
Only replace smileys with an image when they are surrounded by whitespaces.
This fixes smileys in links and other text that happen to include the sequence for a smiley.
