### PR TITLE
Automatic [De]Serialization

### DIFF
--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -112,7 +112,7 @@ PUBLIC_HEADERS =	retroshare/rsdisc.h \
 HEADERS += plugins/pluginmanager.h \
 		plugins/dlfcn_win32.h \
 		serialiser/rspluginitems.h \
-    util/rsinitedptr.h
+		util/rsinitedptr.h
 
 HEADERS += $$PUBLIC_HEADERS
 
@@ -456,6 +456,7 @@ HEADERS +=	serialiser/itempriorities.h \
 			serialiser/rsgxsrecognitems.h \
 			serialiser/rsgxsupdateitems.h \
 			serialiser/rsserviceinfoitems.h \
+			serialiser/rsautoserialize.h
 
 HEADERS +=	services/p3msgservice.h \
 			services/p3service.h \

--- a/libretroshare/src/serialiser/rsautoserialize.h
+++ b/libretroshare/src/serialiser/rsautoserialize.h
@@ -1,0 +1,374 @@
+#ifndef RSAUTOSERIALIZE_H
+#define RSAUTOSERIALIZE_H
+/*
+ * This file is part of libretroshare.
+ *
+ * Copyright (C) 2016 Gioacchino Mazzurco <gio@eigenlab.org>
+ *
+ * libretroshare is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libretroshare is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with libretroshare.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* DISCLAIMER!
+ *
+ * This file has exceptionally long lines that are ugly, this may seems a
+ * violation of libretroshare coding style but is not because those lines became
+ * even uglier if breaked.
+ *
+ * For more information about libretroshare coding style see:
+ * https://github.com/RetroShare/RetroShare/wiki/Coding
+ */
+
+/**
+ * @file rsautoserialize.h
+ * @brief RetroShare automatic [de]serialization.
+ * In RetroShare data is trasmitted between nodes in form of @see RsItem,
+ * historically each discendant type of RsItem and his members had his
+ * [de]serialization code written by hand, this has generated code and work
+ * duplication, subtle bugs and other undesired side effects, the code in this
+ * file is aimed to radically change that situation altought some compromise has
+ * been necessary (@see RsSerializer) to avoid breaking retrocompatibility.
+ *
+ * Make sure to read documentation on this file and in @see rstlvitem.h before
+ * taking any action about RetroShare [de]serialization.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include <ctime>
+
+#include "util/rsnet.h"
+
+/**
+ * @brief The RsSerializable Interface
+ * This interface is supposed to be implemented by serializable classes.
+ * To inherit from RsSerializable doesn't imply that the serialzation will
+ * follow a specific format.
+ * If you are about to implement a new serializable class you should not inherit
+ * direclty from RsSerializable as more functionalities you are probably
+ * interested in are already provided by more specialize classes such as
+ * @see RsAutoSerializable and @see RsAutoTlvSerializable.
+ */
+class RsSerializable
+{
+public:
+	/**
+	 * @brief serialize this object to the given buffer
+	 * @param data Chunk of memory were to dump the serialized data
+	 * @param size Size of memory chunk
+	 * @param offset Readed to determine at witch offset start writing data,
+	 *        written to inform caller were written data ends, the updated value
+	 *        is usually passed by the caller to serialize of another
+	 *        RsSerializable so it can write on the same chunk of memory just
+	 *        after where this RsSerializable has been serialized.
+	 * @return true if serialization successed, false otherwise
+	 */
+	virtual bool serialize(uint8_t data[], uint32_t size,
+	                       uint32_t &offset) const = 0;
+
+	/**
+	 * @brief Populate members by deserializing the given buffer
+	 * @param data Readonly data to read to generate the deserialized object
+	 * @param size Size of memory chunk
+	 * @param offset Readed to determine at witch offset start reading data,
+	 *        written to inform caller were read ended, the updated value is
+	 *        usually passed by the caller to deserialize of another
+	 *        RsSerializable so it can read the same chunk of memory just after
+	 *        where the deserialization of this RsSerializable has ended.
+	 * @return true if deserialization succeded false otherwise
+	 */
+	virtual bool deserialize(const uint8_t data[], uint32_t size,
+	                         uint32_t &offset) = 0;
+
+	/**
+	 * @brief serializedSize calculate the size in bytes of minimum buffer
+	 * needed to serialize this element
+	 * @return the calculated size
+	 */
+	virtual uint32_t serialSize() const = 0;
+};
+
+class RsAutoSerializable;
+
+/**
+ * After long discussion we have consensuated to provide retrocompatible
+ * [de]serialization of basic type also if not wrapped into an RsSerializable
+ * manly to reduce the impact on pre-existent code and make it easier to port it
+ * to the new serialization system (based on RsAutoSerializable), for this only
+ * purpose we provide non wrapping serializers with static methods.
+ * This has been written for RsAutoSerializable internal usage you should not
+ * implement more RsSerializer, neither you should inherit direclty from
+ * RsSerializer, or use it inside your own RsSerializable.
+ * If you have got here you are probably interested in what already provided by
+ * more specialized classes such as @see RsAutoTlvSerializable if you need to
+ * [de]serialize a basic type that is not already provided as an
+ * @see RsSerializer you should write a discendant of @see RsAutoTlvSerializable
+ * for that purpose.
+ */
+template<typename T> class RsSerializer {};
+
+
+/// Template to generate RsSerializer for standard integral types
+template<typename N, uint32_t SIZE> class t_SerializerNType
+{
+public:
+	static bool serialize(uint8_t data[], uint32_t size, uint32_t &offset,
+	                      const RsAutoSerializable * autoObj,
+	                      const int RsAutoSerializable::* member)
+	{
+		if (size <= offset || size - offset < SIZE) return false;
+		const N * absPtr = (const N *) &(autoObj->*member);
+		N tmp = hton<N>(*absPtr);
+		memcpy(data+offset, &tmp, SIZE);
+		offset += SIZE;
+		return true;
+	}
+	static bool deserialize(const uint8_t data[], uint32_t size,
+	                        uint32_t &offset, RsAutoSerializable * autoObj,
+	                        int RsAutoSerializable::* member)
+	{
+		if (size <= offset || size - offset < SIZE) return false;
+		N * absPtr = (N *) &(autoObj->*member);
+		memcpy(absPtr, data+offset, SIZE);
+		*absPtr = ntoh<N>(*absPtr);
+		offset += SIZE;
+		return true;
+	}
+	static inline uint32_t serializedSize() { return SIZE; }
+};
+
+template<> class RsSerializer<uint8_t> : public t_SerializerNType<uint8_t, 1>{};
+template<> class RsSerializer<uint16_t> : public t_SerializerNType<uint16_t, 2>{};
+template<> class RsSerializer<uint32_t> : public t_SerializerNType<uint32_t, 4>{};
+template<> class RsSerializer<uint64_t> : public t_SerializerNType<uint64_t, 8>{};
+template<> class RsSerializer<time_t> : public RsSerializer<uint64_t> {};
+
+/// Serializer for <b>non negative</b> float
+template<> class RsSerializer<float>
+{
+public:
+	static bool serialize(uint8_t data[], uint32_t size, uint32_t &offset,
+	                      const RsAutoSerializable * autoObj,
+	                      const int RsAutoSerializable::* member)
+	{
+		if ( !data || size <= offset ||
+		     size - offset < RsSerializer<float>::serializedSize() )
+			return false;
+
+		const float * absPtr = (const float *) &(autoObj->*member);
+		if(*absPtr < 0.0f)
+		{
+			std::cerr << "(EE) Cannot serialise invalid negative float value "
+			          << *absPtr << " in " << __PRETTY_FUNCTION__ << std::endl;
+			return false;
+		}
+
+		/* This serialisation is quite accurate. The max relative error is approx.
+		 * 0.01% and most of the time less than 1e-05% The error is well distributed
+		 * over numbers also. */
+		uint32_t n;
+		if(*absPtr < 1e-7) n = (~(uint32_t)0);
+		else n = ((uint32_t)( (1.0f/(1.0f+*absPtr) * (~(uint32_t)0))));
+		n = hton<uint32_t>(n);
+		memcpy(data+offset, &n, RsSerializer<float>::serializedSize());
+		offset += RsSerializer<float>::serializedSize();
+		return true;
+	}
+	static bool deserialize(const uint8_t data[], uint32_t size,
+	                        uint32_t &offset, RsAutoSerializable * autoObj,
+	                        int RsAutoSerializable::* member)
+	{
+		if ( !data || size <= offset ||
+		     size - offset < RsSerializer<float>::serializedSize() )
+			return false;
+
+		uint32_t n;
+		memcpy(&n, data+offset, RsSerializer<float>::serializedSize());
+		n = ntoh<uint32_t>(n);
+		float * absPtr = (float *) &(autoObj->*member);
+		*absPtr = 1.0f/ ( n/(float)(~(uint32_t)0)) - 1.0f;
+		return true;
+	}
+	static inline uint32_t serializedSize() { return 4; }
+};
+
+/// Serializer for std::string
+template<> class RsSerializer<std::string>
+{
+public:
+	static bool serialize(uint8_t data[], uint32_t size, uint32_t &offset,
+	                      const RsAutoSerializable * autoObj,
+	                      const int RsAutoSerializable::* member)
+	{
+		if ( !data || size <= offset ||
+		     size - offset < RsSerializer<std::string>::serializedSize(autoObj, member) )
+			return false;
+
+		const std::string * absPtr = (const std::string *) &(autoObj->*member);
+		uint32_t charsLen = absPtr->length();
+		uint32_t netLen = hton<uint32_t>(charsLen);
+		memcpy(data+offset, &netLen, 4); offset += 4;
+		memcpy(data+offset, absPtr->c_str(), charsLen); offset += charsLen;
+		return true;
+	}
+	static bool deserialize(const uint8_t data[], uint32_t size,
+	                        uint32_t &offset, RsAutoSerializable * autoObj,
+	                        int RsAutoSerializable::* member)
+	{
+		if ( !data || size <= offset || size - offset < 4 ) return false;
+		uint32_t charsLen;
+		memcpy(&charsLen, data+offset, 4); offset += 4;
+		charsLen = ntoh<uint32_t>(charsLen);
+
+		if ( size <= offset || size - offset < charsLen ) return false;
+		std::string * absPtr = (std::string *) &(autoObj->*member);
+		absPtr->clear();
+		absPtr->insert(0, (char*)data+offset, charsLen);
+		offset += charsLen;
+		return true;
+	}
+	static inline uint32_t serializedSize(const RsAutoSerializable * autoObj,
+	                                      const int RsAutoSerializable::* member)
+	{
+		const std::string * absPtr = (const std::string *) &(autoObj->*member);
+		return absPtr->length() + 4;
+	}
+};
+
+/**
+ * @brief Base class for RetroShare automatics [de]serializable classes
+ * Provide auto-[de]serialization for members of RsSerializable discendant types
+ * and for some standard C++ types.
+ * Members that wanna be auto-[de]serialized must be registered in constructor.
+ */
+class RsAutoSerializable : public RsSerializable
+{
+public:
+	uint32_t serialSize() const
+	{
+		uint32_t acc = 0;
+		std::vector<std::pair<ObjectType,int RsAutoSerializable::*> >::const_iterator it;
+		for(it = mToSerialise.begin(); it != mToSerialise.end(); ++it)
+		{
+			switch((*it).first)
+			{
+			case OBJECT_TYPE_UINT8:  acc += RsSerializer<uint8_t>::serializedSize(); break;
+			case OBJECT_TYPE_UINT16: acc += RsSerializer<uint16_t>::serializedSize(); break;
+			case OBJECT_TYPE_UINT32: acc += RsSerializer<uint32_t>::serializedSize(); break;
+			case OBJECT_TYPE_UINT64: acc += RsSerializer<uint64_t>::serializedSize(); break;
+			case OBJECT_TYPE_UFLOAT32:
+			case OBJECT_TYPE_TIME:
+			case OBJECT_TYPE_STR: acc += RsSerializer<std::string>::serializedSize(this, (*it).second); break;
+			/* For RsSerializable discendant objects. We need to cast to
+			 * RsSerializable and call the pure virtual serialize(...) method
+			 * and C++ dynamic dispatch will take care of calling serialize(...)
+			 * for the original object class */
+			case OBJECT_TYPE_SRZ: acc += (this->*reinterpret_cast<RsSerializable RsAutoSerializable::*>((*it).second)).serialSize(); break;
+			}
+		}
+		return acc;
+	}
+	bool serialize(uint8_t data[], uint32_t size, uint32_t &offset) const
+	{
+		if ( !data || size <= offset || size - offset < serialSize() )
+			return false;
+
+		bool ok = true;
+		std::vector<std::pair<ObjectType,int RsAutoSerializable::*> >::const_iterator it;
+		for(it = mToSerialise.begin(); ok && it != mToSerialise.end(); ++it)
+		{
+			switch((*it).first)
+			{
+			case OBJECT_TYPE_UINT8:  ok &= RsSerializer<uint8_t>::serialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UINT16: ok &= RsSerializer<uint16_t>::serialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UINT32: ok &= RsSerializer<uint32_t>::serialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UINT64: ok &= RsSerializer<uint64_t>::serialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UFLOAT32:
+			case OBJECT_TYPE_TIME:
+			case OBJECT_TYPE_STR: ok &= RsSerializer<std::string>::serialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_SRZ: ok &= (this->*reinterpret_cast<RsSerializable RsAutoSerializable::*>((*it).second)).serialize(data, size, offset); break;
+			}
+		}
+		return ok;
+	}
+	bool deserialize(const uint8_t data[], uint32_t size, uint32_t &offset)
+	{
+		if ( !data || size <= offset ) return false;
+		/* Can't check if there is enough space because serialSize() may return
+		 * an unvalid value here as empty variable size members can be presents
+		 * this is not unsafe as sub member::deserialize(...) will check it. */
+
+		bool ok = true;
+		std::vector<std::pair<ObjectType,int RsAutoSerializable::*> >::const_iterator it;
+		for(it = mToSerialise.begin(); ok && it != mToSerialise.end(); ++it)
+		{
+			switch((*it).first)
+			{
+			case OBJECT_TYPE_UINT8:  ok &= RsSerializer<uint8_t>::deserialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UINT16: ok &= RsSerializer<uint16_t>::deserialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UINT32: ok &= RsSerializer<uint32_t>::deserialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UINT64: ok &= RsSerializer<uint64_t>::deserialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_UFLOAT32: ok &= RsSerializer<float>::deserialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_TIME: ok &= RsSerializer<time_t>::deserialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_STR: ok &= RsSerializer<std::string>::deserialize(data, size, offset, this, (*it).second); break;
+			case OBJECT_TYPE_SRZ: ok &= (this->*reinterpret_cast<RsSerializable RsAutoSerializable::*>((*it).second)).deserialize(data, size, offset); break;
+			}
+		}
+		return ok;
+	}
+
+protected:
+	/**
+	 * Derivative classes must use this function to register members for
+	 * automatic [de]serialization in constructor.
+	 */
+	template<class A, class T> void registerSerializable(T A::* member) { mToSerialise.push_back( std::make_pair(objectType<T>(),reinterpret_cast<int RsAutoSerializable::*>(member))); }
+
+private:
+	/**
+	 * Used internally to keep track of type of registered for [de]serialization
+	 * members.
+	 */
+	enum ObjectType
+	{
+		OBJECT_TYPE_UINT8    = 0x01, // Integral C++ base types
+		OBJECT_TYPE_UINT16   = 0x02,
+		OBJECT_TYPE_UINT32   = 0x03,
+		OBJECT_TYPE_UINT64   = 0x04,
+		OBJECT_TYPE_UFLOAT32 = 0x05, // Unsigned Float
+		OBJECT_TYPE_TIME     = 0x06, // time_t
+		OBJECT_TYPE_STR      = 0x20, // C++ std::string
+		OBJECT_TYPE_SRZ      = 0x30  // RsSerializable and derivatives
+	};
+
+	/// Map C++ types into corresponding ObjectType
+	template<class T> ObjectType objectType();
+
+	/**
+	 * Keep track of members and associated ObjectType registered for automatic
+	 * [de]serialization.
+	 */
+	std::vector<std::pair<ObjectType,int RsAutoSerializable::*> > mToSerialise;
+};
+
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<uint8_t>()        { return OBJECT_TYPE_UINT8; }
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<uint16_t>()       { return OBJECT_TYPE_UINT16; }
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<uint32_t>()       { return OBJECT_TYPE_UINT32; }
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<uint64_t>()       { return OBJECT_TYPE_UINT64; }
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<float>()          { return OBJECT_TYPE_UFLOAT32; }
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<time_t>()         { return OBJECT_TYPE_TIME; }
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<std::string>()    { return OBJECT_TYPE_STR; }
+template<> inline RsAutoSerializable::ObjectType RsAutoSerializable::objectType<RsSerializable>() { return OBJECT_TYPE_SRZ; }
+
+#endif // RSAUTOSERIALIZE_H

--- a/libretroshare/src/serialiser/rsbaseserial.h
+++ b/libretroshare/src/serialiser/rsbaseserial.h
@@ -31,7 +31,9 @@
 #include <stdint.h>
 #include <retroshare/rsids.h>
 
-/*******************************************************************
+/**
+ * @deprecated @see rsautoserialize.h and @see rstlvitem.h instead
+ *
  * This is at the lowlevel packing routines. They are usually 
  * created in pairs - one to pack the data, the other to unpack.
  *
@@ -46,7 +48,7 @@
  *
  * *in / *out - the data to (un)pack.
  *
- ******************************************************************/
+ */
 
 bool getRawUInt8(void *data, uint32_t size, uint32_t *offset, uint8_t *out);
 bool setRawUInt8(void *data, uint32_t size, uint32_t *offset, uint8_t in);

--- a/libretroshare/src/serialiser/rstlvbase.h
+++ b/libretroshare/src/serialiser/rstlvbase.h
@@ -26,7 +26,9 @@
  */
 
 
-/*******************************************************************
+/**
+ * @deprecated @see rsautoserialize.h and @see rstlvitem.h instead
+ *
  * These are the general TLV (un)packing routines.
  *
  * Data is Serialised into the following format
@@ -59,7 +61,7 @@
  *
  * *in / *out - the data to (un)pack.
  *
- ******************************************************************/
+ */
 
 #include <inttypes.h>
 #include <string>

--- a/libretroshare/src/serialiser/rstlvitem.h
+++ b/libretroshare/src/serialiser/rstlvitem.h
@@ -5,6 +5,7 @@
  * RetroShare Serialiser.
  *
  * Copyright 2007-2008 by Robert Fernie, Chris Parker
+ * Copyright (C) 2016 Gioacchino Mazzurco <gio@eigenlab.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -24,59 +25,262 @@
  *
  */
 
-/*******************************************************************
- * These are the Compound TLV structures that must be (un)packed.
+/* DISCLAIMER!
  *
- ******************************************************************/
+ * This file has exceptionally long lines that are ugly, this may seems a
+ * violation of libretroshare coding style but is not because those lines became
+ * even uglier if breaked.
+ *
+ * For more information about libretroshare coding style see:
+ * https://github.com/RetroShare/RetroShare/wiki/Coding
+ */
+
+/**
+ * @file rsautotlvitem.h
+ * @brief RetroShare automatic TLV [de]serialization.
+ * When an object is serialized all type information handled by the language is
+ * lost, this cause that on deserialization the code have to simply trust the
+ * data and try convert it to the expected object, if everything go as expected
+ * we obtain the "same" object that the other RetroShare instance sent to us,
+ * but the assumption that everything goes as expected depends on the fact that
+ * the two istances uses the same code and that the software has no bugs which
+ * is usually not true.
+ * To reduce the intrinsic unsafenes of deserialization a TLV (Type, Lenght,
+ * Value) format should be adopted, for RsItem members (RsItem itself already
+ * have his own format), with an unsigned 16bit field used as type, and then a
+ * 32bit field used as leght. A serialized TLV would look like this:
+ *
+ * -----------------------------
+ * |      (T) Type 2 bytes     |
+ * |---------------------------|
+ * |     (L) Lenght 4 bytes    |
+ * |---------------------------|
+ * |     (V) Value L bytes     |
+ * |                           |
+ * |                           |
+ * -----------------------------
+ *
+ * Resuming a serialized RsItem containing two TLV (let's call them TLV1 and
+ * TLV2 for simplicity) members would look like:
+ *
+ * -----------------------------
+ * |    RsItem type 4 bytes    |
+ * |---------------------------|
+ * |   RsItem Lenght 4 bytes   |
+ * |---------------------------|
+ * |        T1  2 bytes        |
+ * |---------------------------|
+ * |        L1  4 bytes        |
+ * |---------------------------|
+ * |                           |
+ * |        V1 L1 bytes        |
+ * |                           |
+ * |---------------------------|
+ * |        T2  2 bytes        |
+ * |---------------------------|
+ * |        L2  4 bytes1       |
+ * |---------------------------|
+ * |                           |
+ * |        V2 L2 bytes        |
+ * |                           |
+ * -----------------------------
+ *
+ * TLV type has local meaning, so there is no need to keep them unique accross
+ * RetroShare code but it is suggested to keep them unique inside the same
+ * RsSerializable, type check is not enforced by default to enforce it the
+ * CHECK_TYPE flag must be set on the TLV type, more flags are available like
+ * MANDATORY that enforces the type is checked and that the member is populated
+ * if the deserialization is successful @see RsAutoTlvSerializable::TlvFlags for
+ * more details about TLV flags.
+ *
+ * Take advantage of this is very simple the following example should be enoungh
+ * to understand how to develop your own TLV:
+
+class ExampleHomeAddressTlv : public RsAutoTlvSerializable
+{
+public:
+	ExampleHomeAddressTlv(uint16_t type=0) : RsAutoTlvSerializable(type),
+	  // street has type 1 and is mandatory
+	  street("Via dei ciliegi", MANDATORY|1),
+	  // street_number type is checked but is not a mandatory member
+	  street_number(39, CHECK_TYPE|2),
+	  // zip_code has type 3 and is mandatory
+	  zip_code(47833, MANDATORY|3),
+	  // door has type 4 and is not mandatory and type is not checked
+	  door("", ~MANDATORY&4),
+	  // You can automatically [de]serialize raw standard types supported by
+	  // RsAutoTlvSerializable but without TLV checks
+	  odd("")
+	{
+		registerSerializable(&ExampleHomeAddressTlv::street);
+		registerSerializable(&ExampleHomeAddressTlv::street_number);
+		registerSerializable(&ExampleHomeAddressTlv::zip_code);
+		registerSerializable(&ExampleHomeAddressTlv::odd);
+		//registerSerializable(&ExampleHomeAddressTlv::another_member);
+	}
+
+	RsAutoTlvWrap<std::string> street;
+	RsAutoTlvWrap<uint32_t> street_number;
+	RsAutoTlvWrap<uint32_t> zip_code;
+	RsAutoTlvWrap<std::string> door;
+	std::string odd;
+	//MyRsSerializable another_member;
+};
+
+ */
 
 #include <iosfwd>
 #include <string>
 #include <inttypes.h>
+#include <vector>
 
-//! A base class for all tlv items 
-/*! This class is provided to allow the serialisation and deserialization of compund 
-tlv items 
-*/
-class RsTlvItem
+#include "serialiser/rstlvbase.h"
+#include "serialiser/rsautoserialize.h"
+
+/**
+ * @brief DEPRECATED A base class for Type Length Value items
+ * If you are about to implement a new TLV you should <b>not</b> inherit
+ * direclty from RsTlvItem as this class is kept just for retrocompatibility
+ * purpose and should be not used anymore @see RsAutoTlv instead.
+ */
+class RsTlvItem : public RsSerializable
 {
-	public:
-	 RsTlvItem() { return; }
-virtual ~RsTlvItem() { return; }
-virtual uint32_t TlvSize() const = 0;
-virtual void	 TlvClear() = 0;
-virtual	void	 TlvShallowClear(); /*! Don't delete allocated data */
-virtual bool     SetTlv(void *data, uint32_t size, uint32_t *offset) const = 0; /* serialise   */
-virtual bool     GetTlv(void *data, uint32_t size, uint32_t *offset) = 0; /* deserialise */
-virtual std::ostream &print(std::ostream &out, uint16_t indent) const = 0;
-std::ostream &printBase(std::ostream &out, std::string clsName, uint16_t indent) const;
-std::ostream &printEnd(std::ostream &out, std::string clsName, uint16_t indent) const;
+public:
+	RsTlvItem() {}
+	virtual ~RsTlvItem() {}
+	virtual uint32_t TlvSize() const;
+
+	/**
+	 * @brief clear members and delete them if dinamically allocated.
+	 * Must be overriden by derived classes.
+	 * By default it call the deprecated version for retrocompatibility but this
+	 * should be made pure virtual in future.
+	 */
+	virtual void TlvClear();
+
+	/**
+	 * @brief shallowClear is meant to clear members without deleting them if
+	 * dinamically allocated.
+	 * Should be overriden by derived classes.
+	 * If not overridden call clear().
+	 */
+	virtual	void TlvShallowClear() { TlvClear(); }
+
+	virtual bool GetTlv(void *data, uint32_t size, uint32_t *offset)
+	{ return deserialize((const uint8_t *) data, size, *offset); }
+	virtual bool SetTlv(void *data, uint32_t size, uint32_t *offset) const
+	{ return serialize((uint8_t *)data, size, *offset); }
+	virtual std::ostream &print(std::ostream &out, uint16_t indent) const;
+	std::ostream &printBase(std::ostream &out, std::string clsName, uint16_t indent) const;
+	std::ostream &printEnd(std::ostream &out, std::string clsName, uint16_t indent) const;
+
+	/// Forward compatibility with @see RsSerializable
+	virtual uint32_t serialSize() const;
+	virtual bool serialize(uint8_t data[], uint32_t size, uint32_t &offset) const;
+	virtual bool deserialize(const uint8_t data[], uint32_t size, uint32_t &offset);
+};
+
+/**
+ * @brief The base class for automatized TLV [de]serialization.
+ * Inherit from this class if you are about to implement a new TLV serializable
+ * or are renewing an existing one, retrocompatibility with @see RsTlvItem is
+ * kept both in terms of API and serialized format.
+ * Use class members as building blocks of your derived RsAutoTlvSerializable
+ * then register them for automatic [de]serialization in constructor with
+ * registerSerializable(...), this way your class will benefit of automatic TLV
+ * [de]serialization without writing a single line of boring code.
+ * In addition to what provided by @see RsAutoSerializable this class provide
+ * extra safety by checking Type on the TLV encoded received data against the
+ * initialization type of the item, @see TlvFlags permits to control the
+ * strictness of the check.
+ */
+class RsAutoTlvSerializable : public RsAutoSerializable, public RsTlvItem
+{
+public:
+	/**
+	 * @brief [de]serialization behavior flags
+	 * This flags are matched against TLV type to determine [de]serialization
+	 * behaviour.
+	 */
+	enum TlvFlags
+	{
+		/**
+		 * If CHECK_TYPE flag is set deserialize(...) check if the buffer match
+		 * the expected TLV type, if it doesn't match skipTlv(...) is returned
+		 * leaving the members untouched.
+		 */
+		CHECK_TYPE = 0x8000,
+
+		/**
+		 * If MANDATORY flag is set deserialize(...) check if the buffer match
+		 * the expected TLV type, if it doesn't match restore the previous state
+		 * and return false to inform the caller that the serialization failed.
+		 */
+		MANDATORY = CHECK_TYPE + 0x4000, // = 0xc000
+	};
+
+	/**
+	 * @brief initialize at_type to given value and register members for
+	 * automatic [de]serialization @see RsAutoTlvItem.at_type for more details.
+	 */
+	RsAutoTlvSerializable(uint16_t type=0) : at_type(type)
+	{
+		registerSerializable(&RsAutoTlvSerializable::at_type);
+		registerSerializable(&RsAutoTlvSerializable::at_lenght);
+	}
+
+	/**
+	 * @brief @see RsSerializable
+	 * Set at_lenght and then call @see RsAutoSerializable::serialize(...)
+	 */
+	bool serialize(uint8_t data[], uint32_t size, uint32_t &offset) const;
+
+	/**
+	 * @brief @see RsSerializable
+	 * Check conformance of buffer with TLV type and setted @see TlvFlags and if
+	 * ok call * @see RsAutoSerializable::deserialize(...)
+	 */
+	bool deserialize(const uint8_t data[], uint32_t size, uint32_t &offset);
+
+	/**
+	 * @brief Get Item TLV type setted during initalization or deserialization.
+	 * @return Item TLV type.
+	 */
+	uint16_t getTlvItemType() { return at_type; }
+
+protected:
+	/**
+	 * @brief SkipTlv skip TLV without concerning about type or value
+	 * @param data @see deserialize
+	 * @param size @see deserialize
+	 * @param offset @see deserialize
+	 * @return true if skipping success, false otherwise
+	 */
+	static bool skipTlv(const uint8_t data[], uint32_t size, uint32_t &offset);
+
+private:
+	/**
+	 * @brief at_type TLV type for this item
+	 * The initialization value influence the deserialization bahaviour,
+	 * @see TlvFlags.
+	 * On serialization this value is used as serialized TLV type.
+	 */
+	uint16_t at_type;
+
+	/// @brief Store TLV lenght
+	uint32_t at_lenght;
+};
+
+/**
+ * Template to generate RsAutoTlvSerializable wrappers for standard types
+ * supported by @see RsAutoSerializable
+ */
+template<typename N> class RsAutoTlvWrap : public RsAutoTlvSerializable
+{
+public:
+	RsAutoTlvWrap(const N &val, uint16_t type=0) : RsAutoTlvSerializable(type),
+	    value(val) { registerSerializable(&RsAutoTlvWrap::value); }
+	N value;
 };
 
 std::ostream &printIndent(std::ostream &out, uint16_t indent);
-
-
-class RsTlvUnit: public RsTlvItem
-{
-	public:
-	 RsTlvUnit(uint16_t tlv_type);
-virtual ~RsTlvUnit() { return; }
-virtual uint32_t TlvSize() const;
-virtual bool     SetTlv(void *data, uint32_t size, uint32_t *offset) const;
-virtual bool     GetTlv(void *data, uint32_t size, uint32_t *offset);
-
-virtual uint16_t TlvType() const { return mTlvType; }
-
-// These Functions need to be implemented.
-//virtual void	 TlvClear() = 0;
-//virtual std::ostream &print(std::ostream &out, uint16_t indent) = 0 const;
-
-virtual uint32_t TlvSizeUnit() const = 0;
-virtual bool     SetTlvUnit(void *data, uint32_t size, uint32_t *offset) const = 0;
-virtual bool     GetTlvUnit(void *data, uint32_t size, uint32_t *offset) = 0;
-
-
-	private:
-	uint16_t mTlvType;
-};
-
-

--- a/libretroshare/src/serialiser/rstlvitem.h
+++ b/libretroshare/src/serialiser/rstlvitem.h
@@ -138,10 +138,12 @@ public:
 #include "serialiser/rsautoserialize.h"
 
 /**
- * @brief DEPRECATED A base class for Type Length Value items
+ * @deprecated @see RsAutoTlvSerializable instead
+ *
+ * @brief A base class for Type Length Value items
  * If you are about to implement a new TLV you should <b>not</b> inherit
  * direclty from RsTlvItem as this class is kept just for retrocompatibility
- * purpose and should be not used anymore @see RsAutoTlv instead.
+ * purpose and should be not used anymore @see RsAutoTlvSerializable instead.
  */
 class RsTlvItem : public RsSerializable
 {

--- a/libretroshare/src/util/rsnet.h
+++ b/libretroshare/src/util/rsnet.h
@@ -57,7 +57,10 @@ int inet_aton(const char *name, struct in_addr *addr);
 #endif
 /********************************** WINDOWS/UNIX SPECIFIC PART ******************/
 
-/* 64 bit conversions */
+/**
+ * @brief 64 bit host to network and back conversions
+ * Dont use this directly use templated ntoh instead
+ */
 #ifndef ntohll
 uint64_t ntohll(uint64_t x);
 #endif

--- a/libretroshare/src/util/rsnet.h
+++ b/libretroshare/src/util/rsnet.h
@@ -65,6 +65,20 @@ uint64_t ntohll(uint64_t x);
 uint64_t htonll(uint64_t x);
 #endif
 
+/// Convert from network to host byte order
+template<typename T> T ntoh(T x);
+template<> inline uint8_t ntoh<uint8_t>(uint8_t x) { return x; }
+template<> inline uint16_t ntoh<uint16_t>(uint16_t x) { return ntohs(x); }
+template<> inline uint32_t ntoh<uint32_t>(uint32_t x) { return ntohl(x); }
+template<> inline uint64_t ntoh<uint64_t>(uint64_t x) { return ntohll(x); }
+
+/// Convert from host to network byte order
+template<typename T> T hton(T x);
+template<> inline uint8_t hton<uint8_t>(uint8_t x) { return x; }
+template<> inline uint16_t hton<uint16_t>(uint16_t x) { return htons(x); }
+template<> inline uint32_t hton<uint32_t>(uint32_t x) { return htonl(x); }
+template<> inline uint64_t hton<uint64_t>(uint64_t x) { return htonll(x); }
+
 /* blank a network address */
 void sockaddr_clear(struct sockaddr_in *addr);
 


### PR DESCRIPTION
Implemented automatic [de]serialization based on RsAutoSerializable and RsAutoTlvSerializable, this is a radical change for RetroShare but retro-compatibility is kept and things has been made so the porting to the new [de]serialization is easy and can be progressive
