### PR TITLE
fixed wrong SearchDialog.h includes

### DIFF
--- a/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
@@ -43,7 +43,7 @@
 #include "DLListDelegate.h"
 #include "ULListDelegate.h"
 #include "FileTransferInfoWidget.h"
-#include <gui/SearchDialog.h>
+#include <gui/FileTransfer/SearchDialog.h>
 #include <gui/SharedFilesDialog.h>
 #include "xprogressbar.h"
 #include <gui/settings/rsharesettings.h>

--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -40,7 +40,7 @@
 #include "ui_MainWindow.h"
 #include "MessengerWindow.h"
 #include "NetworkDialog.h"
-#include "SearchDialog.h"
+#include "FileTransfer/SearchDialog.h"
 #include "gui/FileTransfer/TransfersDialog.h"
 #include "MessagesDialog.h"
 #include "SharedFilesDialog.h"

--- a/retroshare-gui/src/gui/RetroShareLink.cpp
+++ b/retroshare-gui/src/gui/RetroShareLink.cpp
@@ -38,7 +38,7 @@
 #include "MainWindow.h"
 #include "gui/gxsforums/GxsForumsDialog.h"
 #include "gui/gxschannels/GxsChannelDialog.h"
-#include "SearchDialog.h"
+#include "FileTransfer/SearchDialog.h"
 #include "msgs/MessageComposer.h"
 #include "util/misc.h"
 #include "common/PeerDefs.h"

--- a/retroshare-gui/src/main.cpp
+++ b/retroshare-gui/src/main.cpp
@@ -25,7 +25,7 @@
 #include <rshare.h>
 #include "gui/MainWindow.h"
 #include "gui/FriendsDialog.h"
-#include "gui/SearchDialog.h"
+#include "gui/FileTransfer/SearchDialog.h"
 #include "gui/FileTransfer/TransfersDialog.h"
 #include "gui/SharedFilesDialog.h"
 #include "gui/NetworkDialog.h"


### PR DESCRIPTION
In 94b586846e294ba14f36811e79d7acc72ec2d71b the search dialog was moved. This pr fixes wrong include paths.
