### PR TITLE
Fix Quote Lines With Image

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -1693,6 +1693,7 @@ void ChatWidget::quote()
 	{
 		QStringList sl = text.split(QRegExp("[\r\n]"),QString::SkipEmptyParts);
 		text = sl.join("\n>");
+		text.replace(QChar(-4),"");//Char used when image on text.
 		emit ui->chatTextEdit->append(QString(">") + text);
 	}
 }

--- a/retroshare-gui/src/gui/common/MimeTextEdit.cpp
+++ b/retroshare-gui/src/gui/common/MimeTextEdit.cpp
@@ -269,7 +269,7 @@ void MimeTextEdit::pasteOwnCertificateLink()
 
 void MimeTextEdit::pastePlainText()
 {
-	insertPlainText(QApplication::clipboard()->text());
+	insertPlainText(QApplication::clipboard()->text().remove(QChar(-4)));//Char used when image on text.
 }
 
 void MimeTextEdit::spoiler()

--- a/retroshare-gui/src/util/HandleRichText.cpp
+++ b/retroshare-gui/src/util/HandleRichText.cpp
@@ -1067,6 +1067,7 @@ QString RsHtml::makeQuotedText(RSTextBrowser *browser)
 	}
 	QStringList sl = text.split(QRegExp("[\r\n]"),QString::SkipEmptyParts);
 	text = sl.join("\n>");
+	text.replace(QChar(-4),"");//Char used when image on text.
 	return QString(">") + text;
 }
 


### PR DESCRIPTION
When get text with image from toPlainText(), a (-4) char is inserted.
