### PR TITLE
Save last state of OpMode status bar droplist and restore it at start.

### DIFF
--- a/retroshare-gui/src/gui/qss/stylesheet/qss.default
+++ b/retroshare-gui/src/gui/qss/stylesheet/qss.default
@@ -217,3 +217,23 @@ GenCertDialog QLabel#entropy_label
 {
 	qproperty-fontSizeFactor: 115;
 }
+
+/* OpModeStatus need to be at end to overload other values*/
+OpModeStatus {
+	qproperty-opMode_Full_Color: #CCFFCC;
+	qproperty-opMode_NoTurtle_Color: #CCCCFF;
+	qproperty-opMode_Gaming_Color: #FFFFCC;
+	qproperty-opMode_Minimal_Color: #FFCCCC;
+}
+OpModeStatus[opMode="Full"] {
+	background: #CCFFCC;
+}
+OpModeStatus[opMode="NoTurtle"] {
+	background: #CCCCFF;
+}
+OpModeStatus[opMode="Gaming"] {
+	background: #FFFFCC;
+}
+OpModeStatus[opMode="Minimal"] {
+	background: #FFCCCC;
+}

--- a/retroshare-gui/src/gui/statusbar/OpModeStatus.cpp
+++ b/retroshare-gui/src/gui/statusbar/OpModeStatus.cpp
@@ -15,7 +15,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor,
  *  Boston, MA  02110-1301, USA.
  ****************************************************************/
 
@@ -23,25 +23,39 @@
 #include <QLabel>
 
 #include "gui/statusbar/OpModeStatus.h"
+#include "gui/settings/rsharesettings.h"
+
 #include <retroshare/rsconfig.h>
+
 #include <iostream>
 
 OpModeStatus::OpModeStatus(QWidget *parent)
- : QComboBox(parent)
+	: QComboBox(parent)
 {
+	onUpdate = false;
+	opMode_Full_Color = QColor("#CCFFCC");
+	opMode_NoTurtle_Color = QColor("#CCCCFF");
+	opMode_Gaming_Color = QColor("#FFFFCC");
+	opMode_Minimal_Color = QColor("#FFCCCC");
+
 	/* add the options */
 	addItem(tr("Normal Mode"), RS_OPMODE_FULL);
+	setItemData(0, opMode_Full_Color, Qt::BackgroundRole);
 	addItem(tr("No Anon D/L"), RS_OPMODE_NOTURTLE);
+	setItemData(1, opMode_NoTurtle_Color, Qt::BackgroundRole);
 	addItem(tr("Gaming Mode"), RS_OPMODE_GAMING);
+	setItemData(2, opMode_Gaming_Color, Qt::BackgroundRole);
 	addItem(tr("Low Traffic"), RS_OPMODE_MINIMAL);
+	setItemData(3, opMode_Minimal_Color, Qt::BackgroundRole);
 
 	connect(this, SIGNAL(activated( int )), this, SLOT(setOpMode()));
 
+	setCurrentIndex(Settings->valueFromGroup("StatusBar", "OpMode", QVariant(0)).toInt());
+	setOpMode();
 	setToolTip(tr("Use this DropList to quickly change Retroshare's behaviour\n No Anon D/L: switches off file forwarding\n Gaming Mode: 25% standard traffic and TODO: reduced popups\n Low Traffic: 10% standard traffic and TODO: pauses all file-transfers"));
 
 	setFocusPolicy(Qt::ClickFocus);
 }
-
 
 void OpModeStatus::getOpMode()
 {
@@ -51,17 +65,26 @@ void OpModeStatus::getOpMode()
 		default:
 		case RS_OPMODE_FULL:
 			setCurrentIndex(0);
-			break;
+			setProperty("opMode", "Full");
+		break;
 		case RS_OPMODE_NOTURTLE:
 			setCurrentIndex(1);
-			break;
+			setProperty("opMode", "NoTurtle");
+		break;
 		case RS_OPMODE_GAMING:
 			setCurrentIndex(2);
-			break;
+			setProperty("opMode", "Gaming");
+		break;
 		case RS_OPMODE_MINIMAL:
 			setCurrentIndex(3);
-			break;
+			setProperty("opMode", "Minimal");
+		break;
 	}
+	onUpdate = true;
+	style()->unpolish(this);
+	style()->polish(this);
+	update();
+	onUpdate = false;
 }
 
 void OpModeStatus::setOpMode()
@@ -69,14 +92,65 @@ void OpModeStatus::setOpMode()
 	std::cerr << "OpModeStatus::setOpMode()";
 	std::cerr << std::endl;
 
-        int idx = currentIndex();
-        QVariant var = itemData(idx);
-        uint32_t opMode = var.toUInt();
+	int idx = currentIndex();
+	QVariant var = itemData(idx);
+	uint32_t opMode = var.toUInt();
 
 	rsConfig->setOperatingMode(opMode);
 
 	// reload to be safe.
 	getOpMode();
+	Settings->setValueToGroup("StatusBar", "OpMode", idx);
 }
 
+QColor OpModeStatus::getOpMode_Full_Color() const
+{
+	return opMode_Full_Color;
+}
 
+void OpModeStatus::setOpMode_Full_Color( QColor c )
+{
+	opMode_Full_Color = c;
+	setItemData(0, opMode_Full_Color, Qt::BackgroundRole);
+	if (!onUpdate)
+		getOpMode();
+}
+
+QColor OpModeStatus::getOpMode_NoTurtle_Color() const
+{
+	return opMode_NoTurtle_Color;
+}
+
+void OpModeStatus::setOpMode_NoTurtle_Color( QColor c )
+{
+	opMode_NoTurtle_Color = c;
+	setItemData(1, opMode_NoTurtle_Color, Qt::BackgroundRole);
+	if (!onUpdate)
+		getOpMode();
+}
+
+QColor OpModeStatus::getOpMode_Gaming_Color() const
+{
+	return opMode_Gaming_Color;
+}
+
+void OpModeStatus::setOpMode_Gaming_Color( QColor c )
+{
+	opMode_Gaming_Color = c;
+	setItemData(2, opMode_Gaming_Color, Qt::BackgroundRole);
+	if (!onUpdate)
+		getOpMode();
+}
+
+QColor OpModeStatus::getOpMode_Minimal_Color() const
+{
+	return opMode_Minimal_Color;
+}
+
+void OpModeStatus::setOpMode_Minimal_Color( QColor c )
+{
+	opMode_Minimal_Color = c;
+	setItemData(3, opMode_Minimal_Color, Qt::BackgroundRole);
+	if (!onUpdate)
+		getOpMode();
+}

--- a/retroshare-gui/src/gui/statusbar/OpModeStatus.h
+++ b/retroshare-gui/src/gui/statusbar/OpModeStatus.h
@@ -15,7 +15,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor,
  *  Boston, MA  02110-1301, USA.
  ****************************************************************/
 #ifndef OP_MODE_STATUS_H
@@ -26,16 +26,37 @@
 class OpModeStatus : public QComboBox
 {
 	Q_OBJECT
+	Q_PROPERTY(QColor opMode_Full_Color READ getOpMode_Full_Color WRITE setOpMode_Full_Color DESIGNABLE true)
+	Q_PROPERTY(QColor opMode_NoTurtle_Color READ getOpMode_NoTurtle_Color WRITE setOpMode_NoTurtle_Color DESIGNABLE true)
+	Q_PROPERTY(QColor opMode_Gaming_Color READ getOpMode_Gaming_Color WRITE setOpMode_Gaming_Color DESIGNABLE true)
+	Q_PROPERTY(QColor opMode_Minimal_Color READ getOpMode_Minimal_Color WRITE setOpMode_Minimal_Color DESIGNABLE true)
 
 public:
 	OpModeStatus(QWidget *parent = 0);
 
+	QColor getOpMode_Full_Color() const;
+	void setOpMode_Full_Color( QColor c );
+
+	QColor getOpMode_NoTurtle_Color() const;
+	void setOpMode_NoTurtle_Color( QColor c );
+
+	QColor getOpMode_Gaming_Color() const;
+	void setOpMode_Gaming_Color( QColor c );
+
+	QColor getOpMode_Minimal_Color() const;
+	void setOpMode_Minimal_Color( QColor c );
+
 private slots:
-    	void setOpMode();
+	void setOpMode();
 
 private:
 	void getOpMode();
 
+	QColor opMode_Full_Color;
+	QColor opMode_NoTurtle_Color;
+	QColor opMode_Gaming_Color;
+	QColor opMode_Minimal_Color;
+	bool onUpdate;
 };
 
 #endif

--- a/retroshare-gui/src/qss/blacknight.qss
+++ b/retroshare-gui/src/qss/blacknight.qss
@@ -273,4 +273,22 @@ QTextEdit {
 	color: white;
 }
 
-
+/* OpModeStatus need to be at end to overload other values*/
+OpModeStatus {
+	qproperty-opMode_Full_Color: #007000;
+	qproperty-opMode_NoTurtle_Color: #000070;
+	qproperty-opMode_Gaming_Color: #707000;
+	qproperty-opMode_Minimal_Color: #700000;
+}
+OpModeStatus[opMode="Full"] {
+	background: #007000;
+}
+OpModeStatus[opMode="NoTurtle"] {
+	background: #000070;
+}
+OpModeStatus[opMode="Gaming"] {
+	background: #707000;
+}
+OpModeStatus[opMode="Minimal"] {
+	background: #700000;
+}

--- a/retroshare-gui/src/qss/qdarkstyle.qss
+++ b/retroshare-gui/src/qss/qdarkstyle.qss
@@ -1058,3 +1058,22 @@ QStatusBar::item {
     border-radius: 3px;
  }
 
+/* OpModeStatus need to be at end to overload other values*/
+OpModeStatus {
+	qproperty-opMode_Full_Color: #007000;
+	qproperty-opMode_NoTurtle_Color: #000070;
+	qproperty-opMode_Gaming_Color: #707000;
+	qproperty-opMode_Minimal_Color: #700000;
+}
+OpModeStatus[opMode="Full"] {
+	background: #007000;
+}
+OpModeStatus[opMode="NoTurtle"] {
+	background: #000070;
+}
+OpModeStatus[opMode="Gaming"] {
+	background: #707000;
+}
+OpModeStatus[opMode="Minimal"] {
+	background: #700000;
+}


### PR DESCRIPTION
Add colored style sheet to OpModeStatus ComboBox.
And defined default color when stylesheet files are not found.

Still get Bad effect for Combo with GTK++ or WindowsVista and Standard, but get it too without this commits, only adding these lines to \retroshare-gui\src\gui\qss\stylesheet\qss.default:
OpModeStatus {
    background: #CCFFCC;
}
