### PR TITLE
Fix GenCertDialog on Mac stay on.

### DIFF
--- a/retroshare-gui/src/gui/GenCertDialog.cpp
+++ b/retroshare-gui/src/gui/GenCertDialog.cpp
@@ -532,7 +532,9 @@ void GenCertDialog::genPerson()
 		setCursor(Qt::WaitCursor) ;
 
 		QCoreApplication::processEvents();
-		while(QAbstractEventDispatcher::instance()->processEvents(QEventLoop::AllEvents)) ;
+		QAbstractEventDispatcher* ed = QAbstractEventDispatcher::instance();
+		if (ed->hasPendingEvents())
+			while(ed->processEvents(QEventLoop::AllEvents));
 
 		std::string email_str = "" ;
 		RsAccounts::GeneratePGPCertificate(


### PR DESCRIPTION
Only call processEvent() if hasPendingEvents().
If no events are available, this function will wait until more are
available and return after processing newly available events.
