### PR TITLE
added openSSL option SSL_OP_SINGLE_DH_USE regarding CVE-2016-0701

### DIFF
--- a/libretroshare/src/pqi/authssl.cc
+++ b/libretroshare/src/pqi/authssl.cc
@@ -334,6 +334,13 @@ static  int initLib = 0;
 	sslctx = SSL_CTX_new(SSLv23_method());
 	SSL_CTX_set_options(sslctx,SSL_OP_NO_SSLv3) ;
 
+	//SSL_OP_SINGLE_DH_USE 	CVE-2016-0701
+	//https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_options.html
+	//If "strong" primes were used, it is not strictly necessary to generate a new DH key during each handshake but it is also recommended. SSL_OP_SINGLE_DH_USE should therefore be enabled whenever temporary/ephemeral DH parameters are used.
+	//SSL_CTX_set_options() adds the options set via bitmask in options to ctx. Options already set before are not cleared!
+        SSL_CTX_set_options(sslctx,SSL_OP_SINGLE_DH_USE) ;
+
+
 	// Setup cipher lists:
 	//
 	//       std::string cipherString = "HIGH:!DSS:!aNULL:!3DES";


### PR DESCRIPTION
tl;dr The OpenSSL 1.0.2 releases suffer from a Key Recovery Attack on DH small subgroups. This issue got assigned CVE-2016-0701 with a severity of High and OpenSSL 1.0.2 users should upgrade to 1.0.2f. If an application is using DH configured with parameters based on primes that are not "safe" or not Lim-Lee (as the one in RFC 5114) and either Static DH ciphersuites are used or DHE ciphersuites with the default OpenSSL configuration (in particular SSL_OP_SINGLE_DH_USE is not set) then is vulnerable to this attack.
