### PR TITLE
discovery: don't remove new added locations too soon

### DIFF
--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -2749,7 +2749,7 @@ bool p3PeerMgrIMPL::removeUnusedLocations()
 		std::map<RsPeerId, peerState>::iterator it;
 		for(it = mFriendList.begin(); it != mFriendList.end(); ++it)
 		{
-			if (now - it->second.lastcontact > RS_PEER_OLD_PEER)
+			if (now > it->second.lastcontact + RS_PEER_OFFLINE_DELETE)
 			{
 				toRemove.push_back(it->first);
 

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -64,8 +64,6 @@ const uint32_t MIN_TIME_BETWEEN_NET_RESET = 		5;
 
 const uint32_t PEER_IP_CONNECT_STATE_MAX_LIST_SIZE =     	4;
 
-#define VERY_OLD_PEER  (90 * 24 * 3600)      // 90 days.
-
 /****
  * #define PEER_DEBUG 1
  ***/
@@ -2751,7 +2749,7 @@ bool p3PeerMgrIMPL::removeUnusedLocations()
 		std::map<RsPeerId, peerState>::iterator it;
 		for(it = mFriendList.begin(); it != mFriendList.end(); ++it)
 		{
-			if (now - it->second.lastcontact > VERY_OLD_PEER)
+			if (now - it->second.lastcontact > RS_PEER_OLD_PEER)
 			{
 				toRemove.push_back(it->first);
 

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -65,8 +65,12 @@ const uint32_t RS_NET_FLAGS_EXTERNAL_ADDR	= 0x0008;
 const uint32_t RS_NET_FLAGS_STABLE_UDP		= 0x0010;
 const uint32_t RS_NET_FLAGS_TRUSTS_ME 		= 0x0020;
 
-/* remove locations offline since 90 days */
-const time_t RS_PEER_OLD_PEER = (90 * 24 * 3600);
+/*
+ * remove locations offline since 90 days
+ * stopt sending locations via discovery when offline for +30 days
+ */
+const time_t RS_PEER_OFFLINE_DELETE  = (90 * 24 * 3600);
+const time_t RS_PEER_OFFLINE_NO_DISC = (30 * 24 * 3600);
 
 class peerState
 {

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -65,6 +65,9 @@ const uint32_t RS_NET_FLAGS_EXTERNAL_ADDR	= 0x0008;
 const uint32_t RS_NET_FLAGS_STABLE_UDP		= 0x0010;
 const uint32_t RS_NET_FLAGS_TRUSTS_ME 		= 0x0020;
 
+/* remove locations offline since 90 days */
+const time_t RS_PEER_OLD_PEER = (90 * 24 * 3600);
+
 class peerState
 {
 	public:

--- a/libretroshare/src/services/p3discovery2.cc
+++ b/libretroshare/src/services/p3discovery2.cc
@@ -24,6 +24,7 @@
  */
 
 #include "services/p3discovery2.h"
+#include "pqi/p3peermgr.h"
 #include "util/rsversioninfo.h"
 
 #include "retroshare/rsiface.h"
@@ -930,7 +931,10 @@ void p3discovery2::processContactInfo(const SSLID &fromId, const RsDiscContactIt
             // We pass RS_NODE_PERM_ALL because the PGP id is already a friend, so we should keep the existing
             // permission flags. Therefore the mask needs to be 0xffff.
 
-            mPeerMgr->addFriend(item->sslId, item->pgpId, item->netMode, RS_VS_DISC_OFF, RS_VS_DHT_FULL,(time_t)0,RS_NODE_PERM_ALL);
+			// set last seen to RS_PEER_OLD_PEER minus 1 day so that the DHT has a fair chance to establish a connection
+			// before the location gets automatically removed again
+
+			mPeerMgr->addFriend(item->sslId, item->pgpId, item->netMode, RS_VS_DISC_OFF, RS_VS_DHT_FULL, time(NULL) - RS_PEER_OLD_PEER + (24 * 3600), RS_NODE_PERM_ALL);
 			updatePeerAddresses(item);
 		}
 	}

--- a/libretroshare/src/services/p3discovery2.cc
+++ b/libretroshare/src/services/p3discovery2.cc
@@ -931,10 +931,10 @@ void p3discovery2::processContactInfo(const SSLID &fromId, const RsDiscContactIt
             // We pass RS_NODE_PERM_ALL because the PGP id is already a friend, so we should keep the existing
             // permission flags. Therefore the mask needs to be 0xffff.
 
-			// set last seen to RS_PEER_OLD_PEER minus 1 day so that the DHT has a fair chance to establish a connection
-			// before the location gets automatically removed again
+			// set last seen to RS_PEER_OFFLINE_NO_DISC minus 1 so that it won't be shared with other friends
+			// until a first connection is established
 
-			mPeerMgr->addFriend(item->sslId, item->pgpId, item->netMode, RS_VS_DISC_OFF, RS_VS_DHT_FULL, time(NULL) - RS_PEER_OLD_PEER + (24 * 3600), RS_NODE_PERM_ALL);
+			mPeerMgr->addFriend(item->sslId, item->pgpId, item->netMode, RS_VS_DISC_OFF, RS_VS_DHT_FULL, time(NULL) - RS_PEER_OFFLINE_NO_DISC - 1, RS_NODE_PERM_ALL);
 			updatePeerAddresses(item);
 		}
 	}


### PR DESCRIPTION
The current code adds new locations via discovery with a "last seen" time stamp set to 0. This leads to the problem that the new location gets cleaned up within the next 10 minutes when no connection is established. This can be to fast for DHT connections when both sides are behind NAT/firewall.

This patch increases the "protection" time to 1 day by adding new locations with a sound "last seen" value.
