### PR TITLE
Enhance error log when receiving bad packet to deserialize.

### DIFF
--- a/libretroshare/src/pqi/pqistreamer.cc
+++ b/libretroshare/src/pqi/pqistreamer.cc
@@ -752,7 +752,7 @@ continue_packet:
 					p3Notify *notify = RsServer::notify();
 					if (notify)
 					{
-						std::string title = "Warning: Error Completing Read";
+						//std::string title = "Warning: Error Completing Read";
 
 						std::string msgout;
 						msgout =   "               **** WARNING ****     \n";
@@ -837,6 +837,36 @@ continue_packet:
 #ifdef DEBUG_PQISTREAMER
 			pqioutput(PQL_ALERT, pqistreamerzone, "Failed to handle Packet!");
 #endif
+			p3Notify *notify = RsServer::notify();
+			if (notify)
+			{
+				//std::string title = "Warning: Error Completing Read";
+
+				std::string msgout;
+				msgout =   "               **** WARNING ****     \n";
+				msgout +=  "Retroshare failed to handle Packet from Peer:";
+				msgout += PeerId().toStdString();
+				msgout +=  "\n";
+				rs_sprintf_append(msgout, "(Packet Lenght:%d)\n", pktlen);
+				msgout +=  "\n";
+				msgout +=  "Note: this error might as well happen (rarely) when a peer send bad packet.\n";
+				msgout +=  "If it happens manny time, please contact the developers, and send them these numbers:";
+				msgout +=  "\n";
+
+				rs_sprintf_append(msgout, "block = %d %d %d %d %d %d %d %d\n",
+				                  (int)(((unsigned char*)block)[0]),
+				                  (int)(((unsigned char*)block)[1]),
+				                  (int)(((unsigned char*)block)[2]),
+				                  (int)(((unsigned char*)block)[3]),
+				                  (int)(((unsigned char*)block)[4]),
+				                  (int)(((unsigned char*)block)[5]),
+				                  (int)(((unsigned char*)block)[6]),
+				                  (int)(((unsigned char*)block)[7]));
+
+				//notify->AddSysMessage(0, RS_SYS_WARNING, title, msgout.str());
+
+				std::cerr << msgout << std::endl;
+			}
 		}
 
 		mReading_state = reading_state_initial ;	// restart at state 1.

--- a/libretroshare/src/serialiser/rsserial.cc
+++ b/libretroshare/src/serialiser/rsserial.cc
@@ -415,7 +415,7 @@ RsItem *    RsSerialiser::deserialise(void *data, uint32_t *size)
 				std::string out;
 				rs_sprintf(out, "%x", getRsItemId(data));
 
-				std::cerr << "RsSerialiser::deserialise() PacketId: ";
+				std::cerr << " PacketId: ";
 				std::cerr << out << std::endl;
 #endif
 				return NULL;


### PR DESCRIPTION
Add message like this:
RsSerialiser::deserialise() ERROR deserialiser missing! PacketId: 0
               ***\* WARNING ****
Retroshare failed to handle Packet from
Peer:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
(Packet Lenght:65)

Note: this error might as well happen (rarely) when a peer send bad
packet.
If it happens manny time, please contact the developers, and send them
these numbers:
block = 0 0 0 0 0 0 0 65
