### PR TITLE
Sqlcipher version fix

### DIFF
--- a/libretroshare/src/rsserver/p3face-info.cc
+++ b/libretroshare/src/rsserver/p3face-info.cc
@@ -35,10 +35,54 @@
 #include <sqlcipher/sqlite3.h>
 #endif
 
+std::string RsServer::getSQLCipherVersion()
+{
+	sqlite3* mDb;
+	std::string versionstring("");
+	const char* version;
+	int rc = sqlite3_open_v2("", &mDb, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE , NULL); //create DB in a temp file
+
+	if(rc){
+		std::cerr << "Can't open database, Error code: " <<  sqlite3_errmsg(mDb)
+				  << std::endl;
+		sqlite3_close(mDb);
+		mDb = NULL;
+		return "";
+	 }
+
+	std::string sqlQuery = "PRAGMA cipher_version;";
+	sqlite3_stmt* stmt = NULL;
+	rc = sqlite3_prepare_v2(mDb, sqlQuery.c_str(), sqlQuery.length(), &stmt, NULL);
+	if (rc == SQLITE_OK) {
+		rc = sqlite3_step(stmt);
+		switch (rc) {
+		case SQLITE_ROW:
+			version = (const char *)sqlite3_column_text(stmt, 0); //not needed to free
+			versionstring.append(version);
+			break;
+		case SQLITE_DONE:
+			break;
+		default:
+			std::cerr << "RetroDb::tableExists(): Error executing statement (code: " << rc << ")"
+					  << std::endl;
+			break;
+		}
+	}
+
+	if (stmt) {
+		sqlite3_finalize(stmt);
+	}
+	sqlite3_close(mDb);	// no-op if mDb is NULL (https://www.sqlite.org/c3ref/close.html)
+	return versionstring;
+}
+
 void RsServer::getLibraries(std::list<RsLibraryInfo> &libraries)
 {
 	libraries.push_back(RsLibraryInfo("bzip2", BZ2_bzlibVersion()));
 	libraries.push_back(RsLibraryInfo("OpenSSL", SSLeay_version(SSLEAY_VERSION)));
-	libraries.push_back(RsLibraryInfo("SQLCipher", SQLITE_VERSION));
+	libraries.push_back(RsLibraryInfo("SQLite", SQLITE_VERSION));
+#ifndef NO_SQLCIPHER
+	libraries.push_back(RsLibraryInfo("SQLCipher", getSQLCipherVersion()));
+#endif
 	libraries.push_back(RsLibraryInfo("Zlib", ZLIB_VERSION));
 }

--- a/libretroshare/src/rsserver/p3face.h
+++ b/libretroshare/src/rsserver/p3face.h
@@ -139,6 +139,8 @@ class RsServer: public RsControl, public RsTickingThread
 
 	private: 
 
+		std::string getSQLCipherVersion();
+
 		// The real Server Parts.
 
 		//filedexserver *server;


### PR DESCRIPTION
- On some platforms the about dialog used to display sqlite's version instead of sqlcipher's version, now both versions are displayed.
- Make it possible to migrate from sqlcipher version 3 to version 2. The database files are not converted back to version 2, instead they are opened in a version 3 compatible mode if needed.
