### PR TITLE
Fix error reported by CppChecker:

### DIFF
--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -2844,11 +2844,11 @@ void RsGenExchange::processRecvdGroups()
 
         		if(gpsi.mAttempts == VALIDATE_MAX_ATTEMPTS)
         		{
-        			delete grp;
-        			erase = true;
 #ifdef GEN_EXCH_DEBUG
 				std::cerr << "  max attempts " << VALIDATE_MAX_ATTEMPTS << " reached. Will delete group " << grp->grpId << std::endl;
 #endif
+        			delete grp;
+        			erase = true;
         		}
         		else
         		{

--- a/libretroshare/src/gxstunnel/p3gxstunnel.cc
+++ b/libretroshare/src/gxstunnel/p3gxstunnel.cc
@@ -1001,7 +1001,7 @@ void p3GxsTunnelService::handleRecvDHPublicKey(RsGxsTunnelDHPublicKeyItem *item)
 
 #ifdef DEBUG_GXS_TUNNEL
     std::cerr << "  DH key computed. Tunnel is now secured!" << std::endl;
-    std::cerr << "  Key computed: " << RsUtil::BinToHex((char*)pinfo.aes_key,16) << std::cerr << std::endl;
+    std::cerr << "  Key computed: " << RsUtil::BinToHex((char*)pinfo.aes_key,16) << std::endl;
     std::cerr << "  Sending a ACK packet." << std::endl;
 #endif
 

--- a/libretroshare/src/util/contentvalue.cc
+++ b/libretroshare/src/util/contentvalue.cc
@@ -182,6 +182,7 @@ void ContentValue::put(const std::string &key, uint32_t len, const char* value){
 
     mKvData.insert(std::pair<std::string, std::pair<uint32_t, char*> >
                    (key, std::pair<uint32_t, char*>(len, dest)));
+    //delete[] dest; //Deleted by clearData()
 }
 
 bool ContentValue::getAsBool(const std::string &key, bool& value) const{

--- a/openpgpsdk/src/openpgpsdk/reader_armoured.c
+++ b/openpgpsdk/src/openpgpsdk/reader_armoured.c
@@ -572,7 +572,15 @@ static int parse_headers(dearmour_arg_t *arg,ops_error_t **errors,
 			if(size <= nbuf+1)
 			{
 				size+=size+80;
-				buf=realloc(buf,size);
+				char *nbuf;
+				nbuf=realloc(buf,size);
+				if (nbuf == NULL)
+				{
+					free(buf);
+					rtn=-1;
+					goto end;
+				}
+				buf = nbuf;
 			}
 			buf[nbuf++]=c;
 		}

--- a/retroshare-gui/src/gui/FileTransfer/DLListDelegate.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/DLListDelegate.cpp
@@ -96,7 +96,7 @@ void DLListDelegate::paint(QPainter * painter, const QStyleOptionViewItem & opti
                                 temp = "";
 			} else {
 				multi = 1.0;
-				for(int i = 0; i < 5; ++i) {
+				for(int i = 0; i < 4; ++i) {
 					if (fileSize < 1024) {
 						fileSize = index.data().toLongLong();
 						temp.sprintf("%.2f ", fileSize / multi);
@@ -115,7 +115,7 @@ void DLListDelegate::paint(QPainter * painter, const QStyleOptionViewItem & opti
         temp = "";
 			} else {
 				multi = 1.0;
-				for(int i = 0; i < 5; ++i) {
+				for(int i = 0; i < 4; ++i) {
 					if (remaining < 1024) {
 						remaining = index.data().toLongLong();
 						temp.sprintf("%.2f ", remaining / multi);
@@ -134,7 +134,7 @@ void DLListDelegate::paint(QPainter * painter, const QStyleOptionViewItem & opti
                                 temp = "";
 			} else {
 				multi = 1.0;
-				for(int i = 0; i < 5; ++i) {
+				for(int i = 0; i < 4; ++i) {
 					if (completed < 1024) {
 						completed = index.data().toLongLong();
 						temp.sprintf("%.2f ", completed / multi);

--- a/retroshare-gui/src/gui/FileTransfer/ULListDelegate.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/ULListDelegate.cpp
@@ -85,7 +85,7 @@ void ULListDelegate::paint(QPainter * painter, const QStyleOptionViewItem & opti
                                 temp = "";
 			} else {
 				multi = 1.0;
-				for(int i = 0; i < 5; ++i) {
+				for(int i = 0; i < 4; ++i) {
 					if (fileSize < 1024) {
 						fileSize = index.data().toLongLong();
 						temp.sprintf("%.2f ", fileSize / multi);
@@ -104,7 +104,7 @@ void ULListDelegate::paint(QPainter * painter, const QStyleOptionViewItem & opti
                                 temp = "";
 			} else {
 				multi = 1.0;
-				for(int i = 0; i < 5; ++i) {
+				for(int i = 0; i < 4; ++i) {
 					if (transferred < 1024) {
 						transferred = index.data().toLongLong();
 						temp.sprintf("%.2f ", transferred / multi);

--- a/retroshare-gui/src/gui/People/PeopleDialog.cpp
+++ b/retroshare-gui/src/gui/People/PeopleDialog.cpp
@@ -768,7 +768,7 @@ void PeopleDialog::pf_dropEventOccursExt(QDropEvent *event)
 
 		QWidget *wid =
 		    qobject_cast<QWidget *>(event->source());//QT5 return QObject
-		FlowLayout *layout;
+		FlowLayout *layout = NULL;
 		if (wid) layout =
 		    qobject_cast<FlowLayout *>(wid->layout());
 		if (layout) {
@@ -858,7 +858,7 @@ void PeopleDialog::pf_dropEventOccursInt(QDropEvent *event)
 
 		QWidget *wid =
 		    qobject_cast<QWidget *>(event->source());//QT5 return QObject
-		FlowLayout *layout;
+		FlowLayout *layout = NULL;
 		if (wid) layout =
 		    qobject_cast<FlowLayout *>(wid->layout());
 		if (layout) {

--- a/retroshare-gui/src/gui/common/AvatarWidget.cpp
+++ b/retroshare-gui/src/gui/common/AvatarWidget.cpp
@@ -177,7 +177,7 @@ void AvatarWidget::refreshStatus()
     }
     case STATUS_FRAME:
     {
-        uint32_t status ;
+        uint32_t status = 0;
 
     if(mId.isNotSet())
         return ;

--- a/retroshare-nogui/src/rpc/proto/rpcprotostream.cc
+++ b/retroshare-nogui/src/rpc/proto/rpcprotostream.cc
@@ -802,6 +802,7 @@ bool fill_stream_data(rsctrl::stream::StreamData &data, const RpcStream &stream)
 	{
 		std::cerr << "fill_stream_data() Failed to get data. data_size=" << data_size << ", base_loc=" << base_loc << " !";
 		std::cerr << std::endl;
+		free(buffer);
 		return false;
 	}
 

--- a/supportlibs/pegmarkdown/GLibFacade.c
+++ b/supportlibs/pegmarkdown/GLibFacade.c
@@ -147,6 +147,7 @@ void g_string_append_printf(GString* baseString, char* format, ...)
 		g_string_append(baseString, formattedString);
 		free(formattedString);
 	}
+	va_end(args);
 } 
 
 void g_string_prepend(GString* baseString, char* prependedString)

--- a/tests/unittests/libretroshare/serialiser/rsturtleitem_test.cc
+++ b/tests/unittests/libretroshare/serialiser/rsturtleitem_test.cc
@@ -187,12 +187,11 @@ bool operator==(const RsTurtleStringSearchRequestItem& it1,const RsTurtleStringS
 		return false ;
 	return true ;
 }
-RsSerialType* init_item(TurtleFileInfo& info)
+void init_item(TurtleFileInfo& info)
 {
 	info.hash = RsFileHash("3f753e8ac3b94ab9fddfad94480f747bf4418370");
 	info.name = "toto.png";
 	info.size = 0x3392085443897ull ;
-	return new RsTurtleSerialiser();
 }
 bool operator==(const TurtleFileInfo& it1,const TurtleFileInfo& it2)
 {


### PR DESCRIPTION
/libretroshare/src/gxs/rsgenexchange.cc:2850: erreur : Cppcheck:
Dereferencing 'grp' after it is deallocated / released
/libretroshare/src/gxstunnel/p3gxstunnel.cc:1004: erreur : Cppcheck:
Invalid usage of output stream: '<< std::cerr'.
/libretroshare/src/util/contentvalue.cc:185: erreur : Cppcheck: Memory
leak: dest
/openpgpsdk/src/openpgpsdk/reader_armoured.c:575: erreur : Cppcheck:
Common realloc mistake: 'buf' nulled but not freed upon failure
/retroshare-gui/src/gui/FileTransfer/DLListDelegate.cpp:103: erreur :
Cppcheck: Array 'byteUnits[4]' accessed at index 4, which is out of
bounds.
/retroshare-gui/src/gui/FileTransfer/DLListDelegate.cpp:122: erreur :
Cppcheck: Array 'byteUnits[4]' accessed at index 4, which is out of
bounds.
/retroshare-gui/src/gui/FileTransfer/DLListDelegate.cpp:141: erreur :
Cppcheck: Array 'byteUnits[4]' accessed at index 4, which is out of
bounds.
/retroshare-gui/src/gui/FileTransfer/ULListDelegate.cpp:92: erreur :
Cppcheck: Array 'byteUnits[4]' accessed at index 4, which is out of
bounds.
/retroshare-gui/src/gui/FileTransfer/ULListDelegate.cpp:111: erreur :
Cppcheck: Array 'byteUnits[4]' accessed at index 4, which is out of
bounds.
/retroshare-gui/src/gui/People/PeopleDialog.cpp:774: erreur : Cppcheck:
Uninitialized variable: layout
/retroshare-gui/src/gui/People/PeopleDialog.cpp:864: erreur : Cppcheck:
Uninitialized variable: layout
/retroshare-gui/src/gui/common/AvatarWidget.cpp:225: erreur : Cppcheck:
Uninitialized variable: status
/retroshare-nogui/src/rpc/proto/rpcprotostream.cc:805: erreur :
Cppcheck: Memory leak: buffer
/supportlibs/pegmarkdown/GLibFacade.c:150: erreur : Cppcheck: va_list
'args' was opened but not closed by va_end().
/openpgpsdk/src/openpgpsdk/reader_armoured.c:575: erreur : Cppcheck:
Common realloc mistake: 'buf' nulled but not freed upon failure
/tests/unittests/libretroshare/serialiser/rsturtleitem_test.cc:213:
erreur : Cppcheck: Return value of allocation function 'init_item' is
not stored.
