### PR TITLE
Clear WebAPI when clear chat history in GUI.

### DIFF
--- a/libresapi/src/api/ChatHandler.cpp
+++ b/libresapi/src/api/ChatHandler.cpp
@@ -167,6 +167,13 @@ void ChatHandler::notifyChatMessage(const ChatMessage &msg)
     mRawMsgs.push_back(msg);
 }
 
+void ChatHandler::notifyChatCleared(const ChatId &chat_id)
+{
+    RS_STACK_MUTEX(mMtx); /********** LOCKED **********/
+    std::list<Msg>& msgs = mMsgs[chat_id];
+    msgs.clear();
+}
+
 void ChatHandler::notifyChatStatus(const ChatId &chat_id, const std::string &status)
 {
     RS_STACK_MUTEX(mMtx); /********** LOCKED **********/

--- a/libresapi/src/api/ChatHandler.h
+++ b/libresapi/src/api/ChatHandler.h
@@ -25,6 +25,7 @@ public:
     // from NotifyClient
     // note: this may get called from the own and from foreign threads
     virtual void notifyChatMessage(const ChatMessage& msg);
+    virtual void notifyChatCleared(const ChatId& chat_id);
 
     // typing label for peer, broadcast and distant chat
     virtual void notifyChatStatus     (const ChatId&      /* chat_id  */, const std::string& /* status_string */);

--- a/libretroshare/src/chat/p3chatservice.cc
+++ b/libretroshare/src/chat/p3chatservice.cc
@@ -244,6 +244,11 @@ void p3ChatService::sendStatusString(const ChatId& id , const std::string& statu
     }
 }
 
+void p3ChatService::clearChatLobby(const ChatId& id)
+{
+	RsServer::notify()->notifyChatCleared(id);
+}
+
 void p3ChatService::sendChatItem(RsChatItem *item)
 {
 	if(DistantChatService::handleOutgoingItem(item))

--- a/libretroshare/src/chat/p3chatservice.h
+++ b/libretroshare/src/chat/p3chatservice.h
@@ -95,7 +95,13 @@ public:
 		 * can be used to send 'immediate' status msgs, these status updates are meant for immediate use by peer (not saved by rs)
 		 * e.g currently used to update user when a peer 'is typing' during a chat
 		 */
-	void  sendStatusString(const ChatId& peer_id,const std::string& status_str) ;
+	void  sendStatusString(const ChatId& id,const std::string& status_str) ;
+
+	/**
+	 * @brief clearChatLobby: Signal chat was cleared by GUI.
+	 * @param id: Chat id cleared.
+	 */
+	virtual void clearChatLobby(const ChatId& id);
 
 	/*!
 		 * send to all peers online

--- a/libretroshare/src/pqi/p3notify.cc
+++ b/libretroshare/src/pqi/p3notify.cc
@@ -223,8 +223,9 @@ void p3Notify::notifyListPreChange(int list, int type) { FOR_ALL_NOTIFY_CLIENTS 
 void p3Notify::notifyListChange   (int list, int type) { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyListChange   (list,type) ; }
 
 void p3Notify::notifyErrorMsg      (int list, int sev, std::string msg)                                                         { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyErrorMsg(list,sev,msg) ; }
-void p3Notify::notifyChatMessage   (const ChatMessage &msg)                                                                            { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyChatMessage(msg) ; }
-void p3Notify::notifyChatStatus    (const ChatId&  chat_id, const std::string& status_string)             { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyChatStatus(chat_id,status_string) ; }
+void p3Notify::notifyChatMessage   (const ChatMessage &msg)                                                                     { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyChatMessage(msg) ; }
+void p3Notify::notifyChatStatus    (const ChatId&  chat_id, const std::string& status_string)                                   { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyChatStatus(chat_id,status_string) ; }
+void p3Notify::notifyChatCleared   (const ChatId&  chat_id)                                                                     { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyChatCleared(chat_id) ; }
 
 void p3Notify::notifyChatLobbyTimeShift     (int                time_shift)                                                     { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyChatLobbyTimeShift(time_shift) ; }
 void p3Notify::notifyCustomState            (const std::string& peer_id   , const std::string&               status_string )    { FOR_ALL_NOTIFY_CLIENTS (*it)->notifyCustomState       (peer_id,status_string) ; }

--- a/libretroshare/src/pqi/p3notify.h
+++ b/libretroshare/src/pqi/p3notify.h
@@ -98,9 +98,10 @@ class p3Notify: public RsNotify
 		void notifyListPreChange              (int /* list */, int /* type */) ;
 		void notifyListChange                 (int /* list */, int /* type */) ;
 		void notifyErrorMsg                   (int /* list */, int /* sev  */, std::string /* msg */) ;
-        void notifyChatMessage                (const ChatMessage& /* msg      */) ;
-        void notifyChatStatus                 (const ChatId&      /* chat_id  */, const std::string& /* status_string */) ;
-        void notifyChatLobbyEvent             (uint64_t           /* lobby id */, uint32_t           /* event type    */ , const RsGxsId & /* nickname */, const std::string& /* any string */) ;
+		void notifyChatMessage                (const ChatMessage& /* msg      */) ;
+		void notifyChatStatus                 (const ChatId&      /* chat_id  */, const std::string& /* status_string */) ;
+		void notifyChatCleared                (const ChatId&      /* chat_id  */) ;
+		void notifyChatLobbyEvent             (uint64_t           /* lobby id */, uint32_t           /* event type    */ , const RsGxsId & /* nickname */, const std::string& /* any string */) ;
 		void notifyChatLobbyTimeShift         (int                /* time_shift*/) ;
 		void notifyCustomState                (const std::string& /* peer_id   */, const std::string&               /* status_string */) ;
 		void notifyHashingInfo                (uint32_t           /* type      */, const std::string&               /* fileinfo      */) ;

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -1567,7 +1567,7 @@ bool p3PeerMgrIMPL::locked_computeCurrentBestOwnExtAddressCandidate(sockaddr_sto
     return true ;
 }
  
-bool p3PeerMgrIMPL::getExtAddressReportedByFriends(sockaddr_storage &addr, uint8_t& isstable)
+bool p3PeerMgrIMPL::getExtAddressReportedByFriends(sockaddr_storage &addr, uint8_t& /*isstable*/)
 {
         RsStackMutex stack(mPeerMtx); /****** STACK LOCK MUTEX *******/
         

--- a/libretroshare/src/retroshare/rsmsgs.h
+++ b/libretroshare/src/retroshare/rsmsgs.h
@@ -443,12 +443,13 @@ virtual bool resetMessageStandardTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
 // sendChat for broadcast, private, lobby and private distant chat
 // note: for lobby chat, you first have to subscribe to a lobby
 //       for private distant chat, it is reqired to have an active distant chat session
-virtual	bool     sendChat(ChatId id, std::string msg) = 0;
+virtual bool sendChat(ChatId id, std::string msg) = 0;
 virtual uint32_t getMaxMessageSecuritySize(int type)  = 0;
 
-virtual void   sendStatusString(const ChatId& id,const std::string& status_string) = 0 ;
+virtual void sendStatusString(const ChatId& id,const std::string& status_string) = 0;
+virtual void clearChatLobby(const ChatId& id) = 0;
 
-virtual void   setCustomStateString(const std::string&  status_string) = 0 ;
+virtual void setCustomStateString(const std::string&  status_string) = 0 ;
 virtual std::string getCustomStateString() = 0 ;
 virtual std::string getCustomStateString(const RsPeerId& peer_id) = 0 ;
 
@@ -478,8 +479,8 @@ virtual bool setIdentityForChatLobby(const ChatLobbyId& lobby_id,const RsGxsId& 
 virtual bool getIdentityForChatLobby(const ChatLobbyId& lobby_id,RsGxsId& nick) = 0 ;
 virtual bool setDefaultIdentityForChatLobby(const RsGxsId& nick) = 0;
 virtual void getDefaultIdentityForChatLobby(RsGxsId& id) = 0 ;
-    virtual void setLobbyAutoSubscribe(const ChatLobbyId& lobby_id, const bool autoSubscribe) = 0 ;
-    virtual bool getLobbyAutoSubscribe(const ChatLobbyId& lobby_id) = 0 ;
+virtual void setLobbyAutoSubscribe(const ChatLobbyId& lobby_id, const bool autoSubscribe) = 0 ;
+virtual bool getLobbyAutoSubscribe(const ChatLobbyId& lobby_id) = 0 ;
 virtual ChatLobbyId createChatLobby(const std::string& lobby_name,const RsGxsId& lobby_identity,const std::string& lobby_topic,const std::set<RsPeerId>& invited_friends,ChatLobbyFlags lobby_privacy_type) = 0 ;
 
 /****************************************/

--- a/libretroshare/src/retroshare/rsnotify.h
+++ b/libretroshare/src/retroshare/rsnotify.h
@@ -210,9 +210,10 @@ class NotifyClient
 		virtual void notifyListPreChange              (int /* list */, int /* type */) {}
 		virtual void notifyListChange                 (int /* list */, int /* type */) {}
 		virtual void notifyErrorMsg                   (int /* list */, int /* sev  */, std::string /* msg */) {}
-        virtual void notifyChatMessage                (const ChatMessage& /* msg      */) {}
-        virtual void notifyChatStatus                 (const ChatId&      /* chat_id  */, const std::string& /* status_string */) {}
-        virtual void notifyChatLobbyEvent             (uint64_t           /* lobby id */, uint32_t           /* event type    */ ,const RsGxsId& /* nickname */,const std::string& /* any string */) {}
+		virtual void notifyChatMessage                (const ChatMessage& /* msg      */) {}
+		virtual void notifyChatStatus                 (const ChatId&      /* chat_id  */, const std::string& /* status_string */) {}
+		virtual void notifyChatCleared                (const ChatId&      /* chat_id  */) {}
+		virtual void notifyChatLobbyEvent             (uint64_t           /* lobby id */, uint32_t           /* event type    */ ,const RsGxsId& /* nickname */,const std::string& /* any string */) {}
 		virtual void notifyChatLobbyTimeShift         (int                /* time_shift*/) {}
 		virtual void notifyCustomState                (const std::string& /* peer_id   */, const std::string&               /* status_string */) {}
 		virtual void notifyHashingInfo                (uint32_t           /* type      */, const std::string&               /* fileinfo      */) {}

--- a/libretroshare/src/rsserver/p3msgs.cc
+++ b/libretroshare/src/rsserver/p3msgs.cc
@@ -409,9 +409,14 @@ uint32_t p3Msgs::getMaxMessageSecuritySize(int type)
 	return mChatSrv->getMaxMessageSecuritySize(type);
 }
 
-void p3Msgs::sendStatusString(const ChatId& peer_id, const std::string& status_string)
+void p3Msgs::sendStatusString(const ChatId& id, const std::string& status_string)
 {
-    mChatSrv->sendStatusString(peer_id, status_string);
+    mChatSrv->sendStatusString(id, status_string);
+}
+
+void p3Msgs::clearChatLobby(const ChatId &id)
+{
+	mChatSrv->clearChatLobby(id);
 }
 
 void p3Msgs::getOwnAvatarData(unsigned char *& data,int& size)

--- a/libretroshare/src/rsserver/p3msgs.h
+++ b/libretroshare/src/rsserver/p3msgs.h
@@ -127,12 +127,18 @@ class p3Msgs: public RsMsgs
 	   */
 	  virtual uint32_t getMaxMessageSecuritySize(int type);
 
-	  /*!
-	   * sends immediate status string to a specific peer, e.g. in a private chat
-       * @param chat_id chat id to send status string to
-	   * @param status_string immediate status to send
-	   */
-      virtual void    sendStatusString(const ChatId& chat_id, const std::string& status_string) ;
+    /*!
+     * sends immediate status string to a specific peer, e.g. in a private chat
+     * @param chat_id chat id to send status string to
+     * @param status_string immediate status to send
+     */
+    virtual void    sendStatusString(const ChatId& id, const std::string& status_string) ;
+
+    /**
+     * @brief clearChatLobby: Signal chat was cleared by GUI.
+     * @param id: Chat id cleared.
+     */
+    virtual void clearChatLobby(const ChatId &id);
 
 	  /****************************************/
 

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -1410,6 +1410,7 @@ void ChatWidget::clearChatHistory()
 	if (chatType() == CHATTYPE_LOBBY) {
 		if (notify) notify->chatLobbyCleared(chatId.toLobbyId(),"");
 	}
+	rsMsgs->clearChatLobby(chatId);
 }
 
 void ChatWidget::deleteChatHistory()

--- a/retroshare-gui/src/gui/notifyqt.cpp
+++ b/retroshare-gui/src/gui/notifyqt.cpp
@@ -519,7 +519,21 @@ void NotifyQt::notifyChatStatus(const ChatId& chat_id,const std::string& status_
     emit chatStatusChanged(chat_id, QString::fromUtf8(status_string.c_str()));
 }
 
-void NotifyQt::notifyTurtleSearchResult(uint32_t search_id,const std::list<TurtleFileInfo>& files) 
+void NotifyQt::notifyChatCleared(const ChatId& chat_id)
+{
+	{
+		QMutexLocker m(&_mutex) ;
+		if(!_enabled)
+			return ;
+	}
+
+#ifdef NOTIFY_DEBUG
+	std::cerr << "notifyQt: Received chat cleared." << std::endl ;
+#endif
+	emit chatCleared(chat_id);
+}
+
+void NotifyQt::notifyTurtleSearchResult(uint32_t search_id,const std::list<TurtleFileInfo>& files)
 {
 	{
 		QMutexLocker m(&_mutex) ;

--- a/retroshare-gui/src/gui/notifyqt.h
+++ b/retroshare-gui/src/gui/notifyqt.h
@@ -42,8 +42,9 @@ class NotifyQt: public QObject, public NotifyClient
 		virtual void notifyListPreChange(int list, int type);
 		virtual void notifyListChange(int list, int type);
 		virtual void notifyErrorMsg(int list, int sev, std::string msg);
-        virtual void notifyChatMessage(const ChatMessage&        /* msg */);
-        virtual void notifyChatStatus(const ChatId &chat_id,const std::string& status_string);
+		virtual void notifyChatMessage(const ChatMessage&        /* msg */);
+		virtual void notifyChatStatus(const ChatId &chat_id,const std::string& status_string);
+		virtual void notifyChatCleared(const ChatId &chat_id);
 		virtual void notifyCustomState(const std::string& peer_id, const std::string& status_string);
 		virtual void notifyHashingInfo(uint32_t type, const std::string& fileinfo);
 		virtual void notifyTurtleSearchResult(uint32_t search_id,const std::list<TurtleFileInfo>& found_files);
@@ -113,7 +114,8 @@ class NotifyQt: public QObject, public NotifyClient
 #endif
 		void configChanged() const ;
 		void logInfoChanged(const QString&) const ;
-        void chatStatusChanged(const ChatId&,const QString&) const ;
+		void chatStatusChanged(const ChatId&,const QString&) const ;
+		void chatCleared(const ChatId&) const ;
 		void peerHasNewCustomStateString(const QString& /* peer_id */, const QString& /* status_string */) const ;
 		void gotTurtleSearchResult(qulonglong search_id,FileDetail file) const ;
 		void peerHasNewAvatar(const QString& peer_id) const ;


### PR DESCRIPTION
Move notifyChatCleared call to p3ChatService
To maintain notify direction.
