### PR TITLE
Fixed compilation for Clang.

### DIFF
--- a/libretroshare/src/grouter/p3grouter.h
+++ b/libretroshare/src/grouter/p3grouter.h
@@ -225,20 +225,13 @@ private:
     void handleLowLevelTransactionAckItem(RsGRouterTransactionAcknItem*) ;
 
     static Sha1CheckSum computeDataItemHash(RsGRouterGenericDataItem *data_item);
-#ifdef __APPLE__
-public:
-#endif
-    class nullstream: public std::ostream {};
 
     std::ostream& grouter_debug() const
     {
-        static nullstream null ;
-
+        static std::ostream null(0);
         return _debug_enabled?(std::cerr):null;
     }
-#ifdef __APPLE__
-private:
-#endif
+
     void routePendingObjects() ;
     void handleTunnels() ;
     void autoWash() ;
@@ -364,5 +357,3 @@ private:
 
     uint64_t _random_salt ;
 };
-
-template<typename T> p3GRouter::nullstream& operator<<(p3GRouter::nullstream& ns,const T&) { return ns ; }

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -366,11 +366,7 @@ int RsInit::InitRetroShare(int argcIgnored, char **argvIgnored, bool strictCheck
 #ifdef LOCALNET_TESTING
 			   >> parameter('R',"restrict-port" ,portRestrictions             ,"port1-port2","Apply port restriction"                   ,false)
 #endif
-#ifdef __APPLE__
  				>> help('h',"help","Display this Help") ;
-#else
-				>> help() ;
-#endif
 
 			as.defaultErrorHandling(true) ;
 

--- a/libretroshare/src/util/argstream.h
+++ b/libretroshare/src/util/argstream.h
@@ -140,16 +140,11 @@ namespace
 		protected:
 			inline OptionHolder(char s,
 					const char* l,
-					const char* desc);  
-#ifdef __APPLE__
+                                        const char* desc);
  			friend OptionHolder help(char s,
  					const char* l,
  					const char* desc);
-#else
-			friend OptionHolder help(char s='h',
-					const char* l="help",
-					const char* desc="Display this help");
-#endif
+
 		private:
 			std::string shortName_;
 			std::string longName_;

--- a/retroshare-gui/src/gui/elastic/graphwidget.cpp
+++ b/retroshare-gui/src/gui/elastic/graphwidget.cpp
@@ -259,7 +259,7 @@ void GraphWidget::keyPressEvent(QKeyEvent *event)
     }
 }
 
-static void convolveWithGaussian(double *forceMap,int S,int /*s*/)
+static void convolveWithGaussian(double *forceMap,unsigned int S,int /*s*/)
 {
 	static double *bf = NULL ;
 
@@ -267,8 +267,8 @@ static void convolveWithGaussian(double *forceMap,int S,int /*s*/)
 	{
 		bf = new double[S*S*2] ;
 
-		for(int i=0;i<S;++i)
-			for(int j=0;j<S;++j)
+        for(unsigned int i=0;i<S;++i)
+            for(unsigned int j=0;j<S;++j)
 			{
 				int x = (i<S/2)?i:(S-i) ;
 				int y = (j<S/2)?j:(S-j) ;
@@ -284,8 +284,8 @@ static void convolveWithGaussian(double *forceMap,int S,int /*s*/)
 	unsigned long nn[2] = {S,S};
 	fourn(&forceMap[-1],&nn[-1],2,1) ;
 
-	for(int i=0;i<S;++i)
-		for(int j=0;j<S;++j)
+    for(unsigned int i=0;i<S;++i)
+        for(unsigned int j=0;j<S;++j)
 		{
 			float a = forceMap[2*(i+S*j)]*bf[2*(i+S*j)] - forceMap[2*(i+S*j)+1]*bf[2*(i+S*j)+1] ;
 			float b = forceMap[2*(i+S*j)]*bf[2*(i+S*j)+1] + forceMap[2*(i+S*j)+1]*bf[2*(i+S*j)] ;
@@ -296,7 +296,7 @@ static void convolveWithGaussian(double *forceMap,int S,int /*s*/)
 
 	fourn(&forceMap[-1],&nn[-1],2,-1) ;
 
-	for(int i=0;i<S*S*2;++i)
+    for(unsigned int i=0;i<S*S*2;++i)
 		forceMap[i] /= S*S;
 }
 

--- a/retroshare-gui/src/rshare.cpp
+++ b/retroshare-gui/src/rshare.cpp
@@ -362,21 +362,21 @@ Rshare::showUsageMessageBox()
   out << "<table>";
   //out << trow(tcol("-"ARG_HELP) + 
   //            tcol(tr("Displays this usage message and exits.")));
-  out << trow(tcol("-"ARG_RESET) +
+  out << trow(tcol("-" ARG_RESET) +
               tcol(tr("Resets ALL stored RetroShare settings.")));
-  out << trow(tcol("-"ARG_DATADIR" &lt;dir&gt;") +
+  out << trow(tcol("-" ARG_DATADIR" &lt;dir&gt;") +
               tcol(tr("Sets the directory RetroShare uses for data files.")));
-  out << trow(tcol("-"ARG_LOGFILE" &lt;file&gt;") +
+  out << trow(tcol("-" ARG_LOGFILE" &lt;file&gt;") +
               tcol(tr("Sets the name and location of RetroShare's logfile.")));
-  out << trow(tcol("-"ARG_LOGLEVEL" &lt;level&gt;") +
+  out << trow(tcol("-" ARG_LOGLEVEL" &lt;level&gt;") +
               tcol(tr("Sets the verbosity of RetroShare's logging.") +
                    "<br>[" + Log::logLevels().join("|") +"]"));
-  out << trow(tcol("-"ARG_GUISTYLE" &lt;style&gt;") +
+  out << trow(tcol("-" ARG_GUISTYLE" &lt;style&gt;") +
               tcol(tr("Sets RetroShare's interface style.") +
                    "<br>[" + QStyleFactory::keys().join("|") + "]"));
-  out << trow(tcol("-"ARG_GUISTYLESHEET" &lt;stylesheet&gt;") +
+  out << trow(tcol("-" ARG_GUISTYLESHEET" &lt;stylesheet&gt;") +
               tcol(tr("Sets RetroShare's interface stylesheets.")));                   
-  out << trow(tcol("-"ARG_LANGUAGE" &lt;language&gt;") + 
+  out << trow(tcol("-" ARG_LANGUAGE" &lt;language&gt;") +
               tcol(tr("Sets RetroShare's language.") +
                    "<br>[" + LanguageSupport::languageCodes().join("|") + "]"));
   out << "</table>";

--- a/retroshare-nogui/src/retroshare.cc
+++ b/retroshare-nogui/src/retroshare.cc
@@ -85,12 +85,9 @@ int main(int argc, char **argv)
     args >> parameter("docroot",      docroot,  "path", "Serve static files from this path.", false);
     // unfinished
     //args >> parameter("http-listen", listenAddress, "ipv6 address", "Listen only on the specified address.", false);
-    args >> option("http-allow-all", allowAllIps, "allow connections from all IP adresses (default= localhost only)");
-#ifdef __APPLE__    
+    args >> option("http-allow-all", allowAllIps, "allow connections from all IP adresses (default= localhost only)"); 
     args >> help('h',"help","Display this Help");
-#else
-    args >> help();
-#endif
+
     if (args.helpRequested())
     {
         std::cerr << args.usage() << std::endl;


### PR DESCRIPTION
Fixed compilation for Clang. Replaced nullstream with std::ostream null(0), a stream opened with invalid buffer, so that nothing gets written in it. This is a bit dirty I think it would be better to remove _debug_enabled and grouter_debug() and replace grouter_debug() with std::cerr, because debug prints can already switched on and of with GROUTER_DEBUG.

However I wanted to provide a solution which doesn't change too much, so I only removed the nullstream because it unnessessarily stored every debug print instead of dropping it and the operator<< function which is incorrect C++, because it accesses a private class.

Edit:
Link to the GCC-Bug which allows p3grouter.h to compile although it should be rejected: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=41437

I revoked my old pull request, here is the link to the old discussion: https://github.com/RetroShare/RetroShare/pull/337
