### PR TITLE
Add trailing semi-colon to MimeType in .desktop files

### DIFF
--- a/build_scripts/RedHat+Fedora/data/retroshare.desktop
+++ b/build_scripts/RedHat+Fedora/data/retroshare.desktop
@@ -7,5 +7,4 @@ Icon=/usr/share/pixmaps/retroshare06.xpm
 Terminal=false
 Type=Application
 Categories=Network;P2P;
-MimeType=x-scheme-handler/retroshare
-
+MimeType=x-scheme-handler/retroshare;

--- a/data/retroshare06.desktop
+++ b/data/retroshare06.desktop
@@ -8,5 +8,4 @@ Icon=/usr/share/pixmaps/retroshare06.xpm
 Terminal=false
 Type=Application
 Categories=Application;Network;
-MimeType=x-scheme-handler/retroshare
-
+MimeType=x-scheme-handler/retroshare;


### PR DESCRIPTION
The desktop-file-validate tool on Fedora complains about a missing semicolon in the .desktop file, the tool is executed when building packages on Fedora, so building packages is currently broken.

`[ 2707s] /home/abuild/rpmbuild/BUILDROOT/retroshare06-git-0.6.0.364.g26574fd-1.1.i386/usr/share/applications/retroshare06.desktop: error: value "x-scheme-handler/retroshare" for string list key "MimeType" in group "Desktop Entry" does not have a semicolon (';') as trailing character`
