### PR TITLE
Improved build files and bugfix.

### DIFF
--- a/libbitdht/src/libbitdht.pro
+++ b/libbitdht/src/libbitdht.pro
@@ -6,39 +6,7 @@ CONFIG -= qt
 TARGET = bitdht
 DESTDIR = lib
 
-QMAKE_CXXFLAGS *= -Wall -DBE_DEBUG
-
-profiling {
-	QMAKE_CXXFLAGS -= -fomit-frame-pointer
-	QMAKE_CXXFLAGS *= -pg -g -fno-omit-frame-pointer
-}
-
-release {
-	# not much here yet.
-}
-
-#CONFIG += debug
-debug {
-        QMAKE_CXXFLAGS -= -O2 -fomit-frame-pointer
-        QMAKE_CXXFLAGS *= -g -fno-omit-frame-pointer
-}
-
-# treat warnings as error for better removing
-#QMAKE_CFLAGS += -Werror
-#QMAKE_CXXFLAGS += -Werror
-
 ################################# Linux ##########################################
-linux-* {
-	QMAKE_CC = g++
-}
-
-linux-g++ {
-	OBJECTS_DIR = temp/linux-g++/obj
-}
-
-linux-g++-64 {
-	OBJECTS_DIR = temp/linux-g++-64/obj
-}
 
 unix {
 	data_files.path = "$${DATA_DIR}"
@@ -64,53 +32,11 @@ win32-x-g++ {
 ################################# Windows ##########################################
 
 win32 {
-		QMAKE_CC = g++
-		OBJECTS_DIR = temp/obj
-		MOC_DIR = temp/moc
 		DEFINES *= STATICLIB WIN32_LEAN_AND_MEAN _USE_32BIT_TIME_T
 		# These have been replaced by _WIN32 && __MINGW32__
 		#DEFINES *= WINDOWS_SYS WIN32 STATICLIB MINGW
-
-		# Switch on extra warnings
-		QMAKE_CFLAGS += -Wextra
-		QMAKE_CXXFLAGS += -Wextra
-
-		# Switch off optimization for release version
-		QMAKE_CXXFLAGS_RELEASE -= -O2
-		QMAKE_CXXFLAGS_RELEASE += -O0
-		QMAKE_CFLAGS_RELEASE -= -O2
-		QMAKE_CFLAGS_RELEASE += -O0
-
-		# Switch on optimization for debug version
-		#QMAKE_CXXFLAGS_DEBUG += -O2
-		#QMAKE_CFLAGS_DEBUG += -O2
 }
 
-################################# MacOSX ##########################################
-
-mac {
-		QMAKE_CC = g++
-		OBJECTS_DIR = temp/obj
-		MOC_DIR = temp/moc
-}
-
-################################# FreeBSD ##########################################
-
-freebsd-* {
-}
-
-################################# OpenBSD ##########################################
-
-openbsd-* {
-}
-
-################################# Haiku ##########################################
-
-haiku-* {
-		DESTDIR = lib
-}
-
-################################### COMMON stuff ##################################
 ################################### COMMON stuff ##################################
 
 DEPENDPATH += .

--- a/libbitdht/src/util/bdnet.h
+++ b/libbitdht/src/util/bdnet.h
@@ -103,8 +103,6 @@ int bdnet_inet_aton(const char *name, struct in_addr *addr);
 int bdnet_checkTTL(int fd);
 
 void	bdsockaddr_clear(struct sockaddr_in *addr);
-/* thread-safe version of inet_ntoa */
-std::string bdnet_inet_ntoa(struct in_addr in);
 
 /* Extra stuff to declare for windows error handling (mimics unix errno)
  */
@@ -174,5 +172,8 @@ int usleep(unsigned int usec);
 #ifdef  __cplusplus
 } /* C Interface */
 #endif
+
+/* thread-safe version of inet_ntoa */
+std::string bdnet_inet_ntoa(struct in_addr in);
 
 #endif /* BITDHT_UNIVERSAL_NETWORK_HEADER */

--- a/libretroshare/src/dbase/cachestrapper.cc
+++ b/libretroshare/src/dbase/cachestrapper.cc
@@ -1159,8 +1159,7 @@ bool CacheTransfer::RequestCache(RsCacheData &data, CacheStore *cbStore)
 			 */
 			if ((data.hash == dit->second.hash) && 
 				(data.path == dit->second.path) && 
-				(data.size == dit->second.size) && 
-				(cbStore == cbStore))
+                (data.size == dit->second.size))
 			{
 				std::cerr << "Re-request duplicate cache... let it continue";
 				std::cerr << std::endl;

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -10,29 +10,6 @@ DESTDIR = lib
 
 #CONFIG += dsdv
 
-profiling {
-	QMAKE_CXXFLAGS -= -fomit-frame-pointer
-	QMAKE_CXXFLAGS *= -pg -g -fno-omit-frame-pointer
-}
-
-# treat warnings as error for better removing
-#QMAKE_CFLAGS += -Werror
-#QMAKE_CXXFLAGS += -Werror
-
-debug {
-#	DEFINES *= DEBUG
-#	DEFINES *= OPENDHT_DEBUG DHT_DEBUG CONN_DEBUG DEBUG_UDP_SORTER P3DISC_DEBUG DEBUG_UDP_LAYER FT_DEBUG EXTADDRSEARCH_DEBUG
-#	DEFINES *= CONTROL_DEBUG FT_DEBUG DEBUG_FTCHUNK P3TURTLE_DEBUG
-#	DEFINES *= P3TURTLE_DEBUG 
-#	DEFINES *= NET_DEBUG
-#	DEFINES *= DISTRIB_DEBUG
-#	DEFINES *= P3TURTLE_DEBUG FT_DEBUG DEBUG_FTCHUNK MPLEX_DEBUG
-#	DEFINES *= STATUS_DEBUG SERV_DEBUG RSSERIAL_DEBUG #CONN_DEBUG 
-
-        QMAKE_CXXFLAGS -= -O2 -fomit-frame-pointer
-        QMAKE_CXXFLAGS *= -g -fno-omit-frame-pointer
-}
-
 dsdv {
 DEFINES *= SERVICES_DSDV
 HEADERS += services/p3dsdv.h \
@@ -121,9 +98,6 @@ HEADERS += $$PUBLIC_HEADERS
 linux-* {
 	CONFIG += link_pkgconfig
 
-	QMAKE_CXXFLAGS *= -Wall -D_FILE_OFFSET_BITS=64
-	QMAKE_CC = g++
-
 	contains(CONFIG, NO_SQLCIPHER) {
 		DEFINES *= NO_SQLCIPHER
 		PKGCONFIG *= sqlite3
@@ -181,14 +155,6 @@ unix {
 	#INSTALLS *= target
 }
 
-linux-g++ {
-	OBJECTS_DIR = temp/linux-g++/obj
-}
-
-linux-g++-64 {
-	OBJECTS_DIR = temp/linux-g++-64/obj
-}
-
 version_detail_bash_script {
     linux-* {
         QMAKE_EXTRA_TARGETS += write_version_detail
@@ -225,7 +191,6 @@ win32-x-g++ {
 ################################# Windows ##########################################
 
 win32 {
-	QMAKE_CC = g++
 	OBJECTS_DIR = temp/obj
 	MOC_DIR = temp/moc
 	DEFINES *= WINDOWS_SYS WIN32 STATICLIB MINGW WIN32_LEAN_AND_MEAN _USE_32BIT_TIME_T
@@ -259,7 +224,6 @@ win32 {
 ################################# MacOSX ##########################################
 
 mac {
-		QMAKE_CC = g++
 		OBJECTS_DIR = temp/obj
 		MOC_DIR = temp/moc
 		#DEFINES = WINDOWS_SYS WIN32 STATICLIB MINGW

--- a/libretroshare/src/pqi/p3netmgr.cc
+++ b/libretroshare/src/pqi/p3netmgr.cc
@@ -1454,6 +1454,8 @@ bool p3NetMgrIMPL::netAssistConnectActive()
 bool p3NetMgrIMPL::netAssistConnectStats(uint32_t &netsize, uint32_t &localnetsize)
 {
 	std::map<uint32_t, pqiNetAssistConnect *>::iterator it;
+    netsize = 0;
+    localnetsize = 0;
 	for(it = mDhts.begin(); it != mDhts.end(); ++it)
 	{
 		if (((it->second)->getActive()) && ((it->second)->getNetworkStats(netsize, localnetsize)))

--- a/libretroshare/src/pqi/pqimonitor.cc
+++ b/libretroshare/src/pqi/pqimonitor.cc
@@ -71,6 +71,10 @@ void    pqiConnectCbDummy::peerConnectRequest(const RsPeerId& id,
     std::cerr << std::endl;
 }
 
+void pqiConnectCbDummy::peerConnectRequest(const RsPeerId &id, const sockaddr_storage &raddr, const sockaddr_storage &, const sockaddr_storage &, uint32_t source, uint32_t, uint32_t, uint32_t) {
+    peerConnectRequest(id, raddr, source);
+}
+
 void pqiMonitor::disconnectPeer(const RsPeerId &peer)
 {
     std::cerr << "(EE) pqiMonitor::disconnectPeer() shouldn't be called!!!"<< std::endl;
@@ -78,7 +82,7 @@ void pqiMonitor::disconnectPeer(const RsPeerId &peer)
 
 #if 0
 void    pqiConnectCbDummy::stunStatus(std::string id, const struct sockaddr_storage *raddr, 
-							uint32_t type, uint32_t flags)
+                                      uint32_t type, uint32_t flags)
 {
 	std::cerr << "pqiConnectCbDummy::stunStatus()";
 	std::cerr << " idhash: " << RsUtil::BinToHex(id) << " raddr: " << sockaddr_storage_tostring(raddr);

--- a/libretroshare/src/pqi/pqimonitor.h
+++ b/libretroshare/src/pqi/pqimonitor.h
@@ -181,6 +181,9 @@ virtual void	peerStatus(const RsPeerId& id, const pqiIpAddrSet &addrs,
 
 virtual void    peerConnectRequest(const RsPeerId& id,              
                         const struct sockaddr_storage &raddr, uint32_t source);
+virtual void    peerConnectRequest(const RsPeerId& id, const struct sockaddr_storage &raddr,
+                const struct sockaddr_storage &/*proxyaddr*/,  const struct sockaddr_storage &/*srcaddr*/,
+                            uint32_t source, uint32_t /*flags*/, uint32_t /*delay*/, uint32_t /*bandwidth*/);
 
 //virtual void	stunStatus(std::string id, const struct sockaddr_storage &raddr, uint32_t type, uint32_t flags);
 };

--- a/libretroshare/src/pqi/pqiperson.cc
+++ b/libretroshare/src/pqi/pqiperson.cc
@@ -40,8 +40,7 @@ const int pqipersonzone = 82371;
 
 pqiperson::pqiperson(const RsPeerId& id, pqipersongrp *pg) :
 	PQInterface(id), mNotifyMtx("pqiperson-notify"), mPersonMtx("pqiperson"),
-	active(false), activepqi(NULL), inConnectAttempt(false), waittimes(0),
-	pqipg(pg) {} // TODO: must check id!
+    active(false), activepqi(NULL), inConnectAttempt(false), pqipg(pg) {} // TODO: must check id!
 
 pqiperson::~pqiperson()
 {

--- a/libretroshare/src/pqi/pqiperson.h
+++ b/libretroshare/src/pqi/pqiperson.h
@@ -66,7 +66,7 @@ public:
 	virtual int reset() { return ni->reset(); }
 	virtual int disconnect() { return ni->reset(); }
 	virtual bool connect_parameter(uint32_t type, uint32_t value) { return ni->connect_parameter(type, value);}
-	virtual bool connect_parameter(uint32_t type, std::string value) { return ni->connect_parameter(type, value);}
+    virtual bool connect_parameter(uint32_t type, const std::string& value) { return ni->connect_parameter(type, value);}
 	virtual bool connect_additional_address(uint32_t type, const struct sockaddr_storage &addr) { return ni->connect_additional_address(type, addr); }
 	virtual int getConnectAddress(struct sockaddr_storage &raddr){ return ni->getConnectAddress(raddr); }
 
@@ -171,7 +171,6 @@ private:
 	bool active;
 	pqiconnect *activepqi;
 	bool inConnectAttempt;
-	int waittimes;
 	time_t lastHeartbeatReceived; // use to track connection failure
 	pqipersongrp *pqipg; /* parent for callback */
 };

--- a/openpgpsdk/src/openpgpsdk.pro
+++ b/openpgpsdk/src/openpgpsdk.pro
@@ -9,8 +9,6 @@ macx {
 
 DEFINES *= OPENSSL_NO_IDEA 
 
-QMAKE_CXXFLAGS *= -Wall -Werror -W
-
 TARGET = ops
 DESTDIR = lib
 DEPENDPATH += .
@@ -18,23 +16,8 @@ INCLUDEPATH += .
 
 #################################### Windows #####################################
 
-linux-* {
-	OBJECTS_DIR = temp/linux/obj
-}
-
 win32 {
 	DEFINES *= WIN32_LEAN_AND_MEAN _USE_32BIT_TIME_T
-
-	# Switch off optimization for release version
-	QMAKE_CXXFLAGS_RELEASE -= -O2
-	QMAKE_CXXFLAGS_RELEASE += -O0
-	QMAKE_CFLAGS_RELEASE -= -O2
-	QMAKE_CFLAGS_RELEASE += -O0
-
-	# Switch on optimization for debug version
-	#QMAKE_CXXFLAGS_DEBUG += -O2
-	#QMAKE_CFLAGS_DEBUG += -O2
-
 	DEPENDPATH += $$INC_DIR
 	INCLUDEPATH += $$INC_DIR
 }

--- a/retroshare-gui/src/gui/FileTransfer/SearchDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/SearchDialog.cpp
@@ -535,7 +535,7 @@ void SearchDialog::collOpen()
 				if (qinfo.exists()) {
 					if (qinfo.absoluteFilePath().endsWith(RsCollectionFile::ExtensionString)) {
 						RsCollectionFile collection;
-						if (collection.load(qinfo.absoluteFilePath(), this)) {
+                        if (collection.load(qinfo.absoluteFilePath(), true)) {
 							collection.downloadFiles();
 							return;
 						}//if (collection.load(this))

--- a/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
@@ -2141,9 +2141,9 @@ void TransfersDialog::collView()
 			if (qinfo.absoluteFilePath().endsWith(RsCollectionFile::ExtensionString)) {
 				RsCollectionFile collection;
 				collection.openColl(qinfo.absoluteFilePath(), true);
-			}//if (qinfo.absoluteFilePath().endsWith(RsCollectionFile::ExtensionString))
-		}//if (qinfo.exists())
-	}//if (info.downloadStatus == FT_STATE_COMPLETE)
+            }
+        }
+    }
 }
 
 void TransfersDialog::collOpen()
@@ -2170,20 +2170,20 @@ void TransfersDialog::collOpen()
 				if (qinfo.exists()) {
 					if (qinfo.absoluteFilePath().endsWith(RsCollectionFile::ExtensionString)) {
 						RsCollectionFile collection;
-						if (collection.load(qinfo.absoluteFilePath(), this)) {
+                        if (collection.load(qinfo.absoluteFilePath(), true)) {
 							collection.downloadFiles();
 							return;
-						}//if (collection.load(this))
-					}//if (qinfo.absoluteFilePath().endsWith(RsCollectionFile::ExtensionString))
-				}//if (qinfo.exists())
-			}//if (info.downloadStatus == FT_STATE_COMPLETE)
-		}//if (rsFiles->FileDetails(
-	}//if (items.size() == 1)
+                        }
+                    }
+                }
+            }
+        }
+    }
 
 	RsCollectionFile collection;
 	if (collection.load(this)) {
 		collection.downloadFiles();
-	}//if (collection.load(this))
+    }
 }
 
 void TransfersDialog::setShowDLSizeColumn(bool show)

--- a/retroshare-gui/src/gui/People/PeopleDialog.cpp
+++ b/retroshare-gui/src/gui/People/PeopleDialog.cpp
@@ -901,7 +901,7 @@ void PeopleDialog::pf_dropEventOccursExt(QDropEvent *event)
 
 		QWidget *wid =
 		    qobject_cast<QWidget *>(event->source());//QT5 return QObject
-		FlowLayout *layout;
+        FlowLayout *layout = NULL;
 		if (wid) layout =
 		    qobject_cast<FlowLayout *>(wid->layout());
 		if (layout) {
@@ -991,7 +991,7 @@ void PeopleDialog::pf_dropEventOccursInt(QDropEvent *event)
 
 		QWidget *wid =
 		    qobject_cast<QWidget *>(event->source());//QT5 return QObject
-		FlowLayout *layout;
+        FlowLayout *layout = NULL;
 		if (wid) layout =
 		    qobject_cast<FlowLayout *>(wid->layout());
 		if (layout) {

--- a/retroshare-gui/src/gui/SharedFilesDialog.cpp
+++ b/retroshare-gui/src/gui/SharedFilesDialog.cpp
@@ -726,14 +726,14 @@ void SharedFilesDialog::collOpen()
 			if (qinfo.exists()) {
 				if (qinfo.absoluteFilePath().endsWith(RsCollectionFile::ExtensionString)) {
 					RsCollectionFile collection;
-					if (collection.load(qinfo.absoluteFilePath(), this)) {
+                    if (collection.load(qinfo.absoluteFilePath(), true)) {
 						collection.downloadFiles();
 						return;
-					}//if (collection.load(this))
-				}//if (qinfo.absoluteFilePath().endsWith(RsCollectionFile::ExtensionString))
-			}//if (qinfo.exists())
-		}//if (rsFiles->FileDetails(
-	}//if(files_info.size() == 1)
+                    }
+                }
+            }
+        }
+    }
 
 	RsCollectionFile collection;
 	if (collection.load(this)) {

--- a/retroshare-gui/src/gui/common/FlowLayout.cpp
+++ b/retroshare-gui/src/gui/common/FlowLayout.cpp
@@ -170,8 +170,6 @@ FlowLayoutWidget::FlowLayoutWidget(QWidget *parent, int margin/*=-1*/, int hSpac
 
 FlowLayoutWidget::FlowLayoutWidget(int margin/*=-1*/, int hSpacing/*=-1*/, int vSpacing/*=-1*/)
 {
-	FlowLayout *fl = new FlowLayout(this, margin, hSpacing, vSpacing);
-	Q_UNUSED(fl)
 	this->installEventFilter(this);
 	this->setMouseTracking(true);
 	this->setAcceptDrops(true);

--- a/retroshare-gui/src/gui/common/FriendList.cpp
+++ b/retroshare-gui/src/gui/common/FriendList.cpp
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 
-#include <QShortcut>
 #include <QTimer>
 #include <QTreeWidgetItem>
 #include <QWidgetAction>
@@ -150,8 +149,8 @@ FriendList::FriendList(QWidget *parent) :
 
     // workaround for Qt bug, should be solved in next Qt release 4.7.0
     // http://bugreports.qt.nokia.com/browse/QTBUG-8270
-    QShortcut *Shortcut = new QShortcut(QKeySequence(Qt::Key_Delete), ui->peerTreeWidget, 0, 0, Qt::WidgetShortcut);
-    connect(Shortcut, SIGNAL(activated()), this, SLOT(removefriend()));
+    mShortcut = new QShortcut(QKeySequence(Qt::Key_Delete), ui->peerTreeWidget, 0, 0, Qt::WidgetShortcut);
+    connect(mShortcut, SIGNAL(activated()), this, SLOT(removefriend()));
 
     /* Initialize tree */
     ui->peerTreeWidget->enableColumnCustomize(true);
@@ -177,6 +176,7 @@ FriendList::FriendList(QWidget *parent) :
 
 FriendList::~FriendList()
 {
+    mShortcut->deleteLater();
     delete ui;
     delete(mCompareRole);
 }

--- a/retroshare-gui/src/gui/common/FriendList.h
+++ b/retroshare-gui/src/gui/common/FriendList.h
@@ -23,9 +23,8 @@
 #define FRIENDLIST_H
 
 #include <set>
-
+#include <QShortcut>
 #include <QWidget>
-
 #include "retroshare-gui/RsAutoUpdatePage.h"
 #include "retroshare/rsstatus.h"
 
@@ -110,6 +109,7 @@ private:
     Ui::FriendList *ui;
     RSTreeWidgetItemCompareRole *mCompareRole;
     QAction *mActionSortByState;
+    QShortcut *mShortcut;
 
     // Settings for peer list display
     bool mShowGroups;

--- a/retroshare-gui/src/gui/common/UserNotify.cpp
+++ b/retroshare-gui/src/gui/common/UserNotify.cpp
@@ -92,16 +92,15 @@ void UserNotify::setNotifyEnabled(bool enabled, bool combined, bool blink)
 void UserNotify::initialize(QToolBar *mainToolBar, QAction *mainAction, QListWidgetItem *listItem)
 {
 	mMainAction = mainAction;
+    mListItem = listItem;
 	if (mMainAction) {
 		mButtonText = mMainAction->text();
 		if (mainToolBar) {
 			mMainToolButton = dynamic_cast<QToolButton*>(mainToolBar->widgetForAction(mMainAction));
 		}
-	}
-	mListItem = listItem;
-	if (mListItem && !mMainAction) {
-		mButtonText = mMainAction->text();
-	}
+    } else {
+        mButtonText = mListItem->text();
+    }
 }
 
 void UserNotify::createIcons(QMenu *notifyMenu)

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -571,6 +571,7 @@ void GxsForumThreadWidget::changedThread()
 {
 	/* just grab the ids of the current item */
 	QTreeWidgetItem *item = ui->threadTreeWidget->currentItem();
+    Q_ASSERT(item != NULL);
 
 	if (!item || !item->isSelected()) {
 		mThreadId.clear();
@@ -582,13 +583,13 @@ void GxsForumThreadWidget::changedThread()
     	if(mForumGroup.mMeta.mSignFlags & GXS_SERV::FLAG_AUTHOR_AUTHENTICATION_TRACK_MESSAGES) 
         {
             RsPeerId providerId ;
-	    std::string msgId = item->data(COLUMN_THREAD_DATA, ROLE_THREAD_MSGID).toString().toStdString();
-        	RsGxsMessageId mid(msgId) ;
-            
-            if(rsGRouter->getTrackingInfo(mid,providerId) && !providerId.isNull() )
-		item->setToolTip(COLUMN_THREAD_TITLE,tr("This message was obtained from %1").arg(QString::fromUtf8(rsPeers->getPeerName(providerId).c_str())));
+            if(item != NULL) {
+                std::string msgId = item->data(COLUMN_THREAD_DATA, ROLE_THREAD_MSGID).toString().toStdString();
+                RsGxsMessageId mid(msgId);
+                if(rsGRouter->getTrackingInfo(mid,providerId) && !providerId.isNull() )
+                    item->setToolTip(COLUMN_THREAD_TITLE,tr("This message was obtained from %1").arg(QString::fromUtf8(rsPeers->getPeerName(providerId).c_str())));
+            }
         }
-        
 	if (mFillThread) {
 		return;
 	}

--- a/retroshare-gui/src/gui/statistics/GlobalRouterStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/GlobalRouterStatistics.cpp
@@ -377,9 +377,7 @@ void GlobalRouterStatisticsWidget::updateContent()
         
     mMaxWheelZoneY = oy+celly ;
     
-    painter.setPen(QColor::fromRgb(0,0,0)) ;
-    
-    painter.setPen(QColor::fromRgb(0.5,0.5,0.5));
+    painter.setPen(QColor::fromRgb(0,0,0));
     painter.drawRect(ox+2*cellx,current_oy+0.15*celly,fm_monospace.width(ids)+cellx*matrix_info.friend_ids.size()- 2*cellx,celly) ;
 
     float total_length = (matrix_info.friend_ids.size()+2)*cellx ;

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -43,15 +43,6 @@ RCC_DIR = temp/qrc
 UI_DIR  = temp/ui
 MOC_DIR = temp/moc
 
-#CONFIG += debug
-debug {
-	QMAKE_CFLAGS += -g
-	QMAKE_CXXFLAGS -= -O2
-	QMAKE_CXXFLAGS += -O0
-	QMAKE_CFLAGS -= -O2
-	QMAKE_CFLAGS += -O0
-}
-
 DEPENDPATH *= retroshare-gui
 INCLUDEPATH *= retroshare-gui
 
@@ -100,14 +91,6 @@ unix {
 	pixmap_files.files = ../../data/retroshare06.xpm
 	INSTALLS += pixmap_files
 
-}
-
-linux-g++ {
-	OBJECTS_DIR = temp/linux-g++/obj
-}
-
-linux-g++-64 {
-	OBJECTS_DIR = temp/linux-g++-64/obj
 }
 
 version_detail_bash_script {
@@ -169,16 +152,6 @@ win32 {
 
 	# solve linker warnings because of the order of the libraries
 	QMAKE_LFLAGS += -Wl,--start-group
-
-	# Switch off optimization for release version
-	QMAKE_CXXFLAGS_RELEASE -= -O2
-	QMAKE_CXXFLAGS_RELEASE += -O0
-	QMAKE_CFLAGS_RELEASE -= -O2
-	QMAKE_CFLAGS_RELEASE += -O0
-
-	# Switch on optimization for debug version
-	#QMAKE_CXXFLAGS_DEBUG += -O2
-	#QMAKE_CFLAGS_DEBUG += -O2
 
 	OBJECTS_DIR = temp/obj
 	#LIBS += -L"D/Qt/2009.03/qt/plugins/imageformats"

--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -10,17 +10,6 @@ CONFIG += webui
 CONFIG -= qt xml gui
 CONFIG += link_prl
 
-#CONFIG += debug
-debug {
-        QMAKE_CFLAGS -= -O2
-        QMAKE_CFLAGS += -O0
-        QMAKE_CFLAGS += -g
-
-        QMAKE_CXXFLAGS -= -O2
-        QMAKE_CXXFLAGS += -O0
-        QMAKE_CXXFLAGS += -g
-}
-
 ################################# Linux ##########################################
 linux-* {
 	#CONFIG += version_detail_bash_script
@@ -34,13 +23,6 @@ unix {
 	INSTALLS += target
 }
 
-linux-g++ {
-	OBJECTS_DIR = temp/linux-g++/obj
-}
-
-linux-g++-64 {
-	OBJECTS_DIR = temp/linux-g++-64/obj
-}
 
 #################### Cross compilation for windows under Linux ###################
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -1,5 +1,54 @@
 # Gxs is always enabled now.
 DEFINES *= RS_ENABLE_GXS
+OBJECTS_DIR = obj
+#CONFIG -= debug
+
+SECURITY_FLAGS += #-fstack-protector-strong #activated by default on modern gcc and clang. However some compilers can't handle it.
+OPTIMIZER_FLAGS += -O2
+
+QMAKE_CXXFLAGS *= -std=c++11
+
+QMAKE_LFLAGS_RELEASE   *= $$SECURITY_FLAGS $$OPTIMIZER_FLAGS
+QMAKE_CFLAGS_RELEASE   *= $$SECURITY_FLAGS $$OPTIMIZER_FLAGS
+QMAKE_CXXFLAGS_RELEASE *= $$SECURITY_FLAGS $$OPTIMIZER_FLAGS
+
+PRETTY_TRACE += -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls
+DEBUG_FLAGS  += -g $$PRETTY_TRACE
+QMAKE_CFLAGS_DEBUG  *= $$DEBUG_FLAGS
+QMAKE_CXXFLAGS_DEBUG *= $$DEBUG_FLAGS
+
+
+profiling {
+        QMAKE_CXXFLAGS *= -pg -g $$OPTIMIZER_FLAGS
+}
+
+#Activates link time optimization. Might cause build failures if your toolchain doesn't support it.
+#CONFIG += lto
+*clang*{
+    lto{
+        OBJECTS_DIR = llvm-bc
+        QMAKE_LFLAGS   *= -flto
+        QMAKE_CFLAGS   *= -emit-llvm -flto
+        QMAKE_CXXFLAGS *= -emit-llvm -flto
+        #SECURITY_FLAGS += -fsanitize=cfi
+    }
+    SECURITY_FLAGS += -D_FORTIFY_SOURCE
+    #SECURITY_FLAGS += -fsanitize=safe-stack
+
+    QMAKE_LFLAGS_RELEASE   *= $$SECURITY_FLAGS
+    QMAKE_CFLAGS_RELEASE   *= $$SECURITY_FLAGS
+    QMAKE_CXXFLAGS_RELEASE *= $$SECURITY_FLAGS
+
+    #DEBUG_FLAGS += -fsanitize=undefined
+
+    #Choose at most one of the 3 following sanitizers
+    #DEBUG_FLAGS += -fsanitize=address $$PRETTY_TRACE
+    #DEBUG_FLAGS += -fsanitize=memory -fsanitize-memory-track-origins=2
+    #DEBUG_FLAGS += -fsanitize=thread
+
+    QMAKE_CFLAGS_DEBUG  *= $$DEBUG_FLAGS
+    QMAKE_CXXFLAGS_DEBUG *= $$DEBUG_FLAGS
+}
 
 unix {
 	isEmpty(PREFIX)   { PREFIX   = "/usr" }

--- a/supportlibs/pegmarkdown/pegmarkdown.pro
+++ b/supportlibs/pegmarkdown/pegmarkdown.pro
@@ -5,30 +5,6 @@ CONFIG -= qt
 TARGET = pegmarkdown
 DESTDIR = lib
 
-QMAKE_CFLAGS *= -Wall -ansi  -D_GNU_SOURCE
-QMAKE_CC = gcc
-
-#CONFIG += debug
-debug {
-        QMAKE_CFLAGS -= -O2 
-        QMAKE_CFLAGS *= -g 
-}
-
-################################# Linux ##########################################
-linux-* {
-	CONFIG += link_pkgconfig
-
-	PKGCONFIG *= glib-2.0
-}
-
-linux-g++ {
-	OBJECTS_DIR = temp/linux-g++/obj
-}
-
-linux-g++-64 {
-	OBJECTS_DIR = temp/linux-g++-64/obj
-}
-
 ################################# Windows ##########################################
 
 win32 {
@@ -37,10 +13,6 @@ win32 {
 
 		# Switch on extra warnings
 		QMAKE_CFLAGS += -Wextra
-
-		# Switch off optimization for release version
-		QMAKE_CFLAGS_RELEASE -= -O2
-		QMAKE_CFLAGS_RELEASE += -O0
 
 		CONFIG += dummy_glib 
 

--- a/tests/librssimulator/librssimulator.pro
+++ b/tests/librssimulator/librssimulator.pro
@@ -3,18 +3,7 @@ CONFIG += staticlib
 CONFIG -= qt
 TARGET = rssimulator
 
-CONFIG += gxs debug
-
-profiling {
-	QMAKE_CXXFLAGS -= -fomit-frame-pointer
-	QMAKE_CXXFLAGS *= -pg -g -fno-omit-frame-pointer
-}
-
-
-debug {
-        QMAKE_CXXFLAGS -= -O2 -fomit-frame-pointer
-        QMAKE_CXXFLAGS *= -g -fno-omit-frame-pointer
-}
+CONFIG += gxs
 
 # gxs defines.
 gxs {
@@ -69,8 +58,6 @@ linux-* {
 	INCLUDEPATH *= $${OPENPGPSDK_DIR} ../openpgpsdk
 
 	DESTDIR = lib
-	QMAKE_CXXFLAGS *= -Wall -D_FILE_OFFSET_BITS=64
-	QMAKE_CC = g++
 
 	SSL_DIR = /usr/include/openssl
 	UPNP_DIR = /usr/include/upnp
@@ -103,14 +90,6 @@ linux-* {
 	DEFINES *= UBUNTU
 	INCLUDEPATH += /usr/include/glib-2.0/ /usr/lib/glib-2.0/include
 	LIBS *= -lgnome-keyring
-}
-
-linux-g++ {
-	OBJECTS_DIR = temp/linux-g++/obj
-}
-
-linux-g++-64 {
-	OBJECTS_DIR = temp/linux-g++-64/obj
 }
 
 version_detail_bash_script {


### PR DESCRIPTION
1. Improved buildfiles:
   -Some subprojects did override compiler flags and commands, which set g++ as the compiler even if clang was chosen.
   -Added link time optimizations for clang. If your toolchain supports it, you can activate it by setting CONFIG += lto in retroshare.pri
   -fstack-protector-strong was added to the compiler flags, although it is set by default in clang and gcc (at least in my distro). However I wanted to raise awareness for security flags and make it easy to add more in the future.
   Edit: Uncommented -fstack-protector-strong because the Travis CI build can't deal with it.
   -Clang users can add sanitizer flags to activate runtime checks for debugging or increasing security by uncommenting certain lines in retroshare.pri (see http://clang.llvm.org/docs/UsersManual.html#controlling-code-generation)
2. Bugfixes
   I fixed some potential bugs found by clang's static analyzer and some compiler warnings.
