### PR TITLE
Fix segfault on shutdown.

### DIFF
--- a/libretroshare/src/util/smallobject.cc
+++ b/libretroshare/src/util/smallobject.cc
@@ -279,10 +279,6 @@ void *SmallObject::operator new(size_t size)
 #endif
 
 	RsStackMutex m(_mtx) ;
-
-	if(!_allocator._active)
-		return (void*)NULL;
-
 	void *p = _allocator.allocate(size) ;
 #ifdef DEBUG_MEMORY
 	std::cerr << "new RsItem: " << p << ", size=" << size << std::endl;


### PR DESCRIPTION
Fix issue https://github.com/RetroShare/RetroShare/issues/324 and https://github.com/RetroShare/RetroShare/issues/366

The problem is similar to this code:

```
#include <iostream>

class Base {
public:
    Base(){
        std::cout<<"Base constructor called.\n";
        //x = 24; //Segfault because this==NULL
    }
    void *operator new(size_t size){
        std::cout<<"Base new called.\n";
        return NULL;
    }
private:
    int x;
};

class Derived :public Base {
public:
    Derived(){
        std::cout<<"Derived constructor called.\n";
        //y = 42; //Segfault because this==NULL
    }
    //void *operator new(size_t size) is inherited.
private:
    int y;
};
int main(){
    Derived* base = new Derived(); //new is inherited from Base
    return 0;
}
```
#0  0x00000000010d8029 in RsMemoryManagement::SmallObject::SmallObject (this=0x0)

```
at ./util/smallobject.h:100
```
#1  0x00000000010d6250 in RsItem::RsItem (this=0x0, t=33559555) at serialiser/rsserial.cc:52
#2  0x00000000010ff238 in RsRawItem::RsRawItem (**this=0x0**, t=33559555, size=38)

```
at ./serialiser/rsserial.h:183 **<--- this is NULL because new which returns NULL is inherited from SmallObject**
```
#3  0x000000000132dced in RsServiceSerialiser::deserialise (this=0x7fffb02a3ea0, data=0x7fffd800e570,

```
pktsize=0x7fff43fe6cd4) at serialiser/rsserviceserialiser.cc:91
```
