### PR TITLE
Introduce thread names to simplify debugging

### DIFF
--- a/libresapi/src/api/RsControlModule.cpp
+++ b/libresapi/src/api/RsControlModule.cpp
@@ -30,7 +30,7 @@ RsControlModule::RsControlModule(int argc, char **argv, StateTokenServer* sts, A
     this->argv = argv;
     // start worker thread
     if(full_control)
-        start();
+        start("RS ctrl module");
     else
         mRunState = RUNNING_OK_NO_FULL_CONTROL;
 

--- a/libretroshare/src/ft/ftserver.cc
+++ b/libretroshare/src/ft/ftserver.cc
@@ -188,19 +188,18 @@ void    ftServer::StartupThreads()
 
 	/* self contained threads */
 	/* startup ExtraList Thread */
-	mFtExtra->start();
+	mFtExtra->start("RS ft extra lst");
 
 	/* startup Monitor Thread */
 	/* startup the FileMonitor (after cache load) */
 	/* start it up */
-	
-	mFiMon->start();
+	mFiMon->start("RS ft monitor");
 
 	/* Controller thread */
-	mFtController->start();
+	mFtController->start("RS ft ctrl");
 
 	/* Dataplex */
-	mFtDataplex->start();
+	mFtDataplex->start("RS ft dataplex");
 }
 
 void ftServer::StopThreads()

--- a/libretroshare/src/util/rsthreads.cc
+++ b/libretroshare/src/util/rsthreads.cc
@@ -83,6 +83,7 @@ RsThread::RsThread()
     mHasStoppedSemaphore.set(1) ;
     mShouldStopSemaphore.set(0) ;
 }
+
 bool RsThread::isRunning()
 {
     // do we need a mutex for this ?
@@ -142,7 +143,8 @@ void RsTickingThread::fullstop()
     THREAD_DEBUG << "  finished!" << std::endl;
 #endif
 }
-void RsThread::start()
+
+void RsThread::start(const std::string &threadName)
 {
     pthread_t tid;
     void  *data = (void *)this ;
@@ -158,11 +160,27 @@ void RsThread::start()
     // -> the new thread will see mIsRunning() = true
 
     if( 0 == (err=pthread_create(&tid, 0, &rsthread_init, data)))
+    {
         mTid = tid;
+
+        // set name
+		if(!threadName.empty()) {
+			// thread names are restricted to 16 characters including the terminating null byte
+			if(threadName.length() > 15)
+			{
+#ifdef DEBUG_THREADS
+				THREAD_DEBUG << "RsThread::start called with to long name '" << name << "' truncating..." << std::endl;
+#endif
+				pthread_setname_np(mTid, threadName.substr(0, 15).c_str());
+			} else {
+				pthread_setname_np(mTid, threadName.c_str());
+			}
+		}
+    }
     else
     {
         THREAD_DEBUG << "Fatal error: pthread_create could not create a thread. Error returned: " << err << " !!!!!!!" << std::endl;
-	mHasStoppedSemaphore.set(1) ;
+        mHasStoppedSemaphore.set(1) ;
     }
 }
 

--- a/libretroshare/src/util/rsthreads.h
+++ b/libretroshare/src/util/rsthreads.h
@@ -245,7 +245,7 @@ class RsThread
     RsThread();
     virtual ~RsThread() {}
 
-    void start() ;
+    void start(const std::string &threadName = "");
 
     // Returns true of the thread is still running.
 


### PR DESCRIPTION
This patch adds the option to specify a thread name when starting/creating a new one.

I'd like to hear your opinions about this and especially how you want the threads to be named. I've added names to a few threads as an example: The scheme is _RS + something specifying_.

When you are fine with the approach and the name schema i'll start adding more thread names to the existing threads.

---

Instead of having a bunch of _RetroShare06_ threads all sitting in _nanosleep()_ you can now tell which thread it is by the name:

```
(gdb) info threads 
  Id   Target Id         Frame 
* 1    Thread 0x7ffff7f0c800 (LWP 16674) "RetroShare06" 0x00007ffff275f68d in poll () from /usr/lib/libc.so.6
  2    Thread 0x7fffe8cc5700 (LWP 16678) "RetroShare06" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
  3    Thread 0x7fffe5d2c700 (LWP 16679) "QXcbEventReader" 0x00007ffff275f68d in poll () from /usr/lib/libc.so.6
  4    Thread 0x7fffd8f05700 (LWP 16680) "QDBusConnection" 0x00007ffff275f68d in poll () from /usr/lib/libc.so.6
  5    Thread 0x7fffd00cf700 (LWP 16681) "RetroShare06" 0x00007ffff32d009f in pthread_cond_wait@@GLIBC_2.3.2 () from /usr/lib/libpthread.so.0
  ...
  21   Thread 0x7fffbd7fa700 (LWP 16699) "RetroShare06" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
  22   Thread 0x7fffbcff9700 (LWP 16700) "RS ft extra lst" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
  23   Thread 0x7fffb3fff700 (LWP 16701) "RS ft monitor" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
  24   Thread 0x7fffb37fe700 (LWP 16702) "RS ft ctrl" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
  25   Thread 0x7fffb2ffd700 (LWP 16703) "RS ft dataplex" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
  26   Thread 0x7fffb27fc700 (LWP 16704) "RetroShare06" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
  27   Thread 0x7fffb1ffb700 (LWP 16705) "RetroShare06" 0x00007ffff27384fd in nanosleep () from /usr/lib/libc.so.6
```
