### PR TITLE
remove compiler warnings in libbitdht and openpgpsdk

### DIFF
--- a/libbitdht/src/bitdht/bdfilter.cc
+++ b/libbitdht/src/bitdht/bdfilter.cc
@@ -46,8 +46,6 @@ bdFilter::bdFilter(const std::string &fname, const bdNodeId *ownid,  uint32_t fi
     mFns = fns;
     mFilename = fname ;
 
-    time_t now = time(NULL) ;
-
     loadBannedIpFile() ;
 
     mFilterFlags = filterFlags;
@@ -91,8 +89,6 @@ void bdFilter::loadBannedIpFile()
         struct sockaddr_in addr;
         memset(&addr, 0, sizeof(struct sockaddr_in));
         addr.sin_family = PF_INET;
-
-        unsigned short port;
 
     FILE *fd = fopen(mFilename.c_str(),"r") ;
 

--- a/libbitdht/src/bitdht/bdpeer.cc
+++ b/libbitdht/src/bitdht/bdpeer.cc
@@ -344,6 +344,8 @@ int bdSpace::find_node(const bdNodeId *id, int number, std::list<bdId> &matchIds
 	std::cerr << " Number: " << number;
 	std::cerr << " Bucket #: " << buckno;
 	std::cerr << std::endl;
+#else
+	(void)number;
 #endif
 
 	bdBucket &buck = buckets[buckno];

--- a/openpgpsdk/src/openpgpsdk/create.c
+++ b/openpgpsdk/src/openpgpsdk/create.c
@@ -509,7 +509,7 @@ ops_boolean_t ops_write_transferable_public_key_from_packet_data(const ops_keyda
 						ops_create_info_t *info)
 {
 	ops_boolean_t rtn = ops_true;
-	unsigned int i=0,j=0;
+	unsigned int i=0;
 
 	if (armoured)
 	{ ops_writer_push_armoured(info, OPS_PGP_PUBLIC_KEY_BLOCK); }
@@ -532,7 +532,7 @@ ops_boolean_t ops_write_transferable_secret_key_from_packet_data(const ops_keyda
 						ops_create_info_t *info)
 {
 	ops_boolean_t rtn = ops_true;
-	unsigned int i=0,j=0;
+	unsigned int i=0;
 
 	if(keydata->type != OPS_PTAG_CT_ENCRYPTED_SECRET_KEY)
 	{

--- a/openpgpsdk/src/openpgpsdk/crypto.c
+++ b/openpgpsdk/src/openpgpsdk/crypto.c
@@ -309,11 +309,6 @@ ops_boolean_t ops_decrypt_memory(const unsigned char *encrypted_memory,int em_le
 										 const ops_boolean_t use_armour,
 										 ops_parse_cb_t* cb_get_passphrase)
 {
-    int fd_in=0;
-    int fd_out=0;
-    char* myfilename=NULL;
-
-    //
     ops_parse_info_t *pinfo=NULL;
 
     // setup for reading from given input file
@@ -368,7 +363,6 @@ ops_boolean_t ops_decrypt_memory(const unsigned char *encrypted_memory,int em_le
  	 *decrypted_memory = ops_mallocz(*out_length) ;
 	 memcpy(*decrypted_memory,ops_memory_get_data(output_mem),*out_length) ;
 
-ops_decrypt_memory_ABORT: 
     ops_teardown_memory_write(pinfo->cbinfo.cinfo, output_mem);
     ops_teardown_memory_read(pinfo, input_mem);
 

--- a/openpgpsdk/src/openpgpsdk/keyring.c
+++ b/openpgpsdk/src/openpgpsdk/keyring.c
@@ -616,8 +616,6 @@ ops_boolean_t ops_add_selfsigned_userid_to_keydata(ops_keydata_t* keydata, ops_u
 ops_boolean_t ops_sign_key(ops_keydata_t* keydata, const unsigned char *signers_key_id,ops_secret_key_t *signers_key)
 {
 /*	ops_memory_t* mem_userid=NULL; */
-	ops_create_info_t* cinfo_userid=NULL;
-
 	ops_memory_t* mem_sig=NULL;
 	ops_create_info_t* cinfo_sig=NULL;
 

--- a/openpgpsdk/src/openpgpsdk/packet-print.c
+++ b/openpgpsdk/src/openpgpsdk/packet-print.c
@@ -998,7 +998,7 @@ int ops_print_packet(const ops_parser_content_t *content_)
 
  case OPS_PTAG_SS_EMBEDDED_SIGNATURE:
      start_subpacket(content_->tag);
-     end_subpacket(content_->tag); // \todo print out contents?
+     end_subpacket(); // \todo print out contents?
      break;
 
     case OPS_PTAG_SS_USERDEFINED00:

--- a/openpgpsdk/src/openpgpsdk/util.c
+++ b/openpgpsdk/src/openpgpsdk/util.c
@@ -118,7 +118,7 @@ void *ops_mallocz(size_t n)
 	void *m=malloc(n);
 
 	if(m == NULL)
-		fprintf(stderr,"(EE) Cannot allocate %d bytes of memory in %s\n",n,__PRETTY_FUNCTION__) ;
+		fprintf(stderr,"(EE) Cannot allocate %lu bytes of memory in %s\n",n,__PRETTY_FUNCTION__) ;
 	else
 		memset(m,'\0',n);
 


### PR DESCRIPTION
The warnings were reported by either gcc or/and clang. 
Most of them are unused variables.
