### PR TITLE
Fix most compiler warning in libretroshare + cleanup UBUNTU define

### DIFF
--- a/libretroshare/src/dbase/cachestrapper.cc
+++ b/libretroshare/src/dbase/cachestrapper.cc
@@ -1159,8 +1159,7 @@ bool CacheTransfer::RequestCache(RsCacheData &data, CacheStore *cbStore)
 			 */
 			if ((data.hash == dit->second.hash) && 
 				(data.path == dit->second.path) && 
-				(data.size == dit->second.size) && 
-				(cbStore == cbStore))
+				(data.size == dit->second.size))
 			{
 				std::cerr << "Re-request duplicate cache... let it continue";
 				std::cerr << std::endl;

--- a/libretroshare/src/ft/ftserver.cc
+++ b/libretroshare/src/ft/ftserver.cc
@@ -256,7 +256,7 @@ bool	ftServer::ResumeTransfers()
 	return true;
 }
 
-bool ftServer::checkHash(const RsFileHash& hash,std::string& error_string)
+bool ftServer::checkHash(const RsFileHash& /*hash*/, std::string& /*error_string*/)
 {
     return true ;
 }

--- a/libretroshare/src/grouter/grouteritems.cc
+++ b/libretroshare/src/grouter/grouteritems.cc
@@ -532,7 +532,7 @@ bool RsGRouterTransactionAcknItem::serialise(void *data,uint32_t& size) const
 
     return ok;
 }
-bool RsGRouterGenericDataItem::serialise_signed_data(void *data,uint32_t& size) const
+bool RsGRouterGenericDataItem::serialise_signed_data(void *data, uint32_t &/*size*/) const
 {
     bool ok = true;
 
@@ -580,7 +580,7 @@ bool RsGRouterSignedReceiptItem::serialise(void *data,uint32_t& size) const
 
 	return ok;
 }
-bool RsGRouterSignedReceiptItem::serialise_signed_data(void *data,uint32_t& size) const
+bool RsGRouterSignedReceiptItem::serialise_signed_data(void *data, uint32_t &/*size*/) const
 {
     bool ok = true;
 

--- a/libretroshare/src/grouter/p3grouter.cc
+++ b/libretroshare/src/grouter/p3grouter.cc
@@ -483,7 +483,7 @@ void p3GRouter::handleLowLevelTransactionAckItem(RsGRouterTransactionAcknItem *t
 #endif
 }
 
-void p3GRouter::receiveTurtleData(RsTurtleGenericTunnelItem *gitem,const RsFileHash& hash,const RsPeerId& virtual_peer_id,RsTurtleGenericTunnelItem::Direction direction)
+void p3GRouter::receiveTurtleData(RsTurtleGenericTunnelItem *gitem, const RsFileHash &/*hash*/, const RsPeerId &virtual_peer_id, RsTurtleGenericTunnelItem::Direction /*direction*/)
 {
 #ifdef GROUTER_DEBUG
     std::cerr << "p3GRouter::receiveTurtleData() " << std::endl;

--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -310,17 +310,16 @@ RsGxsNetService::RsGxsNetService(uint16_t servType, RsGeneralDataService *gds,
                                  const RsServiceInfo serviceInfo,
                                  RsGixsReputation* reputations, RsGcxs* circles, RsGixs *gixs,
                                  PgpAuxUtils *pgpUtils, bool grpAutoSync,bool msgAutoSync)
-                                     : p3ThreadedService(), p3Config(), mTransactionN(0),
-                                       mObserver(nxsObs),
-                                       mDataStore(gds), 
-                                       mServType(servType),
-                                       mGixs(gixs), 
-                                       mTransactionTimeOut(TRANSAC_TIMEOUT), mNetMgr(netMgr), mNxsMutex("RsGxsNetService"),
-                                       mSyncTs(0), mLastKeyPublishTs(0),mLastCleanRejectedMessages(0), mSYNC_PERIOD(SYNC_PERIOD), mCircles(circles), mReputations(reputations),
-					mPgpUtils(pgpUtils),
-                    mGrpAutoSync(grpAutoSync),mAllowMsgSync(msgAutoSync), mGrpServerUpdateItem(NULL),
-					mServiceInfo(serviceInfo)
-
+                                 : p3ThreadedService(), p3Config(), mTransactionN(0),
+                                   mObserver(nxsObs), mDataStore(gds),
+                                   mServType(servType), mTransactionTimeOut(TRANSAC_TIMEOUT),
+                                   mNetMgr(netMgr), mNxsMutex("RsGxsNetService"),
+                                   mSyncTs(0), mLastKeyPublishTs(0),
+                                   mLastCleanRejectedMessages(0), mSYNC_PERIOD(SYNC_PERIOD),
+                                   mCircles(circles), mGixs(gixs),
+                                   mReputations(reputations), mPgpUtils(pgpUtils),
+                                   mGrpAutoSync(grpAutoSync), mAllowMsgSync(msgAutoSync),
+                                   mGrpServerUpdateItem(NULL), mServiceInfo(serviceInfo)
 {
 	addSerialType(new RsNxsSerialiser(mServType));
 	mOwnId = mNetMgr->getOwnId();
@@ -1616,7 +1615,6 @@ void RsGxsNetService::recvNxsItemQueue()
             if(ni->PacketSubType() == RS_PKT_SUBTYPE_NXS_ENCRYPTED_DATA_ITEM)
             {
                 RsNxsItem *decrypted_item ;
-                uint32_t status ;
                 
                 if(decryptSingleNxsItem(dynamic_cast<RsNxsEncryptedDataItem*>(ni),decrypted_item))
                 {

--- a/libretroshare/src/gxs/rsgxsutil.cc
+++ b/libretroshare/src/gxs/rsgxsutil.cc
@@ -54,7 +54,7 @@ RsGxsMessageCleanUp::RsGxsMessageCleanUp(RsGeneralDataService* const dataService
 
 bool RsGxsMessageCleanUp::clean()
 {
-	int i = 1;
+	uint32_t i = 1;
 
 	time_t now = time(NULL);
 
@@ -281,7 +281,7 @@ bool RsGxsIntegrityCheck::check()
 	    std::cerr << "    " << *it <<  std::endl;
 #endif
     }
-    int nb_requested_not_in_cache = 0;
+    uint32_t nb_requested_not_in_cache = 0;
 
 #ifdef GXSUTIL_DEBUG
     std::cerr << "  issuing random get on friends for non existing IDs" << std::endl;
@@ -289,7 +289,7 @@ bool RsGxsIntegrityCheck::check()
 
     // now request a cache update for them, which triggers downloading from friends, if missing.
 
-    for(;nb_requested_not_in_cache<MAX_GXS_IDS_REQUESTS_NET && gxs_ids.size()>0;)
+    for(;nb_requested_not_in_cache < MAX_GXS_IDS_REQUESTS_NET && gxs_ids.size() > (size_t)0;)
     {
 	    uint32_t n = RSRandom::random_u32() % gxs_ids.size() ;
 #ifdef GXSUTIL_DEBUG

--- a/libretroshare/src/gxstunnel/p3gxstunnel.cc
+++ b/libretroshare/src/gxstunnel/p3gxstunnel.cc
@@ -301,7 +301,7 @@ void p3GxsTunnelService::handleIncomingItem(const RsGxsTunnelId& tunnel_id,RsGxs
     delete item ;
 }
 
-void p3GxsTunnelService::handleRecvTunnelDataAckItem(const RsGxsTunnelId& id,RsGxsTunnelDataAckItem *item) 
+void p3GxsTunnelService::handleRecvTunnelDataAckItem(const RsGxsTunnelId &/*id*/,RsGxsTunnelDataAckItem *item)
 {
     RS_STACK_MUTEX(mGxsTunnelMtx); /********** STACK LOCKED MTX ******/
     

--- a/libretroshare/src/gxstunnel/rsgxstunnelitems.cc
+++ b/libretroshare/src/gxstunnel/rsgxstunnelitems.cc
@@ -373,7 +373,7 @@ RsGxsTunnelDHPublicKeyItem *RsGxsTunnelSerialiser::deserialise_RsGxsTunnelDHPubl
     return item ;
 }
 
-RsGxsTunnelDataItem *RsGxsTunnelSerialiser::deserialise_RsGxsTunnelDataItem(void *dat,uint32_t size)
+RsGxsTunnelDataItem *RsGxsTunnelSerialiser::deserialise_RsGxsTunnelDataItem(void *dat,uint32_t /*size*/)
 {
     uint32_t offset = 8; // skip the header 
     uint32_t rssize = getRsItemSize(dat);
@@ -450,7 +450,7 @@ RsGxsTunnelDataAckItem *RsGxsTunnelSerialiser::deserialise_RsGxsTunnelDataAckIte
     return item ;
 }
 
-RsGxsTunnelStatusItem *RsGxsTunnelSerialiser::deserialise_RsGxsTunnelStatusItem(void *dat,uint32_t size)
+RsGxsTunnelStatusItem *RsGxsTunnelSerialiser::deserialise_RsGxsTunnelStatusItem(void *dat, uint32_t /*size*/)
 {
     uint32_t offset = 8; // skip the header 
     uint32_t rssize = getRsItemSize(dat);

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -160,7 +160,7 @@ linux-* {
 		DEFINES *= PATCHED_LIBUPNP
 	}
 
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 	PKGCONFIG *= gnome-keyring-1
 	PKGCONFIG *= libssl libupnp
 	PKGCONFIG *= libcrypto zlib

--- a/libretroshare/src/plugins/pluginmanager.cc
+++ b/libretroshare/src/plugins/pluginmanager.cc
@@ -554,7 +554,7 @@ bool RsPluginManager::saveList(bool& cleanup, std::list<RsItem*>& list)
 // {
 // }
 
-RsPQIService::RsPQIService(uint16_t service_type,uint32_t /*tick_delay_in_seconds*/, RsPluginHandler* /*pgHandler*/)
+RsPQIService::RsPQIService(uint16_t /*service_type*/, uint32_t /*tick_delay_in_seconds*/, RsPluginHandler* /*pgHandler*/)
 	: p3Service(),p3Config()
 {
 }

--- a/libretroshare/src/pqi/p3historymgr.cc
+++ b/libretroshare/src/pqi/p3historymgr.cc
@@ -105,7 +105,6 @@ void p3HistoryMgr::addMessage(const ChatMessage& cm)
 
         if(cm.chat_id.isDistantChatId())
 	{
-		uint32_t status;
 		DistantChatPeerInfo dcpinfo;
 		if (rsMsgs->getDistantChatStatus(cm.chat_id.toDistantChatId(), dcpinfo))
 			peerName = cm.chat_id.toPeerId().toStdString();

--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -1036,7 +1036,7 @@ bool p3LinkMgrIMPL::connectResult(const RsPeerId &id, bool success, bool isIncom
  */
 
 // from pqissl, when a connection failed due to security
-void 	p3LinkMgrIMPL::notifyDeniedConnection(const RsPgpId& gpgid,const RsPeerId& sslid,const std::string& sslcn,const struct sockaddr_storage &addr, bool incoming)
+void 	p3LinkMgrIMPL::notifyDeniedConnection(const RsPgpId& gpgid,const RsPeerId& sslid,const std::string& sslcn,const struct sockaddr_storage &/*addr*/, bool incoming)
 {
 	std::cerr << "p3LinkMgrIMPL::notifyDeniedConnection()";
 	std::cerr << " pgpid: " << gpgid;

--- a/libretroshare/src/pqi/p3servicecontrol.cc
+++ b/libretroshare/src/pqi/p3servicecontrol.cc
@@ -125,7 +125,7 @@ public:
         return ok;
     }
 
-    static RsServicePermissionItem *deserialise(uint8_t *data,uint32_t size)
+    static RsServicePermissionItem *deserialise(uint8_t *data, uint32_t /*size*/)
     {
         RsServicePermissionItem *item = new RsServicePermissionItem ;
 
@@ -1247,6 +1247,8 @@ void    p3ServiceControl::updatePeerConnect(const RsPeerId &peerId)
 #ifdef SERVICECONTROL_DEBUG
 	std::cerr << "p3ServiceControl::updatePeerConnect(): " << peerId.toStdString();
 	std::cerr << std::endl;
+#else
+	(void)peerId;
 #endif
 	return;
 }

--- a/libretroshare/src/pqi/pqibin.cc
+++ b/libretroshare/src/pqi/pqibin.cc
@@ -270,7 +270,7 @@ int BinEncryptedFileInterface::readdata(void* data, int len)
 	else
 	{
 
-		if((cpyCount + len) <= sizeData)
+		if((cpyCount + len) <= (uint64_t)sizeData)
 		{
 			memcpy(data, (void *) ((this->data) + cpyCount), len);
 			cpyCount += len;
@@ -306,9 +306,9 @@ uint64_t BinEncryptedFileInterface::bytecount()
 bool BinEncryptedFileInterface::moretoread(uint32_t /* usec */)
 {
 	if(haveData)
-		return (cpyCount < sizeData);
+		return (cpyCount < (uint64_t)sizeData);
 	else
-		return cpyCount < getFileSize();
+		return cpyCount < (uint64_t)getFileSize();
 }
 
 BinMemInterface::BinMemInterface(int defsize, int flags)

--- a/libretroshare/src/pqi/pqimonitor.cc
+++ b/libretroshare/src/pqi/pqimonitor.cc
@@ -71,7 +71,7 @@ void    pqiConnectCbDummy::peerConnectRequest(const RsPeerId& id,
     std::cerr << std::endl;
 }
 
-void pqiMonitor::disconnectPeer(const RsPeerId &peer)
+void pqiMonitor::disconnectPeer(const RsPeerId &/*peer*/)
 {
     std::cerr << "(EE) pqiMonitor::disconnectPeer() shouldn't be called!!!"<< std::endl;
 }

--- a/libretroshare/src/pqi/pqissl.cc
+++ b/libretroshare/src/pqi/pqissl.cc
@@ -1303,7 +1303,7 @@ int 	pqissl::Authorise_SSL_Connection()
 	// 	which could be 
 	//      (pqissl's case) sslcert->serveraddr or sslcert->localaddr.
 
-    bool res = AuthSSL::getAuthSSL()->CheckCertificate(PeerId(), peercert);
+	AuthSSL::getAuthSSL()->CheckCertificate(PeerId(), peercert);
 	bool certCorrect = true; /* WE know it okay already! */
 
     uint32_t check_result ;

--- a/libretroshare/src/pqi/pqissllistener.cc
+++ b/libretroshare/src/pqi/pqissllistener.cc
@@ -57,7 +57,7 @@ const int pqissllistenzone = 49787;
 
 
 pqissllistenbase::pqissllistenbase(const sockaddr_storage &addr, p3PeerMgr *pm)
-	: laddr(addr), active(false), mPeerMgr(pm)
+	: laddr(addr), mPeerMgr(pm), active(false)
 {
 	if (!(AuthSSL::getAuthSSL()-> active()))
 	{

--- a/libretroshare/src/pqi/pqistreamer.cc
+++ b/libretroshare/src/pqi/pqistreamer.cc
@@ -605,7 +605,7 @@ int	pqistreamer::handleoutgoing_locked()
 #endif
             		int ss=0;
 
-		    if (mPkt_wpending_size != (ss = mBio->senddata(mPkt_wpending, mPkt_wpending_size)))
+		    if (mPkt_wpending_size != (uint32_t)(ss = mBio->senddata(mPkt_wpending, mPkt_wpending_size)))
 		    {
 #ifdef DEBUG_PQISTREAMER
 			    std::string out;
@@ -846,7 +846,7 @@ continue_packet:
 		    // so, don't do that:
 		    //		memset( extradata,0,extralen ) ;	
 
-		    if (extralen != (tmplen = mBio->readdata(extradata, extralen)))
+		    if (extralen != (uint32_t)(tmplen = mBio->readdata(extradata, extralen)))
 		    {
 #ifdef DEBUG_PQISTREAMER
 			    if(tmplen > 0)
@@ -1288,7 +1288,7 @@ int pqistreamer::locked_gatherStatistics(std::list<RSTrafficClue>& out_lst,std::
     return 1 ;
 }
 
-void *pqistreamer::locked_pop_out_data(uint32_t max_slice_size,uint32_t& size,bool& starts,bool& ends,uint32_t& packet_id)
+void *pqistreamer::locked_pop_out_data(uint32_t /*max_slice_size*/, uint32_t &size, bool &starts, bool &ends, uint32_t &packet_id)
 {
     size = 0 ;
     starts = true ;

--- a/libretroshare/src/pqi/pqithreadstreamer.cc
+++ b/libretroshare/src/pqi/pqithreadstreamer.cc
@@ -34,7 +34,7 @@
 //#define PQISTREAMER_DEBUG
 
 pqithreadstreamer::pqithreadstreamer(PQInterface *parent, RsSerialiser *rss, const RsPeerId& id, BinInterface *bio_in, int bio_flags_in)
-:pqistreamer(rss, id, bio_in, bio_flags_in), mParent(parent), mThreadMutex("pqithreadstreamer"),  mTimeout(0)
+:pqistreamer(rss, id, bio_in, bio_flags_in), mParent(parent), mTimeout(0), mThreadMutex("pqithreadstreamer")
 {
     mTimeout = DEFAULT_STREAMER_TIMEOUT;
     mSleepPeriod = DEFAULT_STREAMER_SLEEP;

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -1381,8 +1381,8 @@ RsPeerDetails::RsPeerDetails()
 		  trustLvl(0), validLvl(0),ownsign(false), 
 	hasSignedMe(false),accept_connection(false),
 	state(0),localAddr(""),localPort(0),extAddr(""),extPort(0),netMode(0),vs_disc(0), vs_dht(0),
-	lastConnect(0),connectState(0),connectStateString(""),connectPeriod(0),foundDHT(false), 
-	wasDeniedConnection(false), deniedTS(0), hiddenType(RS_HIDDEN_TYPE_NONE)
+    lastConnect(0),connectState(0),connectStateString(""),connectPeriod(0),
+    hiddenType(RS_HIDDEN_TYPE_NONE), foundDHT(false), wasDeniedConnection(false), deniedTS(0)
 {
 }
 

--- a/libretroshare/src/rsserver/rsloginhandler.cc
+++ b/libretroshare/src/rsserver/rsloginhandler.cc
@@ -4,7 +4,7 @@
 #include "rsloginhandler.h"
 #include "util/rsdir.h"
 #include "rsaccounts.h"
-#if defined(UBUNTU) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(HAS_GNOME_KEYRING) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <gnome-keyring-1/gnome-keyring.h>
 
 	GnomeKeyringPasswordSchema my_schema = {
@@ -119,7 +119,7 @@ bool RsLoginHandler::tryAutoLogin(const RsPeerId& ssl_id,std::string& ssl_passwd
 	/******************************** WINDOWS/UNIX SPECIFIC PART ******************/
 #ifndef __HAIKU__
 #ifndef WINDOWS_SYS /* UNIX */
-#if defined(UBUNTU) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(HAS_GNOME_KEYRING) || defined(__FreeBSD__) || defined(__OpenBSD__)
 
 	gchar *passwd = NULL;
 
@@ -195,7 +195,7 @@ bool RsLoginHandler::tryAutoLogin(const RsPeerId& ssl_id,std::string& ssl_passwd
 	return (status == 0);
 
 	/******************** OSX KeyChain stuff *****************************/
-#else /* UNIX, but not UBUNTU or APPLE */
+#else /* UNIX, but not HAS_GNOME_KEYRING or APPLE */
 
 	FILE* helpFile = RsDirUtil::rs_fopen(getAutologinFileName(ssl_id).c_str(), "r");
 
@@ -246,7 +246,7 @@ bool RsLoginHandler::tryAutoLogin(const RsPeerId& ssl_id,std::string& ssl_passwd
 
 	return true;
 #endif // APPLE
-#endif	// UBUNTU
+#endif	// HAS_GNOME_KEYRING
 	/******* WINDOWS BELOW *****/
 #else
 
@@ -370,7 +370,7 @@ bool RsLoginHandler::enableAutoLogin(const RsPeerId& ssl_id,const std::string& s
 	/******************************** WINDOWS/UNIX SPECIFIC PART ******************/
 #ifndef __HAIKU__
 #ifndef WINDOWS_SYS /* UNIX */
-#if defined(UBUNTU) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(HAS_GNOME_KEYRING) || defined(__FreeBSD__) || defined(__OpenBSD__)
 	if(GNOME_KEYRING_RESULT_OK == gnome_keyring_store_password_sync(&my_schema, NULL, (gchar*)("RetroShare password for SSL Id "+ssl_id.toStdString()).c_str(),(gchar*)ssl_passwd.c_str(),"RetroShare SSL Id",ssl_id.toStdString().c_str(),NULL)) 
 	{
 		std::cerr << "Stored passwd " << "************************" << " into gnome keyring" << std::endl;
@@ -448,7 +448,7 @@ bool RsLoginHandler::enableAutoLogin(const RsPeerId& ssl_id,const std::string& s
 
 	return true;
 #endif // __APPLE__
-#endif // UBUNTU.
+#endif // HAS_GNOME_KEYRING.
 #else  /* windows */
 
 	/* store password encrypted in a file */
@@ -532,7 +532,7 @@ bool RsLoginHandler::enableAutoLogin(const RsPeerId& ssl_id,const std::string& s
 
 bool RsLoginHandler::clearAutoLogin(const RsPeerId& ssl_id)
 {
-#ifdef UBUNTU
+#ifdef HAS_GNOME_KEYRING
 	if(GNOME_KEYRING_RESULT_OK == gnome_keyring_delete_password_sync(&my_schema,"RetroShare SSL Id", ssl_id.toStdString().c_str(),NULL))
 	{
 		std::cerr << "Successfully Cleared gnome keyring passwd for SSLID " << ssl_id << std::endl;

--- a/libretroshare/src/serialiser/rsgxscircleitems.cc
+++ b/libretroshare/src/serialiser/rsgxscircleitems.cc
@@ -126,7 +126,6 @@ void RsGxsCircleSubscriptionRequestItem::clear()
 std::ostream& RsGxsCircleSubscriptionRequestItem::print(std::ostream& out, uint16_t indent)
 { 
 	printRsItemBase(out, "RsGxsCircleSubscriptionRequestItem", indent);
-	uint16_t int_Indent = indent + 2;
 
 	printRsItemBase(out, "time stmp: ", indent); out << time_stamp ;
 	printRsItemBase(out, "time out : ", indent); out << time_out ;

--- a/libretroshare/src/serialiser/rsgxscommentitems.cc
+++ b/libretroshare/src/serialiser/rsgxscommentitems.cc
@@ -288,10 +288,8 @@ std::ostream& RsGxsVoteItem::print(std::ostream& out, uint16_t indent)
 }
 
 
-uint32_t RsGxsCommentSerialiser::sizeGxsVoteItem(RsGxsVoteItem *item)
+uint32_t RsGxsCommentSerialiser::sizeGxsVoteItem(RsGxsVoteItem */*item*/)
 {
-
-	const RsGxsVote& msg = item->mMsg;
 	uint32_t s = 8; // header
 
 	s += 4; // vote flags.

--- a/libretroshare/src/serialiser/rsgxsiditems.cc
+++ b/libretroshare/src/serialiser/rsgxsiditems.cc
@@ -110,7 +110,6 @@ uint32_t RsGxsIdLocalInfoItem::serial_size()
 std::ostream& RsGxsIdLocalInfoItem::print(std::ostream& out, uint16_t indent)
 {
     printRsItemBase(out, "RsGxsIdLocalInfoItem", indent);
-    uint16_t int_Indent = indent + 2;
 
     // convert from binary to hex.
     for(std::map<RsGxsId,time_t>::const_iterator it(mTimeStamps.begin());it!=mTimeStamps.end();++it)
@@ -382,7 +381,7 @@ RsGxsIdLocalInfoItem *RsGxsIdSerialiser::deserialise_GxsIdLocalInfoItem(void *da
     uint32_t n=0 ;
     ok &= getRawUInt32(data, rssize, &offset, &n) ;
 
-    for(int i=0;ok && i<n;++i)
+    for(uint32_t i=0;ok && i<n;++i)
     {
         RsGxsId gxsid ;
         time_t TS ;
@@ -397,8 +396,8 @@ RsGxsIdLocalInfoItem *RsGxsIdSerialiser::deserialise_GxsIdLocalInfoItem(void *da
     {
 	ok &= getRawUInt32(data, rssize, &offset, &n) ;
     	RsGxsId gxsid ;
-    
-    	for(int i=0;ok && i<n;++i)
+
+        for(uint32_t i=0;ok && i<n;++i)
         {
 		ok &= gxsid.deserialise(data,rssize,offset) ;
         

--- a/libretroshare/src/serialiser/rsgxsreputationitems.cc
+++ b/libretroshare/src/serialiser/rsgxsreputationitems.cc
@@ -81,7 +81,6 @@ void RsGxsReputationUpdateItem::clear()
 std::ostream& RsGxsReputationConfigItem::print(std::ostream &out, uint16_t indent)
 {
         printRsItemBase(out, "RsReputationConfigItem", indent);
-	uint16_t int_Indent = indent + 2;
 
     	out << "mPeerId: " << mPeerId << std::endl;
     	out << "last update: " << time(NULL) - mLatestUpdate << " secs ago." << std::endl;
@@ -94,7 +93,6 @@ std::ostream& RsGxsReputationConfigItem::print(std::ostream &out, uint16_t inden
 std::ostream& RsGxsReputationSetItem::print(std::ostream &out, uint16_t indent)
 {
         printRsItemBase(out, "RsReputationSetItem", indent);
-	uint16_t int_Indent = indent + 2;
 
     	out << "GxsId: " << mGxsId << std::endl;
     	out << "mOwnOpinion: " << mOwnOpinion << std::endl;
@@ -110,7 +108,6 @@ std::ostream& RsGxsReputationSetItem::print(std::ostream &out, uint16_t indent)
 std::ostream& RsGxsReputationUpdateItem::print(std::ostream &out, uint16_t indent)
 {
         printRsItemBase(out, "RsReputationUpdateItem", indent);
-	uint16_t int_Indent = indent + 2;
 
     	out << "from: " << PeerId() << std::endl;
     	out << "last update: " << time(NULL) - mLatestUpdate << " secs ago." << std::endl;
@@ -124,7 +121,6 @@ std::ostream& RsGxsReputationUpdateItem::print(std::ostream &out, uint16_t inden
 std::ostream& RsGxsReputationRequestItem::print(std::ostream &out, uint16_t indent)
 {
         printRsItemBase(out, "RsReputationRequestItem", indent);
-	uint16_t int_Indent = indent + 2;
 
     	out << "last update: " << time(NULL) - mLastUpdate << " secs ago." << std::endl;
         

--- a/libretroshare/src/serialiser/rsgxsreputationitems.cc
+++ b/libretroshare/src/serialiser/rsgxsreputationitems.cc
@@ -323,7 +323,7 @@ RsGxsReputationSetItem *RsGxsReputationSerialiser::deserialiseReputationSetItem_
     uint32_t S ;
     ok &= getRawUInt32(data, tlvsize, &offset, &S);
     
-    for(int i=0;ok && i<S;++i)
+    for(uint32_t i = 0; ok && (i < S); ++i)
     {
             RsPeerId pid ;
             uint32_t op ;
@@ -361,7 +361,7 @@ RsGxsReputationSetItem *RsGxsReputationSerialiser::deserialiseReputationSetItem(
     uint32_t S ;
     ok &= getRawUInt32(data, tlvsize, &offset, &S);
     
-    for(int i=0;ok && i<S;++i)
+    for(uint32_t i = 0; ok && (i < S); ++i)
     {
             RsPeerId pid ;
             uint32_t op ;

--- a/libretroshare/src/serialiser/rsserviceinfoitems.cc
+++ b/libretroshare/src/serialiser/rsserviceinfoitems.cc
@@ -36,7 +36,7 @@
 /***** RsServiceInfo ****/
 
 template<>
-std::ostream &RsTlvParamRef<RsServiceInfo>::print(std::ostream &out, uint16_t indent) const
+std::ostream &RsTlvParamRef<RsServiceInfo>::print(std::ostream &out, uint16_t /*indent*/) const
 {
 	out << "RsServiceInfo: " << mParam.mServiceType << " name " << mParam.mServiceName;
 	out << std::endl;

--- a/libretroshare/src/serialiser/rstlvgenericparam.cc
+++ b/libretroshare/src/serialiser/rstlvgenericparam.cc
@@ -56,8 +56,7 @@ void RsTlvParamRef<uint16_t>::TlvClear()
 template<>
 bool RsTlvParamRef<uint16_t>::SetTlv(void *data, uint32_t size, uint32_t *offset) const
 {
-	uint16_t param = mParam;
-        return SetTlvUInt16(data, size, offset, mParamType, mParam);
+	return SetTlvUInt16(data, size, offset, mParamType, mParam);
 }
 
 template<>
@@ -100,7 +99,7 @@ bool RsTlvParamRef<const uint16_t>::SetTlv(void *data, uint32_t size, uint32_t *
 }
 
 template<>
-bool RsTlvParamRef<const uint16_t>::GetTlv(void *data, uint32_t size, uint32_t *offset)
+bool RsTlvParamRef<const uint16_t>::GetTlv(void */*data*/, uint32_t /*size*/, uint32_t */*offset*/)
 {
 	return false; //GetTlvUInt16(data, size, offset, mParamType, &mParam);
 }
@@ -169,7 +168,7 @@ bool RsTlvParamRef<const uint32_t>::SetTlv(void *data, uint32_t size, uint32_t *
 }
 
 template<>
-bool RsTlvParamRef<const uint32_t>::GetTlv(void *data, uint32_t size, uint32_t *offset)
+bool RsTlvParamRef<const uint32_t>::GetTlv(void */*data*/, uint32_t /*size*/, uint32_t */*offset*/)
 {
 	return false;
 	//GetTlvUInt32(data, size, offset, mParamType, &mParam);

--- a/libretroshare/src/services/p3banlist.cc
+++ b/libretroshare/src/services/p3banlist.cc
@@ -675,7 +675,7 @@ bool p3BanList::recvBanItem(RsBanListItem *item)
 }
 
 /* overloaded from pqiNetAssistSharePeer */
-void p3BanList::updatePeer(const RsPeerId& /*id*/, const struct sockaddr_storage &addr, int type, int /*reason*/, int time_stamp)
+void p3BanList::updatePeer(const RsPeerId& /*id*/, const struct sockaddr_storage &addr, int /*type*/, int /*reason*/, int time_stamp)
 {
     RsPeerId ownId = mServiceCtrl->getOwnId();
 

--- a/libretroshare/src/services/p3gxscircles.cc
+++ b/libretroshare/src/services/p3gxscircles.cc
@@ -1044,6 +1044,8 @@ bool p3GxsCircles::cache_load_for_token(uint32_t token)
 bool p3GxsCircles::locked_processLoadingCacheEntry(RsGxsCircleCache& cache)
 {
 	bool isUnprocessedPeers = false;
+	// remove unused-but-set warning
+	(void)isUnprocessedPeers;
 
 	if (cache.mIsExternal)
 	{

--- a/libretroshare/src/services/p3gxsforums.cc
+++ b/libretroshare/src/services/p3gxsforums.cc
@@ -563,7 +563,7 @@ bool p3GxsForums::generateGroup(uint32_t &token, std::string groupName)
 
 
         // Overloaded from RsTickEvent for Event callbacks.
-void p3GxsForums::handle_event(uint32_t event_type, const std::string &elabel)
+void p3GxsForums::handle_event(uint32_t event_type, const std::string &/*elabel*/)
 {
 	std::cerr << "p3GxsForums::handle_event(" << event_type << ")";
 	std::cerr << std::endl;

--- a/libretroshare/src/services/p3gxsreputation.h
+++ b/libretroshare/src/services/p3gxsreputation.h
@@ -65,7 +65,7 @@ public:
 	Reputation()
         	:mOwnOpinion(RsReputations::OPINION_NEUTRAL), mOwnOpinionTs(0),mFriendAverage(1.0f), mReputation(RsReputations::OPINION_NEUTRAL),mIdentityFlags(REPUTATION_IDENTITY_FLAG_NEEDS_UPDATE){ }
                                                                                             
-	Reputation(const RsGxsId& about)                                                           
+	Reputation(const RsGxsId& /*about*/)
         	:mOwnOpinion(RsReputations::OPINION_NEUTRAL), mOwnOpinionTs(0),mFriendAverage(1.0f), mReputation(RsReputations::OPINION_NEUTRAL),mIdentityFlags(REPUTATION_IDENTITY_FLAG_NEEDS_UPDATE){ }
 
 	void updateReputation();

--- a/libretroshare/src/services/p3idservice.cc
+++ b/libretroshare/src/services/p3idservice.cc
@@ -3871,7 +3871,7 @@ void p3IdService::handleResponse(uint32_t token, uint32_t req_type)
 
 
 	// Overloaded from RsTickEvent for Event callbacks.
-void p3IdService::handle_event(uint32_t event_type, const std::string &elabel)
+void p3IdService::handle_event(uint32_t event_type, const std::string &/*elabel*/)
 {
 #ifdef DEBUG_IDS
 	std::cerr << "p3IdService::handle_event(" << event_type << ")";

--- a/libretroshare/src/services/p3msgservice.cc
+++ b/libretroshare/src/services/p3msgservice.cc
@@ -1945,7 +1945,7 @@ uint32_t p3MsgService::getDistantMessagingPermissionFlags()
     return mDistantMessagePermissions ;
 }
             
-void p3MsgService::receiveGRouterData(const RsGxsId& destination_key, const RsGxsId& signing_key,GRouterServiceId& client_id,uint8_t *data,uint32_t data_size)
+void p3MsgService::receiveGRouterData(const RsGxsId &destination_key, const RsGxsId &signing_key, GRouterServiceId &/*client_id*/, uint8_t *data, uint32_t data_size)
 {
     std::cerr << "p3MsgService::receiveGRouterData(): received message item of size " << data_size << ", for key " << destination_key << std::endl;
 

--- a/libretroshare/src/services/p3rtt.cc
+++ b/libretroshare/src/services/p3rtt.cc
@@ -261,12 +261,12 @@ int p3rtt::handlePing(RsItem *item)
 	// add our timestamp.
 	pong->mPongTS = convertTsTo64bits(ts);
 
-    static double mLastResponseToPong = 0.0 ;// bad stuff
 #ifdef DEBUG_RTT
+	static double mLastResponseToPong = 0.0 ;// bad stuff
     std::cerr << "Delay since last response to PONG: " << ts - mLastResponseToPong << std::endl;
+	mLastResponseToPong = ts ;
 #endif
-    
-    mLastResponseToPong = ts ;
+
 	sendItem(pong);
 	return true ;
 }

--- a/libretroshare/src/tests/gxs/data_service/nxs_tests.pro
+++ b/libretroshare/src/tests/gxs/data_service/nxs_tests.pro
@@ -76,7 +76,7 @@ linux-* {
 	LIBS += -lssl -lgpgme -lupnp -lixml  -lgnome-keyring -lsqlite3 -lbz2
 	LIBS *= -rdynamic -frtti
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 }
 
 linux-g++ {

--- a/libretroshare/src/tests/gxs/gen_exchange/genexchange_test.pro
+++ b/libretroshare/src/tests/gxs/gen_exchange/genexchange_test.pro
@@ -61,7 +61,7 @@ linux-* {
 	LIBS += /home/crispy/Development/retroshare/sqlcipher/sqlcipher/.libs/libsqlite3.a
 	LIBS *= -rdynamic -frtti
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 }
 
 linux-g++ {

--- a/libretroshare/src/tests/gxs/nxs_test/nxs_tests.pro
+++ b/libretroshare/src/tests/gxs/nxs_test/nxs_tests.pro
@@ -76,7 +76,7 @@ linux-* {
 	LIBS += -lssl -lgpgme -lupnp -lixml  -lgnome-keyring -lsqlite3 -lbz2
 	LIBS *= -rdynamic -frtti
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 }
 
 linux-g++ {

--- a/libretroshare/src/util/retrodb.cc
+++ b/libretroshare/src/util/retrodb.cc
@@ -120,6 +120,8 @@ void RetroDb::closeDb(){
 
 #ifdef RETRODB_DEBUG
     std::cerr << "RetroDb::closeDb(): Error code on close: " << rc << std::endl;
+#else
+    (void)rc;
 #endif
 
 }

--- a/libretroshare/src/util/rsdir.cc
+++ b/libretroshare/src/util/rsdir.cc
@@ -294,7 +294,7 @@ bool RsDirUtil::copyFile(const std::string& source,const std::string& dest)
 	fclose(in) ;
 	fclose(out) ;
 
-	return true ;
+	return bRet ;
 
 #endif
 

--- a/libretroshare/src/util/rsnet_ss.cc
+++ b/libretroshare/src/util/rsnet_ss.cc
@@ -951,7 +951,7 @@ bool sockaddr_storage_ipv4_isExternalNet(const struct sockaddr_storage &addr)
 }
 
 
-bool sockaddr_storage_ipv6_isnull(const struct sockaddr_storage &addr)
+bool sockaddr_storage_ipv6_isnull(const struct sockaddr_storage &/*addr*/)
 {
 #ifdef SS_DEBUG
     std::cerr << "sockaddr_storage_ipv6_isnull() TODO";
@@ -961,7 +961,7 @@ bool sockaddr_storage_ipv6_isnull(const struct sockaddr_storage &addr)
 	return false;
 }
 
-bool sockaddr_storage_ipv6_isValidNet(const struct sockaddr_storage &addr)
+bool sockaddr_storage_ipv6_isValidNet(const struct sockaddr_storage &/*addr*/)
 {
 #ifdef SS_DEBUG
     std::cerr << "sockaddr_storage_ipv6_isValidNet() TODO";
@@ -971,7 +971,7 @@ bool sockaddr_storage_ipv6_isValidNet(const struct sockaddr_storage &addr)
 	return false;
 }
 
-bool sockaddr_storage_ipv6_isLoopbackNet(const struct sockaddr_storage &addr)
+bool sockaddr_storage_ipv6_isLoopbackNet(const struct sockaddr_storage &/*addr*/)
 {
 #ifdef SS_DEBUG
     std::cerr << "sockaddr_storage_ipv6_isLoopbackNet() TODO";
@@ -981,7 +981,7 @@ bool sockaddr_storage_ipv6_isLoopbackNet(const struct sockaddr_storage &addr)
 	return false;
 }
 
-bool sockaddr_storage_ipv6_isPrivateNet(const struct sockaddr_storage &addr)
+bool sockaddr_storage_ipv6_isPrivateNet(const struct sockaddr_storage &/*addr*/)
 {
 #ifdef SS_DEBUG
     std::cerr << "sockaddr_storage_ipv6_isPrivateNet() TODO";
@@ -991,7 +991,7 @@ bool sockaddr_storage_ipv6_isPrivateNet(const struct sockaddr_storage &addr)
 	return false;
 }
 
-bool sockaddr_storage_ipv6_isExternalNet(const struct sockaddr_storage &addr)
+bool sockaddr_storage_ipv6_isExternalNet(const struct sockaddr_storage &/*addr*/)
 {
 #ifdef SS_DEBUG
     std::cerr << "sockaddr_storage_ipv6_isExternalNet() TODO";

--- a/retroshare-gui/src/gui/settings/rsharesettings.cpp
+++ b/retroshare-gui/src/gui/settings/rsharesettings.cpp
@@ -101,8 +101,8 @@ RshareSettings::RshareSettings()
 
 void RshareSettings::initSettings()
 { 
-#ifdef UBUNTU
-	// use GTK as default style on ubuntu
+#ifdef Q_OS_LINUX
+	// use GTK as default style on linux
 	setDefault(SETTING_STYLE, "GTK+");
 #else
 #if defined(Q_OS_MAC)

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -70,7 +70,7 @@ linux-* {
 
 	LIBS *= -rdynamic
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 }
 
 unix {

--- a/tests/librssimulator/librssimulator.pro
+++ b/tests/librssimulator/librssimulator.pro
@@ -100,7 +100,7 @@ linux-* {
 		DEFINES *= PATCHED_LIBUPNP
 	}
 
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 	INCLUDEPATH += /usr/include/glib-2.0/ /usr/lib/glib-2.0/include
 	LIBS *= -lgnome-keyring
 }

--- a/tests/unittests/libretroshare/gxs/gen_exchange/genexchange_test.pro
+++ b/tests/unittests/libretroshare/gxs/gen_exchange/genexchange_test.pro
@@ -61,7 +61,7 @@ linux-* {
 	LIBS += /home/crispy/Development/retroshare/sqlcipher/sqlcipher/.libs/libsqlite3.a
 	LIBS *= -rdynamic -frtti
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 }
 
 linux-g++ {

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -72,7 +72,7 @@ linux-* {
 	LIBS *= -lglib-2.0
 	LIBS *= -rdynamic
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
-	DEFINES *= UBUNTU
+	DEFINES *= HAS_GNOME_KEYRING
 }
 
 linux-g++ {


### PR DESCRIPTION
This patch set fixes most compiler warnings (gcc) in libretroshare. 
Some warnings (comparison between (unsigned) ints )are still left because i don't know whether i can fix them with a cast or not.

---

The 4th patch renames a define which has a misleading name

---

The patches are separated into categories so in case you aren't happy with one patch you can still cherry-pick the others.
