### PR TITLE
Fix SIGFPE in QProgressBar::paintEvent

### DIFF
--- a/retroshare-gui/src/gui/qss/stylesheet/Standard.qss
+++ b/retroshare-gui/src/gui/qss/stylesheet/Standard.qss
@@ -521,6 +521,7 @@ SubFileItem QProgressBar#progressBar::chunk {
 	border-top-left-radius: 7px;
 	border-bottom-left-radius: 7px;
 	border: 1px solid black;
+	width: 15px;
 }
 
 PluginItem QLabel#infoLabel {

--- a/retroshare-gui/src/qss/qdarkstyle.qss
+++ b/retroshare-gui/src/qss/qdarkstyle.qss
@@ -27,9 +27,11 @@ QProgressBar:horizontal {
     text-align: center;
     padding: 1px;
     background: #201F1F;
+    width: 15px;
 }
 QProgressBar::chunk:horizontal {
     background-color: qlineargradient(spread:reflect, x1:1, y1:0.545, x2:1, y2:0, stop:0 rgba(28, 66, 111, 255), stop:1 rgba(37, 87, 146, 255));
+    width: 15px;
 }
 
 QFrame#titleBarFrame, QFrame#toolBarFrame


### PR DESCRIPTION
When feenableexcept(FE_INVALID | FE_DIVBYZERO) is activated.
