### PR TITLE
This is the first set of patches to improve RS' logging functionality

### DIFF
--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -41,8 +41,6 @@
 #include "util/rsprint.h"
 #include "util/rsdebug.h"
 #include "util/rsstring.h"
-const int p3connectzone = 3431;
-
 #include "serialiser/rsconfigitems.h"
 
 #include "retroshare/rsiface.h"
@@ -52,6 +50,8 @@ const int p3connectzone = 3431;
 
 /* Network setup States */
 
+static struct RsLog::logInfo p3connectzoneInfo = {RsLog::Default, "p3connect"};
+#define p3connectzone &p3connectzoneInfo
 
 /****
  * #define LINKMGR_DEBUG 1

--- a/libretroshare/src/pqi/p3netmgr.cc
+++ b/libretroshare/src/pqi/p3netmgr.cc
@@ -39,7 +39,8 @@
 
 //#include "util/rsprint.h"
 //#include "util/rsdebug.h"
-const int p3netmgrzone = 7563;
+struct RsLog::logInfo p3netmgrzoneInfo = {RsLog::Default, "p3netmgr"};
+#define p3netmgrzone &p3netmgrzoneInfo
 
 #include "serialiser/rsconfigitems.h"
 #include "retroshare/rsiface.h"

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -41,7 +41,6 @@
 #include "util/rsprint.h"
 #include "util/rsstring.h"
 #include "util/rsdebug.h"
-const int p3peermgrzone = 9531;
 
 #include "serialiser/rsconfigitems.h"
 
@@ -63,6 +62,9 @@ const uint32_t RS_NET_DOWN =    	0x0007;
 const uint32_t MIN_TIME_BETWEEN_NET_RESET = 		5;
 
 const uint32_t PEER_IP_CONNECT_STATE_MAX_LIST_SIZE =     	4;
+
+static struct RsLog::logInfo p3peermgrzoneInfo = {RsLog::Default, "p3peermgr"};
+#define p3peermgrzone &p3peermgrzoneInfo
 
 /****
  * #define PEER_DEBUG 1

--- a/libretroshare/src/pqi/pqihandler.cc
+++ b/libretroshare/src/pqi/pqihandler.cc
@@ -58,7 +58,8 @@ static double getCurrentTS()
 }
 #endif
 
-const int pqihandlerzone = 34283;
+struct RsLog::logInfo pqihandlerzoneInfo = {RsLog::Default, "pqihandler"};
+#define pqihandlerzone &pqihandlerzoneInfo
 
 static const int PQI_HANDLER_NB_PRIORITY_LEVELS = 10 ;
 static const float PQI_HANDLER_NB_PRIORITY_RATIO = 2 ;

--- a/libretroshare/src/pqi/pqinetwork.cc
+++ b/libretroshare/src/pqi/pqinetwork.cc
@@ -41,7 +41,8 @@
 #include "util/rsstring.h"
 #include "util/rsnet.h"
 
-static const int pqinetzone = 96184;
+static struct RsLog::logInfo pqinetzoneInfo = {RsLog::Default, "pqinet"};
+#define pqinetzone &pqinetzoneInfo
 
 /*****
  * #define NET_DEBUG 1

--- a/libretroshare/src/pqi/pqiperson.cc
+++ b/libretroshare/src/pqi/pqiperson.cc
@@ -27,12 +27,12 @@
 #include "pqi/pqiperson.h"
 #include "pqi/pqipersongrp.h"
 #include "pqi/pqissl.h"
-
-
-const int pqipersonzone = 82371;
 #include "util/rsdebug.h"
 #include "util/rsstring.h"
 #include "retroshare/rspeers.h"
+
+static struct RsLog::logInfo pqipersonzoneInfo = {RsLog::Default, "pqiperson"};
+#define pqipersonzone &pqipersonzoneInfo
 
 /****
  * #define PERSON_DEBUG 1
@@ -67,7 +67,7 @@ int pqiperson::SendItem(RsItem *i,uint32_t& serialized_size)
 		// check if debug output is wanted, to avoid unecessary work
 		// getZoneLevel() locks a global mutex and does a lookup in a map or returns a default value
 		// (not sure if this is a performance problem)
-		if (PQL_DEBUG_BASIC <= getZoneLevel(pqipersonzone))
+		if (PQL_DEBUG_BASIC <= pqipersonzoneInfo.lvl)
 		{
 			std::string out = "pqiperson::SendItem() Active: Sending On\n";
 			i->print_string(out, 5); // this can be very expensive
@@ -80,7 +80,7 @@ int pqiperson::SendItem(RsItem *i,uint32_t& serialized_size)
 	}
 	else
 	{
-		if (PQL_DEBUG_BASIC <= getZoneLevel(pqipersonzone))
+		if (PQL_DEBUG_BASIC <= pqipersonzoneInfo.lvl)
 		{
 			std::string out = "pqiperson::SendItem()";
 			out += " Not Active: Used to put in ToGo Store\n";

--- a/libretroshare/src/pqi/pqipersongrp.cc
+++ b/libretroshare/src/pqi/pqipersongrp.cc
@@ -31,7 +31,8 @@
 
 #include <stdio.h>
 
-const int pqipersongrpzone = 354;
+static struct RsLog::logInfo pqipersongrpzoneInfo = {RsLog::Default, "pqipersongrp"};
+#define pqipersongrpzone &pqipersongrpzoneInfo
 
 #ifdef WINDOWS_SYS
 ///////////////////////////////////////////////////////////

--- a/libretroshare/src/pqi/pqissl.cc
+++ b/libretroshare/src/pqi/pqissl.cc
@@ -44,7 +44,8 @@
 
 #include "rsserver/p3face.h"
 
-const int pqisslzone = 37714;
+static struct RsLog::logInfo pqisslzoneInfo = {RsLog::Default, "pqisslzone"};
+#define pqisslzone &pqisslzoneInfo
 
 /*********
 #define WAITING_NOT            0

--- a/libretroshare/src/pqi/pqissllistener.cc
+++ b/libretroshare/src/pqi/pqissllistener.cc
@@ -38,7 +38,8 @@
 #include "retroshare/rsbanlist.h"
 #include <unistd.h>
 
-const int pqissllistenzone = 49787;
+static struct RsLog::logInfo pqissllistenzoneInfo = {RsLog::Default, "p3peermgr"};
+#define pqissllistenzone &pqissllistenzoneInfo
 
 /* NB: This #define makes the listener open 0.0.0.0:X port instead
  * of a specific port - this might help retroshare work on PCs with

--- a/libretroshare/src/pqi/pqisslpersongrp.cc
+++ b/libretroshare/src/pqi/pqisslpersongrp.cc
@@ -29,8 +29,8 @@
 #include "pqi/pqisslpersongrp.h"
 #include "pqi/authssl.h"
 
-
-const int pqipersongrpzone = 354;
+static struct RsLog::logInfo pqipersongrpzoneInfo = {RsLog::Default, "pqipersongrp"};
+#define pqipersongrpzone &pqipersongrpzoneInfo
 
 /****
  * #define PQI_DISABLE_UDP 1

--- a/libretroshare/src/pqi/pqisslproxy.cc
+++ b/libretroshare/src/pqi/pqisslproxy.cc
@@ -38,7 +38,8 @@
 
 #include "pqi/p3linkmgr.h"
 
-const int pqisslproxyzone = 3517;
+static struct RsLog::logInfo pqisslproxyzoneInfo = {RsLog::Default, "pqisslproxy"};
+#define pqisslproxyzone &pqisslproxyzoneInfo
 
 // #define PROXY_DEBUG	1
 

--- a/libretroshare/src/pqi/pqissludp.cc
+++ b/libretroshare/src/pqi/pqissludp.cc
@@ -40,7 +40,8 @@
 #include "pqi/p3linkmgr.h"
 #include <unistd.h>
 
-const int pqissludpzone = 3144;
+static struct RsLog::logInfo pqissludpzoneInfo = {RsLog::Default, "pqissludp"};
+#define pqissludpzone &pqissludpzoneInfo
 
 	/* a final timeout, to ensure this never blocks completely
 	 * 300 secs to complete udp/tcp/ssl connection.

--- a/libretroshare/src/pqi/pqistore.cc
+++ b/libretroshare/src/pqi/pqistore.cc
@@ -53,7 +53,8 @@
 // #define PQISTORE_DEBUG
 // 
 
-const int pqistorezone = 9511;
+static struct RsLog::logInfo pqistorezoneInfo = {RsLog::Default, "pqistore"};
+#define pqistorezone &pqistorezoneInfo
 
 pqistore::pqistore(RsSerialiser *rss, const RsPeerId& srcId, BinInterface *bio_in, int bio_flags_in)
 	:PQInterface(RsPeerId()), rsSerialiser(rss), bio_flags(bio_flags_in),

--- a/libretroshare/src/pqi/pqistreamer.cc
+++ b/libretroshare/src/pqi/pqistreamer.cc
@@ -37,7 +37,8 @@
 
 #include "serialiser/rsserial.h" 
 
-const int pqistreamerzone = 8221;
+static struct RsLog::logInfo pqistreamerzoneInfo = {RsLog::Default, "pqistreamer"};
+#define pqistreamerzone &pqistreamerzoneInfo
 
 static const int   PQISTREAM_ABS_MAX    			= 100000000; /* 100 MB/sec (actually per loop) */
 static const int   PQISTREAM_AVG_PERIOD 			= 5; 		// update speed estimate every 5 seconds

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -221,7 +221,7 @@ void RsInit::InitRsConfig()
 
 	/* Setup the Debugging */
 	// setup debugging for desired zones.
-	setOutputLevel(PQL_WARNING); // default to Warnings.
+	setOutputLevel(RsLog::Warning); // default to Warnings.
 
 	// For Testing purposes.
 	// We can adjust everything under Linux.
@@ -418,7 +418,7 @@ int RsInit::InitRetroShare(int argcIgnored, char **argvIgnored, bool strictCheck
          }
 #endif
 
-			setOutputLevel(rsInitConfig->debugLevel);
+			setOutputLevel((RsLog::logLvl)rsInitConfig->debugLevel);
 
 //	// set the default Debug Level...
 //	if (rsInitConfig->haveDebugLevel)

--- a/libretroshare/src/services/p3msgservice.cc
+++ b/libretroshare/src/services/p3msgservice.cc
@@ -67,7 +67,11 @@
 
 using namespace Rs::Msgs;
 
-const int msgservicezone = 54319;
+static struct RsLog::logInfo msgservicezoneInfo = {
+	.lvl = RsLog::Default,
+	.name = "msgservice"
+};
+#define msgservicezone &msgservicezoneInfo
 
 static const uint32_t RS_MSG_DISTANT_MESSAGE_HASH_KEEP_TIME = 2*30*86400 ; // keep msg hashes for 2 months to avoid re-sent msgs
 

--- a/libretroshare/src/services/p3msgservice.cc
+++ b/libretroshare/src/services/p3msgservice.cc
@@ -67,10 +67,7 @@
 
 using namespace Rs::Msgs;
 
-static struct RsLog::logInfo msgservicezoneInfo = {
-	.lvl = RsLog::Default,
-	.name = "msgservice"
-};
+static struct RsLog::logInfo msgservicezoneInfo = {RsLog::Default, "msgservice"};
 #define msgservicezone &msgservicezoneInfo
 
 static const uint32_t RS_MSG_DISTANT_MESSAGE_HASH_KEEP_TIME = 2*30*86400 ; // keep msg hashes for 2 months to avoid re-sent msgs

--- a/libretroshare/src/tcponudp/tcpstream.cc
+++ b/libretroshare/src/tcponudp/tcpstream.cc
@@ -43,8 +43,8 @@
 #include "util/rsstring.h"
 #include "util/rsrandom.h"
 
-const int rstcpstreamzone = 28455;
-
+static struct RsLog::logInfo rstcpstreamzoneInfo = {RsLog::Default, "rstcpstream"};
+#define rstcpstreamzone &rstcpstreamzoneInfo
 
 /*
  * #define DEBUG_TCP_STREAM		1

--- a/libretroshare/src/util/rsdebug.cc
+++ b/libretroshare/src/util/rsdebug.cc
@@ -160,11 +160,11 @@ int locked_setDebugFile(const char *fname)
 	}
 }
 
-//int setOutputLevel(RsLog::logLvl lvl)
-//{
-//	RsStackMutex stack(logMtx); /******** LOCKED ****************/
-//	return defaultLevel = lvl;
-//}
+int setOutputLevel(RsLog::logLvl lvl)
+{
+	RsStackMutex stack(logMtx); /******** LOCKED ****************/
+	return defaultLevel = lvl;
+}
 
 //#ifdef deadcode // this code is not used by RS
 //int setZoneLevel(int lvl, int zone)
@@ -194,7 +194,7 @@ int locked_setDebugFile(const char *fname)
 //	return defaultLevel;
 //}
 
-void rslog(const RsLog::logLvl lvl, const RsLog::logInfo *info, const std::string &msg)
+void rslog(const RsLog::logLvl lvl, RsLog::logInfo *info, const std::string &msg)
 {
 	// skipp when log level is set to 'None'
 	// NB: when default is set to 'None' the later check will always fail -> no need to check it here
@@ -203,7 +203,7 @@ void rslog(const RsLog::logLvl lvl, const RsLog::logInfo *info, const std::strin
 
 	RsStackMutex stack(logMtx); /******** LOCKED ****************/
 
-	bool process = info-lvl == RsLog::Default ? (lvl <= defaultLevel) : lvl <= info->lvl;
+	bool process = info->lvl == RsLog::Default ? (lvl <= defaultLevel) : lvl <= info->lvl;
 	if(process)
 	{
 		time_t t = time(NULL);
@@ -235,8 +235,8 @@ void rslog(const RsLog::logLvl lvl, const RsLog::logInfo *info, const std::strin
 		std::string timestr = ctime(&t);
 		std::string timestr2 = timestr.substr(0,timestr.length()-1);
 		/* remove the endl */
-		fprintf(ofd, "(%s Z: %d, lvl:%u): %s \n", 
-				timestr2.c_str(), zone, (unsigned int)info->lvl, msg.c_str());
+		fprintf(ofd, "(%s Z: %s, lvl: %u): %s \n",
+				timestr2.c_str(), info->name.c_str(), (unsigned int)info->lvl, msg.c_str());
 		fflush(ofd);
 		lineCount++;
 	}

--- a/libretroshare/src/util/rsdebug.cc
+++ b/libretroshare/src/util/rsdebug.cc
@@ -37,7 +37,6 @@ const int RS_DEBUG_LOGCRASH 	= 3;  /* minimal logfile stored after crashes */
 const int RS_DEBUG_LOGC_MAX 	= 100000;  /* max length of crashfile log */
 const int RS_DEBUG_LOGC_MIN_SAVE = 100;    /* min length of crashfile log */
 
-//static std::map<int, int> zoneLevel;
 static RsLog::logLvl defaultLevel = RsLog::Warning;
 static FILE *ofd = stderr;
 
@@ -110,33 +109,6 @@ int setDebugCrashMode(const char *cfile)
 	return 1;
 }
 
-
-#ifdef deadcode // this code is not used by RS
-/* this is called when we exit normally */
-int clearDebugCrashLog()
-{
-	RsStackMutex stack(logMtx); /******** LOCKED ****************/
-	/* check we are in crashLog Mode */
-	if (debugMode != RS_DEBUG_LOGCRASH)
-	{
-		fprintf(stderr, "Not in CrashLog Mode - nothing to clear!\n");
-		return 1;
-	}
-
-	fprintf(stderr, "clearDebugCrashLog() Cleaning up\n");
-	/* shutdown crashLog Mode */
-	fclose(ofd);
-	ofd = stderr;
-	debugMode = RS_DEBUG_STDERR;
-
-	/* just open the file, and then close */
-	FILE *tmpin = RsDirUtil::rs_fopen(crashfile.c_str(), "w");
-	fclose(tmpin);
-
-	return 1;
-}
-#endif
-
 int setDebugFile(const char *fname)
 {
 	RsStackMutex stack(logMtx); /******** LOCKED ****************/
@@ -165,34 +137,6 @@ int setOutputLevel(RsLog::logLvl lvl)
 	RsStackMutex stack(logMtx); /******** LOCKED ****************/
 	return defaultLevel = lvl;
 }
-
-//#ifdef deadcode // this code is not used by RS
-//int setZoneLevel(int lvl, int zone)
-//{
-//	RsStackMutex stack(logMtx); /******** LOCKED ****************/
-//	zoneLevel[zone] = lvl;
-//	return zone;
-//}
-//#endif
-
-//int getZoneLevel(int zone)
-//{
-//	RsStackMutex stack(logMtx); /******** LOCKED ****************/
-//	return locked_getZoneLevel(zone);
-//}
-
-//int locked_getZoneLevel(int /*zone*/)
-//{
-//#ifdef deadcode // this code is not used by RS
-//	std::map<int, int>::iterator it = zoneLevel.find(zone);
-//	if (it == zoneLevel.end())
-//	{
-//		return defaultLevel;
-//	}
-//	return it -> second;
-//#endif
-//	return defaultLevel;
-//}
 
 void rslog(const RsLog::logLvl lvl, RsLog::logInfo *info, const std::string &msg)
 {

--- a/libretroshare/src/util/rsdebug.cc
+++ b/libretroshare/src/util/rsdebug.cc
@@ -112,6 +112,7 @@ int setDebugCrashMode(const char *cfile)
 }
 
 
+#ifdef deadcode // this code is not used by RS
 /* this is called when we exit normally */
 int clearDebugCrashLog()
 {
@@ -135,7 +136,7 @@ int clearDebugCrashLog()
 
 	return 1;
 }
-
+#endif
 
 
 int setDebugFile(const char *fname)
@@ -168,13 +169,14 @@ int setOutputLevel(int lvl)
 	return defaultLevel = lvl;
 }
 
+#ifdef deadcode // this code is not used by RS
 int setZoneLevel(int lvl, int zone)
 {
 	RsStackMutex stack(logMtx); /******** LOCKED ****************/
 	zoneLevel[zone] = lvl;
 	return zone;
 }
-
+#endif
 
 int getZoneLevel(int zone)
 {
@@ -182,14 +184,17 @@ int getZoneLevel(int zone)
 	return locked_getZoneLevel(zone);
 }
 
-int locked_getZoneLevel(int zone)
+int locked_getZoneLevel(int /*zone*/)
 {
+#ifdef deadcode // this code is not used by RS
 	std::map<int, int>::iterator it = zoneLevel.find(zone);
 	if (it == zoneLevel.end())
 	{
 		return defaultLevel;
 	}
 	return it -> second;
+#endif
+	return defaultLevel;
 }
 
 int rslog(unsigned int lvl, int zone, const std::string &msg)

--- a/libretroshare/src/util/rsdebug.h
+++ b/libretroshare/src/util/rsdebug.h
@@ -48,34 +48,28 @@ namespace RsLog {
 	struct logInfo {
 		// module specific log lvl
 		logLvl lvl;
-		// module name
+		// module name (displayed in log)
 		const std::string name;
 	};
 }
 
-// current RS code uses these (deprecated) defines
-#define RSL_NONE     	RsLog::None
-#define RSL_ALERT     	RsLog::Alert
-#define RSL_ERROR	RsLog::Error
-#define RSL_WARNING	RsLog::Warning
-#define RSL_DEBUG_ALERT RsLog::Debug_Alert
-#define RSL_DEBUG_BASIC	RsLog::Debug_Basic
-#define RSL_DEBUG_ALL	RsLog::Debug_Basic
-
 int setDebugCrashMode(const char *cfile);
-//int clearDebugCrashLog();
-
 int setDebugFile(const char *fname);
 int setOutputLevel(RsLog::logLvl lvl);
-//int setZoneLevel(int lvl, int zone);
-//int getZoneLevel(int zone);
 void rslog(const RsLog::logLvl lvl, RsLog::logInfo *info, const std::string &msg);
-
 
 
 /*
  * retaining old #DEFINES and functions for backward compatibility.
  */
+
+#define RSL_NONE     	RsLog::None
+#define RSL_ALERT     	RsLog::Alert
+#define RSL_ERROR	RsLog::Error
+#define RSL_WARNING	RsLog::Warning
+#define RSL_DEBUG_ALERT	RsLog::Debug_Alert
+#define RSL_DEBUG_BASIC	RsLog::Debug_Basic
+#define RSL_DEBUG_ALL	RsLog::Debug_Basic
 
 //int pqioutput(unsigned int lvl, int zone, std::string msg);
 #define pqioutput rslog

--- a/libretroshare/src/util/rsdebug.h
+++ b/libretroshare/src/util/rsdebug.h
@@ -30,14 +30,6 @@
 #ifndef RS_LOG_DEBUG_H
 #define RS_LOG_DEBUG_H
 
-#define RSL_NONE     	-1
-#define RSL_ALERT     	 1
-#define RSL_ERROR	 3
-#define RSL_WARNING	 5
-#define RSL_DEBUG_ALERT  6
-#define RSL_DEBUG_BASIC	 8
-#define RSL_DEBUG_ALL	10
-
 #include <string>
 
 namespace RsLog {
@@ -54,12 +46,21 @@ namespace RsLog {
 
 	// this struct must be provided by the caller (to rslog())
 	struct logInfo {
-		// module name
-		const std::string name;
 		// module specific log lvl
 		logLvl lvl;
+		// module name
+		const std::string name;
 	};
 }
+
+// current RS code uses these (deprecated) defines
+#define RSL_NONE     	RsLog::None
+#define RSL_ALERT     	RsLog::Alert
+#define RSL_ERROR	RsLog::Error
+#define RSL_WARNING	RsLog::Warning
+#define RSL_DEBUG_ALERT RsLog::Debug_Alert
+#define RSL_DEBUG_BASIC	RsLog::Debug_Basic
+#define RSL_DEBUG_ALL	RsLog::Debug_Basic
 
 int setDebugCrashMode(const char *cfile);
 //int clearDebugCrashLog();
@@ -68,7 +69,7 @@ int setDebugFile(const char *fname);
 int setOutputLevel(RsLog::logLvl lvl);
 //int setZoneLevel(int lvl, int zone);
 //int getZoneLevel(int zone);
-void rslog(const RsLog::logLvl lvl, const RsLog::logInfo *info, const std::string &msg);
+void rslog(const RsLog::logLvl lvl, RsLog::logInfo *info, const std::string &msg);
 
 
 

--- a/libretroshare/src/util/rsdebug.h
+++ b/libretroshare/src/util/rsdebug.h
@@ -30,8 +30,6 @@
 #ifndef RS_LOG_DEBUG_H
 #define RS_LOG_DEBUG_H
 
-
-
 #define RSL_NONE     	-1
 #define RSL_ALERT     	 1
 #define RSL_ERROR	 3
@@ -40,17 +38,37 @@
 #define RSL_DEBUG_BASIC	 8
 #define RSL_DEBUG_ALL	10
 
-
 #include <string>
 
+namespace RsLog {
+	enum logLvl {
+		None	= -1,
+		Default	=  0,
+		Alert	=  1,
+		Error	=  3,
+		Warning	=  5,
+		Debug_Alert	=  6,
+		Debug_Basic	=  8,
+		Debug_All	= 10
+	};
+
+	// this struct must be provided by the caller (to rslog())
+	struct logInfo {
+		// module name
+		const std::string name;
+		// module specific log lvl
+		logLvl lvl;
+	};
+}
+
 int setDebugCrashMode(const char *cfile);
-int clearDebugCrashLog();
+//int clearDebugCrashLog();
 
 int setDebugFile(const char *fname);
-int setOutputLevel(int lvl);
-int setZoneLevel(int lvl, int zone);
-int getZoneLevel(int zone);
-int rslog(unsigned int lvl, int zone, const std::string &msg);
+int setOutputLevel(RsLog::logLvl lvl);
+//int setZoneLevel(int lvl, int zone);
+//int getZoneLevel(int zone);
+void rslog(const RsLog::logLvl lvl, const RsLog::logInfo *info, const std::string &msg);
 
 
 


### PR DESCRIPTION
The most notable changes are:
- the module zone name is displayed
- no map lookup everytime something is printed to the log

---

Things i plan for the future:
- show a label for a level instead of a number
- add command line parameters to turn on/off debugging for zones 
- change more zones to use the log
