### PR TITLE
This patch set adds an option to use the DHT stunner to qmake

### DIFF
--- a/libretroshare/src/dht/p3bitdht.cc
+++ b/libretroshare/src/dht/p3bitdht.cc
@@ -30,7 +30,9 @@
 #include "bitdht/bdstddht.h"
 
 #include "tcponudp/udprelay.h"
+#ifdef RS_USE_DHT_STUNNER
 #include "tcponudp/udpstunner.h"
+#endif // RS_USE_DHT_STUNNER
 
 #include <openssl/sha.h>
 
@@ -86,8 +88,10 @@ p3BitDht::p3BitDht(const RsPeerId& id, pqiConnectCb *cb, p3NetMgr *nm,
             UdpStack *udpstack, std::string bootstrapfile,const std::string& filteredipfile)
 	:p3Config(), pqiNetAssistConnect(id, cb), mNetMgr(nm), dhtMtx("p3BitDht")
 {
+#ifdef RS_USE_DHT_STUNNER
 	mDhtStunner = NULL;
 	mProxyStunner = NULL;
+#endif
 	mRelay = NULL;
 
         mPeerSharer = NULL;
@@ -168,13 +172,19 @@ bool 	p3BitDht::getOwnDhtId(std::string &ownDhtId)
 	return true;
 }
 
-
+#ifdef RS_USE_DHT_STUNNER
 void    p3BitDht::setupConnectBits(UdpStunner *dhtStunner, UdpStunner *proxyStunner, UdpRelayReceiver  *relay)
 {
 	mDhtStunner = dhtStunner;
 	mProxyStunner = proxyStunner;
 	mRelay = relay;
 }
+#else // RS_USE_DHT_STUNNER
+void    p3BitDht::setupConnectBits(UdpRelayReceiver  *relay)
+{
+	mRelay = relay;
+}
+#endif //RS_USE_DHT_STUNNER
 
 void    p3BitDht::setupPeerSharer(pqiNetAssistPeerShare *sharer)
 {

--- a/libretroshare/src/dht/p3bitdht.h
+++ b/libretroshare/src/dht/p3bitdht.h
@@ -136,7 +136,9 @@ class p3BitDhtRelayHandler
 
 
 class UdpRelayReceiver;
+#ifdef RS_USE_DHT_STUNNER
 class UdpStunner;
+#endif // RS_USE_DHT_STUNNER
 class p3NetMgr;
 
 class p3BitDht: public p3Config, public pqiNetAssistConnect, public RsDht
@@ -174,8 +176,11 @@ public:
  ********** External RsDHT Interface (defined in libretroshare/src/retroshare/rsdht.h) *********
 ************************************************************************************************/
 
-
+#ifdef RS_USE_DHT_STUNNER
     void	setupConnectBits(UdpStunner *dhtStunner, UdpStunner *proxyStunner, UdpRelayReceiver  *relay);
+#else // RS_USE_DHT_STUNNER
+	void	setupConnectBits(UdpRelayReceiver *relay);
+#endif // RS_USE_DHT_STUNNER
     void	setupPeerSharer(pqiNetAssistPeerShare *sharer);
     void    modifyNodesPerBucket(uint16_t count);
 
@@ -359,8 +364,10 @@ private:
     int 	removeTranslation_locked(const RsPeerId& pid);
 
     UdpBitDht *mUdpBitDht; /* has own mutex, is static except for creation/destruction */
+#ifdef RS_USE_DHT_STUNNER
     UdpStunner *mDhtStunner;
     UdpStunner *mProxyStunner;
+#endif // RS_USE_DHT_STUNNER
     UdpRelayReceiver   *mRelay;
 
     p3NetMgr *mNetMgr;

--- a/libretroshare/src/dht/p3bitdht_interface.cc
+++ b/libretroshare/src/dht/p3bitdht_interface.cc
@@ -152,7 +152,7 @@ std::string p3BitDht::getUdpAddressString()
 		
 	struct sockaddr_in extAddr;
 	uint8_t extStable;
-
+#ifdef RS_USE_DHT_STUNNER
 	if (mDhtStunner->externalAddr(extAddr, extStable))
 	{
 		rs_sprintf_append(out, " DhtExtAddr: %s:%u", rs_inet_ntoa(extAddr.sin_addr).c_str(), ntohs(extAddr.sin_port));
@@ -187,7 +187,10 @@ std::string p3BitDht::getUdpAddressString()
 	{
 		out += " ProxyExtAddr: Unknown ";
 	}
-		
+#else // RS_USE_DHT_STUNNER
+	// whitespaces taken from above
+	out = " DhtExtAddr: Unknown  ProxyExtAddr: Unknown ";
+#endif // RS_USE_DHT_STUNNER
 	return out;
 }
 

--- a/libretroshare/src/dht/p3bitdht_interface.cc
+++ b/libretroshare/src/dht/p3bitdht_interface.cc
@@ -149,10 +149,10 @@ int      p3BitDht::getNetFailedPeer(std::string peerId, PeerStatus &status)
 std::string p3BitDht::getUdpAddressString()
 {
 	std::string out;
-		
+#ifdef RS_USE_DHT_STUNNER
 	struct sockaddr_in extAddr;
 	uint8_t extStable;
-#ifdef RS_USE_DHT_STUNNER
+
 	if (mDhtStunner->externalAddr(extAddr, extStable))
 	{
 		rs_sprintf_append(out, " DhtExtAddr: %s:%u", rs_inet_ntoa(extAddr.sin_addr).c_str(), ntohs(extAddr.sin_port));

--- a/libretroshare/src/dht/p3bitdht_peernet.cc
+++ b/libretroshare/src/dht/p3bitdht_peernet.cc
@@ -81,6 +81,7 @@ int p3BitDht::InfoCallback(const bdId *id, uint32_t /*type*/, uint32_t /*flags*/
 		mPeerSharer->updatePeer(rsid, tmpaddr, outtype, outreason, outage);
 	}
 
+#ifdef RS_USE_DHT_STUNNER
 	/* call to the Stunners to drop the address as well */
 	/* IDEALLY these addresses should all be filtered at UdpLayer level instead! */
 	if (mDhtStunner)
@@ -91,6 +92,7 @@ int p3BitDht::InfoCallback(const bdId *id, uint32_t /*type*/, uint32_t /*flags*/
 	{
 		mProxyStunner->dropStunPeer(addr);
 	}
+#endif // RS_USE_DHT_STUNNER
 
 	return 1;
 }
@@ -135,7 +137,7 @@ int p3BitDht::NodeCallback(const bdId *id, uint32_t peerflags)
 			}
 		}
 
-
+#ifdef RS_USE_DHT_STUNNER
 		if ((mProxyStunner) && (mProxyStunner->needStunPeers()))
 		{
 #ifdef DEBUG_BITDHT_COMMON
@@ -156,6 +158,7 @@ int p3BitDht::NodeCallback(const bdId *id, uint32_t peerflags)
 #endif
 			mDhtStunner->addStunPeer(id->addr, NULL);
 		}
+#endif // RS_USE_DHT_STUNNER
 	}
 	return 1;
 }
@@ -731,6 +734,7 @@ int p3BitDht::ConnectCallback(const bdId *srcId, const bdId *proxyId, const bdId
 					std::cerr << std::endl;
 				}
 
+#ifdef RS_USE_DHT_STUNNER
 				UdpStunner *stunner = mProxyStunner;
 				if (!proxyPort)
 				{
@@ -849,6 +853,9 @@ int p3BitDht::ConnectCallback(const bdId *srcId, const bdId *proxyId, const bdId
 					std::cerr << std::endl;
 #endif
 				}
+#else // RS_USE_DHT_STUNNER
+				connectionAllowed = BITDHT_CONNECT_ERROR_TEMPUNAVAIL;
+#endif // RS_USE_DHT_STUNNER
 			}
 
 			ca.mMode = mode;
@@ -1234,6 +1241,7 @@ int p3BitDht::doActions()
 							std::cerr << std::endl;
 						}
 					}
+#ifdef RS_USE_DHT_STUNNER
 					UdpStunner *stunner = mProxyStunner;
 					if (!proxyPort)
 					{
@@ -1333,6 +1341,10 @@ int p3BitDht::doActions()
 						connectionReqFailed = true;
 						failReason = CSB_UPDATE_RETRY_ATTEMPT;
 					}
+#else // RS_USE_DHT_STUNNER
+					connectionReqFailed = true;
+					failReason = CSB_UPDATE_RETRY_ATTEMPT;
+#endif //RS_USE_DHT_STUNNER
 				}
 
 				if (doConnectionRequest)
@@ -1416,7 +1428,9 @@ int p3BitDht::doActions()
 						{
 							std::cerr << "PeerAction: ERROR ERROR, we grabd Exclusive Port to do this, trying emergency release";
 							std::cerr << std::endl;
+#ifdef RS_USE_DHT_STUNNER
 							mProxyStunner->releaseExclusiveMode(pid,false);
+#endif // RS_USE_DHT_STUNNER
 						}
 					}
 				}
@@ -2378,6 +2392,7 @@ void p3BitDht::ReleaseProxyExclusiveMode_locked(DhtPeerDetails *dpd, bool addrCh
 	
 	if (dpd->mExclusiveProxyLock)
 	{
+#ifdef RS_USE_DHT_STUNNER
 		if (mProxyStunner->releaseExclusiveMode(pid, addrChgLikely))
 		{
 			dpd->mExclusiveProxyLock = false;
@@ -2389,6 +2404,7 @@ void p3BitDht::ReleaseProxyExclusiveMode_locked(DhtPeerDetails *dpd, bool addrCh
 #endif
 		}
 		else 
+#endif // RS_USE_DHT_STUNNER
 		{
 			dpd->mExclusiveProxyLock = false;
 

--- a/libretroshare/src/dht/p3bitdht_peernet.cc
+++ b/libretroshare/src/dht/p3bitdht_peernet.cc
@@ -686,7 +686,6 @@ int p3BitDht::ConnectCallback(const bdId *srcId, const bdId *proxyId, const bdId
 #endif
 
 				struct sockaddr_in extaddr;
-				uint8_t extStable = 0;
 				sockaddr_clear(&extaddr);
 
 				bool connectOk = false;
@@ -735,6 +734,8 @@ int p3BitDht::ConnectCallback(const bdId *srcId, const bdId *proxyId, const bdId
 				}
 
 #ifdef RS_USE_DHT_STUNNER
+				uint8_t extStable = 0;
+
 				UdpStunner *stunner = mProxyStunner;
 				if (!proxyPort)
 				{
@@ -855,6 +856,8 @@ int p3BitDht::ConnectCallback(const bdId *srcId, const bdId *proxyId, const bdId
 				}
 #else // RS_USE_DHT_STUNNER
 				connectionAllowed = BITDHT_CONNECT_ERROR_TEMPUNAVAIL;
+				(void) connectOk;
+				(void) exclusivePort;
 #endif // RS_USE_DHT_STUNNER
 			}
 
@@ -1195,7 +1198,6 @@ int p3BitDht::doActions()
 				else if (action.mMode == BITDHT_CONNECT_MODE_PROXY)
 				{
 					struct sockaddr_in extaddr;
-					uint8_t extStable = 0;
 					sockaddr_clear(&extaddr);
 					bool proxyPort = true;
 					bool exclusivePort = false;
@@ -1242,6 +1244,8 @@ int p3BitDht::doActions()
 						}
 					}
 #ifdef RS_USE_DHT_STUNNER
+					uint8_t extStable = 0;
+
 					UdpStunner *stunner = mProxyStunner;
 					if (!proxyPort)
 					{
@@ -1344,6 +1348,7 @@ int p3BitDht::doActions()
 #else // RS_USE_DHT_STUNNER
 					connectionReqFailed = true;
 					failReason = CSB_UPDATE_RETRY_ATTEMPT;
+					(void) connectOk;
 #endif //RS_USE_DHT_STUNNER
 				}
 
@@ -2404,6 +2409,8 @@ void p3BitDht::ReleaseProxyExclusiveMode_locked(DhtPeerDetails *dpd, bool addrCh
 #endif
 		}
 		else 
+#else // RS_USE_DHT_STUNNER
+		(void)addrChgLikely;
 #endif // RS_USE_DHT_STUNNER
 		{
 			dpd->mExclusiveProxyLock = false;

--- a/libretroshare/src/dht/p3bitdht_peers.cc
+++ b/libretroshare/src/dht/p3bitdht_peers.cc
@@ -202,7 +202,7 @@ int p3BitDht::addBadPeer(const struct sockaddr_storage &addr, uint32_t /*reason*
 	addrv4.sin_addr = ap->sin_addr;
 	addrv4.sin_port = ap->sin_port;	
 	
-	
+#ifdef RS_USE_DHT_STUNNER
 	if (mDhtStunner)
 	{
 		mDhtStunner->dropStunPeer(addrv4);
@@ -211,7 +211,7 @@ int p3BitDht::addBadPeer(const struct sockaddr_storage &addr, uint32_t /*reason*
 	{
 		mProxyStunner->dropStunPeer(addrv4);
 	}
-
+#endif // RS_USE_DHT_STUNNER
 	return 1;
 }
 

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -10,6 +10,10 @@ DESTDIR = lib
 
 #CONFIG += dsdv
 
+# the dht stunner is used to obtain RS' external ip addr. when it is natted
+# this system is unreliable and rs supports a newer and better one (asking connected peers)
+# CONFIG += useDhtStunner
+
 profiling {
 	QMAKE_CXXFLAGS -= -fomit-frame-pointer
 	QMAKE_CXXFLAGS *= -pg -g -fno-omit-frame-pointer
@@ -47,8 +51,7 @@ SOURCES *= serialiser/rstlvdsdv.cc \
 bitdht {
 
 HEADERS +=	dht/p3bitdht.h \
-		dht/connectstatebox.h \
-		dht/stunaddrassist.h
+		dht/connectstatebox.h
 
 SOURCES +=	dht/p3bitdht.cc  \
 		dht/p3bitdht_interface.cc \
@@ -62,7 +65,6 @@ HEADERS +=	tcponudp/udppeer.h \
 		tcponudp/tcppacket.h \
 		tcponudp/tcpstream.h \
 		tcponudp/tou.h \
-		tcponudp/udpstunner.h \
 		tcponudp/udprelay.h \
 
 SOURCES +=	tcponudp/udppeer.cc \
@@ -70,8 +72,16 @@ SOURCES +=	tcponudp/udppeer.cc \
 		tcponudp/tcpstream.cc \
 		tcponudp/tou.cc \
 		tcponudp/bss_tou.c \
-		tcponudp/udpstunner.cc \
 		tcponudp/udprelay.cc \
+
+	useDhtStunner {
+		HEADERS +=	dht/stunaddrassist.h \
+				tcponudp/udpstunner.h
+
+		SOURCES +=	tcponudp/udpstunner.cc
+
+		DEFINES += RS_USE_DHT_STUNNER
+	}
 
 	DEFINES *= RS_USE_BITDHT
 

--- a/libretroshare/src/pqi/p3netmgr.cc
+++ b/libretroshare/src/pqi/p3netmgr.cc
@@ -1736,12 +1736,12 @@ void p3NetMgrIMPL::updateNetStateBox_temporal()
 	std::cerr << "p3NetMgrIMPL::updateNetStateBox_temporal() ";
 	std::cerr << std::endl;
 #endif
-
-	uint8_t isstable = 0;
 	struct sockaddr_storage tmpaddr;
 	sockaddr_storage_clear(tmpaddr);
 
 #ifdef RS_USE_DHT_STUNNER
+	uint8_t isstable = 0;
+
 	if (mDhtStunner)
 	{
 

--- a/libretroshare/src/pqi/p3netmgr.cc
+++ b/libretroshare/src/pqi/p3netmgr.cc
@@ -169,12 +169,13 @@ void p3NetMgrIMPL::setManagers(p3PeerMgr *peerMgr, p3LinkMgr *linkMgr)
 //	mDhtMgr = dhtMgr;
 //}
 
+#ifdef RS_USE_DHT_STUNNER
 void p3NetMgrIMPL::setAddrAssist(pqiAddrAssist *dhtStun, pqiAddrAssist *proxyStun)
 {
 	mDhtStunner = dhtStun;
 	mProxyStunner = proxyStun;
 }
-
+#endif // RS_USE_DHT_STUNNER
 
 
 /***** Framework / initial implementation for a connection manager.
@@ -445,6 +446,7 @@ void p3NetMgrIMPL::slowTick()
 	netAssistTick();
 	updateNetStateBox_temporal();
 
+#ifdef RS_USE_DHT_STUNNER
 	if (mDhtStunner)
 	{
 		mDhtStunner->tick();
@@ -454,7 +456,7 @@ void p3NetMgrIMPL::slowTick()
 	{
 		mProxyStunner->tick();
 	}
-
+#endif // RS_USE_DHT_STUNNER
 }
 
 #define STARTUP_DELAY 5
@@ -1739,6 +1741,7 @@ void p3NetMgrIMPL::updateNetStateBox_temporal()
 	struct sockaddr_storage tmpaddr;
 	sockaddr_storage_clear(tmpaddr);
 
+#ifdef RS_USE_DHT_STUNNER
 	if (mDhtStunner)
 	{
 
@@ -1776,6 +1779,7 @@ void p3NetMgrIMPL::updateNetStateBox_temporal()
 		
 		}
 	}
+#endif // RS_USE_DHT_STUNNER
 
 
 	{
@@ -1789,7 +1793,7 @@ void p3NetMgrIMPL::updateNetStateBox_temporal()
 
 	/* now we check if a WebIP address is required? */
 
-
+#ifdef	NETMGR_DEBUG_STATEBOX
 	{
 		RsStackMutex stack(mNetMtx); /****** STACK LOCK MUTEX *******/
 
@@ -1805,7 +1809,6 @@ void p3NetMgrIMPL::updateNetStateBox_temporal()
 		std::string nattypestr = NetStateNatTypeString(natType);
 		std::string netmodestr = NetStateNetworkModeString(netMode);
 
-#ifdef	NETMGR_DEBUG_STATEBOX
 		std::cerr << "p3NetMgrIMPL::updateNetStateBox_temporal() NetStateBox Thinking";
 		std::cerr << std::endl;
 		std::cerr << "\tNetState: " << netstatestr;
@@ -1818,10 +1821,9 @@ void p3NetMgrIMPL::updateNetStateBox_temporal()
 		std::cerr << std::endl;
 		std::cerr << "\tNatType: " << nattypestr;
 		std::cerr << std::endl;
-#endif
 
 	}
-	
+#endif
 	
 	updateNatSetting();
 
@@ -1869,7 +1871,7 @@ void p3NetMgrIMPL::updateNatSetting()
 		std::cerr << std::endl;
 #endif
 		
-		
+#ifdef RS_USE_DHT_STUNNER
 		switch(natType)
 		{
 			case RSNET_NATTYPE_RESTRICTED_CONE: 
@@ -1894,7 +1896,7 @@ void p3NetMgrIMPL::updateNatSetting()
 				mProxyStunner->setRefreshPeriod(NET_STUNNER_PERIOD_SLOW);
 				break;
 		}
-
+#endif // RS_USE_DHT_STUNNER
 
 		/* This controls the Attach mode of the DHT... 
 		 * which effectively makes the DHT "attach" to Open Nodes.

--- a/libretroshare/src/pqi/p3netmgr.h
+++ b/libretroshare/src/pqi/p3netmgr.h
@@ -209,7 +209,9 @@ virtual bool	getDHTEnabled();
 /************************************************************************************************/
 
 void	setManagers(p3PeerMgr *peerMgr, p3LinkMgr *linkMgr);
+#ifdef RS_USE_DHT_STUNNER
 void	setAddrAssist(pqiAddrAssist *dhtStun, pqiAddrAssist *proxyStun);
+#endif // RS_USE_DHT_STUNNER
 
 void 	tick();
 
@@ -319,8 +321,10 @@ private:
 	p3LinkMgr *mLinkMgr; 
 
 	//p3BitDht   *mBitDht;
+#ifdef RS_USE_DHT_STUNNER
 	pqiAddrAssist *mDhtStunner;
 	pqiAddrAssist *mProxyStunner;
+#endif // RS_USE_DHT_STUNNER
 
 	RsMutex mNetMtx; /* protects below */
 

--- a/libretroshare/src/pqi/pqiassist.h
+++ b/libretroshare/src/pqi/pqiassist.h
@@ -115,6 +115,7 @@ virtual void 	updatePeer(const RsPeerId& id, const struct sockaddr_storage &addr
 };
 
 
+#ifdef RS_USE_DHT_STUNNER
 /* this is for the Stunners 
  *
  *
@@ -132,7 +133,7 @@ virtual void    setRefreshPeriod(int32_t period) = 0;
 virtual int	tick() = 0; /* for internal accounting */
 
 };
-
+#endif // RS_USE_DHT_STUNNER
 
 #define NETASSIST_KNOWN_PEER_OFFLINE        0x0001
 #define NETASSIST_KNOWN_PEER_ONLINE         0x0002

--- a/libretroshare/src/services/p3idservice.cc
+++ b/libretroshare/src/services/p3idservice.cc
@@ -395,9 +395,6 @@ void p3IdService::cleanUnusedKeys()
 		}
 
 		// grab at most 10 identities to delete. No need to send too many requests to the token queue at once.
-        
-		time_t now = time(NULL) ;
-		int n=0 ;
 		IdCacheEntryCleaner idcec(mKeysTS) ;
 
 		mKeyCache.applyToAllCachedEntries(idcec,&IdCacheEntryCleaner::processEntry);


### PR DESCRIPTION
The DHT stunner is used to obtain RS' external ip addr. when it is natted.

@csoler RS runs fine with the stunner being disabled. Though i can't tell if this affects the UDP-stuff in some way for obvious reasons..
