### PR TITLE
Fix "!!!The RetroShare's desktop file is missing or wrong!!!" message

### DIFF
--- a/retroshare-gui/src/gui/settings/rsharesettings.cpp
+++ b/retroshare-gui/src/gui/settings/rsharesettings.cpp
@@ -777,7 +777,7 @@ bool RshareSettings::getRetroShareProtocol()
 		}
 	}
 #elif defined(Q_OS_LINUX)
-	QFile desktop("/usr/share/applications/retroshare06.desktop");
+	QFile desktop("/usr/share/applications/RetroShare06.desktop");
 	if (desktop.exists()) {
 		desktop.open(QIODevice::ReadOnly | QIODevice::Text);
 		QTextStream in(&desktop);


### PR DESCRIPTION
for Linux.
