### PR TITLE
Fix RsGxsNetService::handleRecvPublishKeys when grpMeta is NULL

### DIFF
--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -4827,6 +4827,10 @@ void RsGxsNetService::handleRecvPublishKeys(RsNxsGroupPublishKeyItem *item)
 	// update the publish keys in this group meta info
 
 	RsGxsGrpMetaData *grpMeta = grpMetaMap[item->grpId] ;
+	if (!grpMeta) {
+		std::cerr << "(EE) RsGxsNetService::handleRecvPublishKeys() grpMeta not found." << std::endl;
+		return ;
+	}
 
 	// Check that the keys correspond, and that FULL keys are supplied, etc.
 


### PR DESCRIPTION
Bug noted by Papache
