### PR TITLE
Change I2P proxy default port to 4447

### DIFF
--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -75,7 +75,7 @@ static struct RsLog::logInfo p3peermgrzoneInfo = {RsLog::Default, "p3peermgr"};
 
 static const std::string kConfigDefaultProxyServerIpAddr = "127.0.0.1";
 static const uint16_t    kConfigDefaultProxyServerPortTor = 9050; // standard port.
-static const uint16_t    kConfigDefaultProxyServerPortI2P = 10; // there is no standard port though
+static const uint16_t    kConfigDefaultProxyServerPortI2P = 4447; // I2Pd's standard port
 
 static const std::string kConfigKeyExtIpFinder = "USE_EXTR_IP_FINDER";
 static const std::string kConfigKeyProxyServerIpAddrTor = "PROXY_SERVER_IPADDR";


### PR DESCRIPTION
4447 is [I2Pd](http://i2pd.website/)'s standard port.
