### PR TITLE
Add a small statistic to libresapi

### DIFF
--- a/libresapi/src/api/ApiServer.cpp
+++ b/libresapi/src/api/ApiServer.cpp
@@ -15,6 +15,7 @@
 
 #include "ApiPluginHandler.h"
 #include "ChannelsHandler.h"
+#include "StatsHandler.h"
 
 /*
 data types in json       http://json.org/
@@ -234,7 +235,8 @@ public:
         mTransfersHandler(sts, ifaces.mFiles),
         mChatHandler(sts, ifaces.mNotify, ifaces.mMsgs, ifaces.mPeers, ifaces.mIdentity, &mPeersHandler),
         mApiPluginHandler(sts, ifaces),
-        mChannelsHandler(ifaces.mGxsChannels)
+	    mChannelsHandler(ifaces.mGxsChannels),
+	    mStatsHandler()
     {
         // the dynamic cast is to not confuse the addResourceHandler template like this:
         // addResourceHandler(derived class, parent class)
@@ -258,6 +260,8 @@ public:
                                   &ChatHandler::handleRequest);
         router.addResourceHandler("channels", dynamic_cast<ResourceRouter*>(&mChannelsHandler),
                                   &ChannelsHandler::handleRequest);
+		router.addResourceHandler("stats", dynamic_cast<ResourceRouter*>(&mStatsHandler),
+		                          &StatsHandler::handleRequest);
     }
 
     PeersHandler mPeersHandler;
@@ -269,6 +273,7 @@ public:
     ChatHandler mChatHandler;
     ApiPluginHandler mApiPluginHandler;
     ChannelsHandler mChannelsHandler;
+	StatsHandler mStatsHandler;
 };
 
 ApiServer::ApiServer():

--- a/libresapi/src/api/StatsHandler.cpp
+++ b/libresapi/src/api/StatsHandler.cpp
@@ -1,0 +1,39 @@
+#include "StatsHandler.h"
+#include "Operators.h"
+
+#include <retroshare/rspeers.h>
+#include <retroshare/rsconfig.h>
+#include <pqi/authssl.h>
+
+namespace resource_api
+{
+
+StatsHandler::StatsHandler()
+{
+	addResourceHandler("*", this, &StatsHandler::handleStatsRequest);
+}
+
+void StatsHandler::handleStatsRequest(Request &/*req*/, Response &resp)
+{
+	StreamBase& itemStream = resp.mDataStream.getStreamToMember();
+
+	// location info
+	itemStream << makeKeyValue("name", rsPeers->getGPGName(rsPeers->getGPGOwnId()));
+	itemStream << makeKeyValue("location", AuthSSL::getAuthSSL()->getOwnLocation());
+
+	// peer info
+	unsigned int all, online;
+	rsPeers->getPeerCount(&all, &online, false);
+	itemStream << makeKeyValue("peers_all", all);
+	itemStream << makeKeyValue("peers_connected", online);
+
+	// bandwidth info
+	float downKb, upKb;
+	rsConfig->GetCurrentDataRates(downKb, upKb);
+	itemStream << makeKeyValue("bandwidth_up_kb", (double)upKb);
+	itemStream << makeKeyValue("bandwidth_down_kb", (double)downKb);
+
+	resp.setOk();
+}
+
+} // namespace resource_api

--- a/libresapi/src/api/StatsHandler.cpp
+++ b/libresapi/src/api/StatsHandler.cpp
@@ -1,8 +1,8 @@
 #include "StatsHandler.h"
 #include "Operators.h"
 
-#include <retroshare/rspeers.h>
 #include <retroshare/rsconfig.h>
+#include <retroshare/rspeers.h>
 #include <pqi/authssl.h>
 
 namespace resource_api
@@ -33,6 +33,17 @@ void StatsHandler::handleStatsRequest(Request &/*req*/, Response &resp)
 	itemStream << makeKeyValue("bandwidth_up_kb", (double)upKb);
 	itemStream << makeKeyValue("bandwidth_down_kb", (double)downKb);
 
+	// DHT/NAT info
+	RsConfigNetStatus config;
+	rsConfig->getConfigNetStatus(config);
+	itemStream << makeKeyValue("dht_active",	config.DHTActive);
+	itemStream << makeKeyValue("dht_ok",		config.netDhtOk);
+	itemStream << makeKeyValue("dht_size_all",	config.netDhtNetSize);
+	itemStream << makeKeyValue("dht_size_rs",	config.netDhtRsNetSize);
+	uint32_t netState = rsConfig -> getNetState();
+	itemStream << makeKeyValue("nat_state", netState);
+
+	// ok
 	resp.setOk();
 }
 

--- a/libresapi/src/api/StatsHandler.h
+++ b/libresapi/src/api/StatsHandler.h
@@ -1,0 +1,25 @@
+#ifndef STATSHANDLER_H
+#define STATSHANDLER_H
+
+/*
+ * simple class to output some basic stats about RS
+ * like bandwidth, connected peers, ...
+ */
+
+#include "ResourceRouter.h"
+
+namespace resource_api
+{
+
+class StatsHandler : public ResourceRouter
+{
+public:
+	StatsHandler();
+
+private:
+	void handleStatsRequest(Request& req, Response& resp);
+};
+
+} // namespace resource_api
+
+#endif // STATSHANDLER_H

--- a/libresapi/src/libresapi.pro
+++ b/libresapi/src/libresapi.pro
@@ -146,7 +146,8 @@ SOURCES += \
     api/TmpBlobStore.cpp \
     util/ContentTypes.cpp \
     api/ApiPluginHandler.cpp \
-    api/ChannelsHandler.cpp
+    api/ChannelsHandler.cpp \
+    api/StatsHandler.cpp
 
 HEADERS += \
 	api/ApiServer.h \
@@ -172,7 +173,8 @@ HEADERS += \
     api/TmpBlobStore.h \
     util/ContentTypes.h \
     api/ApiPluginHandler.h \
-    api/ChannelsHandler.h
+    api/ChannelsHandler.h \
+    api/StatsHandler.h
 
 libresapilocalserver {
     CONFIG *= qt


### PR DESCRIPTION
This makes some statistic available through the json api 

> http://localhost:9090/api/v2/stats
> 
> ``` json
> {"data":[{"bandwidth_down_kb":2.769594,"bandwidth_up_kb":2.190846,"dht_active":false,"dht_ok":false,"dht_size_all":"0","dht_size_rs":"0","location":"someLocation","name":"somePGPIdName","nat_state":"4","peers_all":"44","peers_connected":"13"}],"debug_msg":"","returncode":"ok"}
> ```

The idea behind this is to add RS support to [netdata](https://github.com/firehol/netdata)
