### PR TITLE
add thread names & remove warnings

### DIFF
--- a/libretroshare/src/file_sharing/dir_hierarchy.cc
+++ b/libretroshare/src/file_sharing/dir_hierarchy.cc
@@ -184,7 +184,7 @@ bool InternalFileHierarchyStorage::updateSubDirectoryList(const DirectoryStorage
     return true;
 }
 
-RsFileHash InternalFileHierarchyStorage::createDirHash(const std::string& dir_name,const std::string& dir_parent_path)
+RsFileHash InternalFileHierarchyStorage::createDirHash(const std::string &/*dir_name*/, const std::string &/*dir_parent_path*/)
 {
     // What we need here: a unique identifier
     // - that cannot be bruteforced to find the real directory name and path
@@ -226,7 +226,7 @@ bool InternalFileHierarchyStorage::removeDirectory(DirectoryStorage::EntryIndex 
             parent_dir.subdirs[i] = parent_dir.subdirs.back() ;
             parent_dir.subdirs.pop_back();
 
-            bool res = recursRemoveDirectory(indx) ;
+			recursRemoveDirectory(indx) ;
 #ifdef DEBUG_DIRECTORY_STORAGE
             print();
             std::string err ;

--- a/libretroshare/src/file_sharing/directory_storage.cc
+++ b/libretroshare/src/file_sharing/directory_storage.cc
@@ -426,6 +426,10 @@ void LocalDirectoryStorage::updateTimeStamps()
 
 #ifdef DEBUG_LOCAL_DIRECTORY_STORAGE
         std::cerr << "LocalDirectoryStorage: global last modf time is " << last_modf_time << " (which is " << time(NULL) - last_modf_time << " secs ago)" << std::endl;
+#else
+		// remove unused variable warning
+		// variable is only used for debugging
+		(void)last_modf_time;
 #endif
     }
 }

--- a/libretroshare/src/file_sharing/directory_updater.cc
+++ b/libretroshare/src/file_sharing/directory_updater.cc
@@ -55,7 +55,7 @@ void LocalDirectoryUpdater::setEnabled(bool b)
         return ;
 
     if(b)
-        start() ;
+		start("fs dir updater") ;
     else
         shutdown();
 
@@ -203,7 +203,7 @@ bool LocalDirectoryUpdater::inDirectoryCheck() const
     return mHashCache->isRunning();
 }
 
-void LocalDirectoryUpdater::hash_callback(uint32_t client_param, const std::string& name, const RsFileHash& hash, uint64_t size)
+void LocalDirectoryUpdater::hash_callback(uint32_t client_param, const std::string &/*name*/, const RsFileHash &hash, uint64_t /*size*/)
 {
     if(!mSharedDirectories->updateHash(DirectoryStorage::EntryIndex(client_param),hash))
         std::cerr << "(EE) Cannot update file. Something's wrong." << std::endl;

--- a/libretroshare/src/file_sharing/hash_cache.cc
+++ b/libretroshare/src/file_sharing/hash_cache.cc
@@ -252,7 +252,7 @@ bool HashStorage::requestHash(const std::string& full_path,uint64_t size,time_t 
         mHashCounter = 0;
         mTotalHashedSize = 0;
 
-        start() ;
+		start("fs hash cache") ;
     }
 
     return false;
@@ -301,7 +301,9 @@ bool HashStorage::locked_load()
     }
     uint32_t offset = 0 ;
     HashStorageInfo info ;
+#ifdef HASHSTORAGE_DEBUG
     uint32_t n=0;
+#endif
 
     while(offset < data_size)
        if(readHashStorageInfo(data,data_size,offset,info))

--- a/libretroshare/src/file_sharing/p3filelists.cc
+++ b/libretroshare/src/file_sharing/p3filelists.cc
@@ -239,7 +239,7 @@ void p3FileDatabase::startThreads()
 #ifdef DEBUG_P3FILELISTS
     P3FILELISTS_DEBUG() << "Starting directory watcher thread..." ;
 #endif
-    mLocalDirWatcher->start();
+	mLocalDirWatcher->start("fs dir watcher");
 #ifdef DEBUG_P3FILELISTS
     P3FILELISTS_DEBUG() << "Done." << std::endl;
 #endif
@@ -458,8 +458,7 @@ void p3FileDatabase::cleanup()
         for(std::set<RsPeerId>::const_iterator it(friend_set.begin());it!=friend_set.end();++it)
         {
             // Check if a remote directory exists for that friend, possibly creating the index.
-
-            uint32_t friend_index = locked_getFriendIndex(*it) ;
+			locked_getFriendIndex(*it) ;
         }
 
         // cancel existing requests for which the peer is offline
@@ -639,8 +638,8 @@ bool p3FileDatabase::findChildPointer(void *ref, int row, void *& result, FileSe
             convertEntryIndexToPointer(mRemoteDirectories[row]->root(),row+1,result);
             return true;
         }
-        else
-            return false;
+	else
+		return false;
 
     uint32_t fi;
     DirectoryStorage::EntryIndex e ;
@@ -788,7 +787,7 @@ int p3FileDatabase::RequestDirDetails(void *ref, DirDetails& d, FileSearchFlags 
     return true;
 }
 
-int p3FileDatabase::RequestDirDetails(const RsPeerId& uid,const std::string& path, DirDetails &details) const
+int p3FileDatabase::RequestDirDetails(const RsPeerId &/*uid*/, const std::string &/*path*/, DirDetails &/*details*/) const
 {
     NOT_IMPLEMENTED();
     return 0;

--- a/libretroshare/src/file_sharing/rsfilelistitems.cc
+++ b/libretroshare/src/file_sharing/rsfilelistitems.cc
@@ -226,10 +226,12 @@ RsFileListsSyncResponseItem* RsFileListsSerialiser::deserialFileListsSyncRespons
 
     RsFileListsSyncResponseItem* item = new RsFileListsSyncResponseItem();
 
+	/*
     uint32_t entry_index ;              // index of the directory to sync
     uint32_t flags;                     // used to say that it's a request or a response, say that the directory has been removed, ask for further update, etc.
     uint32_t last_known_recurs_modf_TS; // time of last modification, computed over all files+directories below.
     uint64_t request_id;                // use to determine if changes that have occured since last hash
+	*/
 
     ok &= item->entry_hash.deserialise(data, *size, offset);
     ok &= item->checksum.deserialise(data, *size, offset);


### PR DESCRIPTION
removes all unused variable warnings within the new filelist system and names the three new threads
