### PR TITLE
[libretroshare][file_sharing] fix undefined behavior

### DIFF
--- a/libretroshare/src/file_sharing/hash_cache.cc
+++ b/libretroshare/src/file_sharing/hash_cache.cc
@@ -76,7 +76,7 @@ void HashStorage::data_tick()
 {
     FileHashJob job;
     RsFileHash hash;
-    uint64_t size ;
+    uint64_t size = 0;
 
     {
         bool empty ;


### PR DESCRIPTION
:bug: label: [hacktoberfest](https://hacktoberfest.digitalocean.com/)

Greetings,

It's always good to initialize integer variables, at least to `0`, because if we try to retrieve its value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior, e.g. line number `182` of [hash_cache.cc](https://github.com/RetroShare/RetroShare/blob/master/libretroshare/src/file_sharing/hash_cache.cc#L182).

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com
