### PR TITLE
Automatically detect retroshare links when pasting text

### DIFF
--- a/retroshare-gui/src/gui/RetroShareLink.cpp
+++ b/retroshare-gui/src/gui/RetroShareLink.cpp
@@ -1587,46 +1587,8 @@ void RSLinkClipboard::parseClipboard(QList<RetroShareLink> &links)
 {
 	// parse clipboard for links.
 	//
-	links.clear();
 	QString text = QApplication::clipboard()->text() ;
-
-	std::cerr << "Parsing clipboard:" << text.toStdString() << std::endl ;
-
-	QRegExp rx(QString("retroshare://(%1)[^\r\n]+").arg(HOST_REGEXP));
-
-	int pos = 0;
-
-	while((pos = rx.indexIn(text, pos)) != -1)
-	{
-		QString url(text.mid(pos, rx.matchedLength()));
-		RetroShareLink link(url);
-
-		if(link.valid())
-		{
-			// check that the link is not already in the list:
-			bool already = false ;
-			for (int i = 0; i <links.size(); ++i)
-				if(links[i] == link)
-				{
-					already = true ;
-					break ;
-				}
-
-			if(!already)
-			{
-				links.push_back(link) ;
-#ifdef DEBUG_RSLINK
-				std::cerr << "captured link: " << link.toString().toStdString() << std::endl ;
-#endif
-			}
-		}
-#ifdef DEBUG_RSLINK
-		else
-			std::cerr << "invalid link" << std::endl ;
-#endif
-
-		pos += rx.matchedLength();
-	}
+	parseText(text, links);
 }
 
 QString RSLinkClipboard::toString()
@@ -1688,5 +1650,48 @@ bool RSLinkClipboard::empty(RetroShareLink::enumType type /* = RetroShareLink::T
 	}
 
 	return RetroShareLink::process(linksToProcess, flag);
+}
+
+void RSLinkClipboard::parseText(QString text, QList<RetroShareLink> &links)
+{
+	links.clear();
+
+	std::cerr << "Parsing text:" << text.toStdString() << std::endl ;
+
+	QRegExp rx(QString("retroshare://(%1)[^\r\n]+").arg(HOST_REGEXP));
+
+	int pos = 0;
+
+	while((pos = rx.indexIn(text, pos)) != -1)
+	{
+		QString url(text.mid(pos, rx.matchedLength()));
+		RetroShareLink link(url);
+
+		if(link.valid())
+		{
+			// check that the link is not already in the list:
+			bool already = false ;
+			for (int i = 0; i <links.size(); ++i)
+				if(links[i] == link)
+				{
+					already = true ;
+					break ;
+				}
+
+			if(!already)
+			{
+				links.push_back(link) ;
+#ifdef DEBUG_RSLINK
+				std::cerr << "captured link: " << link.toString().toStdString() << std::endl ;
+#endif
+			}
+		}
+#ifdef DEBUG_RSLINK
+		else
+			std::cerr << "invalid link" << std::endl ;
+#endif
+
+		pos += rx.matchedLength();
+	}
 }
 

--- a/retroshare-gui/src/gui/RetroShareLink.h
+++ b/retroshare-gui/src/gui/RetroShareLink.h
@@ -208,6 +208,8 @@ class RSLinkClipboard
 		//
 		static int process(RetroShareLink::enumType type = RetroShareLink::TYPE_UNKNOWN, uint flag = RSLINK_PROCESS_NOTIFY_ALL);
 
+		static void parseText(QString text, QList<RetroShareLink> &links) ;
+
 	private:
 		static void parseClipboard(QList<RetroShareLink> &links) ;
 };

--- a/retroshare-gui/src/gui/common/MimeTextEdit.cpp
+++ b/retroshare-gui/src/gui/common/MimeTextEdit.cpp
@@ -78,6 +78,17 @@ void MimeTextEdit::insertFromMimeData(const QMimeData* source)
 	}
 #endif
 
+	//insert retroshare links
+	QList<RetroShareLink> links;
+	RSLinkClipboard::parseText(source->text(), links);
+	if(links.size() > 0)
+	{
+		for(int i = 0; i < links.size(); ++i)
+			insertHtml(links[i].toHtml() + "<br>");
+
+		return;
+	}
+
 	return RSTextEdit::insertFromMimeData(source);
 }
 


### PR DESCRIPTION
Detect retroshare links and insert them in pretty format when pasting text.
One can still use the paste as plain text option, when the long format is needed for some reason.
