### PR TITLE
added an option to follow symbolic links or not, and anti-loop system…

### DIFF
--- a/libretroshare/src/file_sharing/directory_updater.cc
+++ b/libretroshare/src/file_sharing/directory_updater.cc
@@ -145,7 +145,7 @@ void LocalDirectoryUpdater::recursUpdateSharedDir(const std::string& cumulated_p
 		std::string real_path = RsDirUtil::removeSymLinks(cumulated_path) ;
 		if(existing_directories.end() != existing_directories.find(real_path))
 		{
-            std::cerr << "(EE) Directory " << cumulated_path << " has real path " << real_path << " which already belongs to another shared directory. Ignoring" << std::endl;
+            std::cerr << "(WW) Directory " << cumulated_path << " has real path " << real_path << " which already belongs to another shared directory. Ignoring" << std::endl;
 			return ;
 		}
 		existing_directories.insert(real_path) ;

--- a/libretroshare/src/file_sharing/directory_updater.h
+++ b/libretroshare/src/file_sharing/directory_updater.h
@@ -74,5 +74,6 @@ private:
     uint32_t mDelayBetweenDirectoryUpdates;
     bool mIsEnabled ;
     bool mFollowSymLinks;
+    bool mNeedsFullRebuild ;
 };
 

--- a/libretroshare/src/file_sharing/directory_updater.h
+++ b/libretroshare/src/file_sharing/directory_updater.h
@@ -47,6 +47,9 @@ public:
     void setFileWatchPeriod(int seconds) ;
     uint32_t fileWatchPeriod() const ;
 
+    void setFollowSymLinks(bool b) ;
+    bool followSymLinks() const ;
+
     void setEnabled(bool b) ;
     bool isEnabled() const ;
 
@@ -56,7 +59,7 @@ protected:
     virtual void hash_callback(uint32_t client_param, const std::string& name, const RsFileHash& hash, uint64_t size);
     virtual bool hash_confirm(uint32_t client_param) ;
 
-    void recursUpdateSharedDir(const std::string& cumulated_path,DirectoryStorage::EntryIndex indx);
+    void recursUpdateSharedDir(const std::string& cumulated_path, DirectoryStorage::EntryIndex indx, std::set<std::string>& existing_directories);
     void sweepSharedDirectories();
 
 private:
@@ -70,5 +73,6 @@ private:
 
     uint32_t mDelayBetweenDirectoryUpdates;
     bool mIsEnabled ;
+    bool mFollowSymLinks;
 };
 

--- a/libretroshare/src/file_sharing/file_sharing_defaults.h
+++ b/libretroshare/src/file_sharing/file_sharing_defaults.h
@@ -37,6 +37,7 @@ static const uint32_t DELAY_BEFORE_DELETE_EMPTY_REMOTE_DIR      =  5*24*86400 ; 
 static const std::string HASH_CACHE_DURATION_SS = "HASH_CACHE_DURATION" ;	 // key string to store hash remembering time
 static const std::string WATCH_FILE_DURATION_SS = "WATCH_FILES_DELAY" ;		 // key to store delay before re-checking for new files
 static const std::string WATCH_FILE_ENABLED_SS  = "WATCH_FILES_ENABLED"; 	 // key to store ON/OFF flags for file whatch
+static const std::string FOLLOW_SYMLINKS_SS     = "FOLLOW_SYMLINKS"; 	 	 // dereference symbolic links, or just ignore them.
 static const std::string WATCH_HASH_SALT_SS     = "WATCH_HASH_SALT"; 	 	 // Salt that is used to hash directory names
 
 static const std::string FILE_SHARING_DIR_NAME       = "file_sharing" ;			 // hard-coded directory name to store friend file lists, hash cache, etc.
@@ -53,3 +54,5 @@ static const uint32_t NB_FRIEND_INDEX_BITS                    = 10 ;			// Do not
 static const uint32_t NB_ENTRY_INDEX_BITS                     = 22 ;			// Do not change this!
 static const uint32_t ENTRY_INDEX_BIT_MASK                    = 0x003fffff ;	// used for storing (EntryIndex,Friend) couples into a 32bits pointer. Depends on the two values just before. Dont change!
 static const uint32_t DELAY_BEFORE_DROP_REQUEST               = 600; 			// every 10 min
+
+static const bool FOLLOW_SYMLINKS_DEFAULT = true;

--- a/libretroshare/src/file_sharing/p3filelists.h
+++ b/libretroshare/src/file_sharing/p3filelists.h
@@ -138,6 +138,9 @@ class p3FileDatabase: public p3Service, public p3Config, public ftSearch //, pub
         void setWatchEnabled(bool b) ;
         bool watchEnabled() ;
 
+        bool followSymLinks() const;
+        void setFollowSymLinks(bool b) ;
+
         // interfact for directory parsing
 
 		void forceDirectoryCheck();              // Force re-sweep the directories and see what's changed

--- a/libretroshare/src/ft/ftserver.cc
+++ b/libretroshare/src/ft/ftserver.cc
@@ -804,11 +804,13 @@ bool 	ftServer::removeSharedDirectory(std::string dir)
 
 	return true;
 }
-bool     ftServer::watchEnabled()                      { return mFileDatabase->watchEnabled() ; }
-int      ftServer::watchPeriod() const                 { return mFileDatabase->watchPeriod()/60 ; }
+bool ftServer::watchEnabled()                      { return mFileDatabase->watchEnabled() ; }
+int  ftServer::watchPeriod() const                 { return mFileDatabase->watchPeriod()/60 ; }
+bool ftServer::followSymLinks() const              { return mFileDatabase->followSymLinks() ; }
 
-void ftServer::setWatchEnabled(bool b)                      { mFileDatabase->setWatchEnabled(b) ; }
-void ftServer::setWatchPeriod(int minutes)                  { mFileDatabase->setWatchPeriod(minutes*60) ; }
+void ftServer::setWatchEnabled(bool b)             { mFileDatabase->setWatchEnabled(b) ; }
+void ftServer::setWatchPeriod(int minutes)         { mFileDatabase->setWatchPeriod(minutes*60) ; }
+void ftServer::setFollowSymLinks(bool b)           { mFileDatabase->setFollowSymLinks(b) ; }
 
 bool ftServer::getShareDownloadDirectory()
 {

--- a/libretroshare/src/ft/ftserver.h
+++ b/libretroshare/src/ft/ftserver.h
@@ -215,6 +215,8 @@ public:
     virtual int watchPeriod() const ;
     virtual void setWatchEnabled(bool b) ;
     virtual bool watchEnabled() ;
+	virtual bool followSymLinks() const;
+	virtual void setFollowSymLinks(bool b);
 
     /***************************************************************/
     /*************** Data Transfer Interface ***********************/

--- a/libretroshare/src/retroshare/rsfiles.h
+++ b/libretroshare/src/retroshare/rsfiles.h
@@ -247,6 +247,8 @@ class RsFiles
         virtual void setWatchEnabled(bool b) =0;
         virtual int watchPeriod() const =0;
         virtual bool watchEnabled() =0;
+        virtual bool followSymLinks() const=0;
+        virtual void setFollowSymLinks(bool b)=0 ;
 
 		virtual bool	getShareDownloadDirectory() = 0;
 		virtual bool 	shareDownloadDirectory(bool share) = 0;

--- a/libretroshare/src/util/rsdir.cc
+++ b/libretroshare/src/util/rsdir.cc
@@ -482,8 +482,8 @@ bool	RsDirUtil::checkCreateDirectory(const std::string& dir)
 
 std::string RsDirUtil::removeSymLinks(const std::string& path)
 {
-#warning (Mr.Alice): I don't know how to do this on windows. See https://msdn.microsoft.com/en-us/library/windows/desktop/hh707084(v=vs.85).aspx
-#ifdef WINDOWS_SYS
+#if defined(WINDOWS_SYS) || defined(__APPLE__)
+#warning (Mr.Alice): I don't know how to do this on windows/MacOS. See https://msdn.microsoft.com/en-us/library/windows/desktop/hh707084(v=vs.85).aspx
     //if(!S_OK == PathCchCanonicalizeEx(tmp,...) ;
     return path ;
 #else

--- a/libretroshare/src/util/rsdir.cc
+++ b/libretroshare/src/util/rsdir.cc
@@ -480,6 +480,21 @@ bool	RsDirUtil::checkCreateDirectory(const std::string& dir)
 }
 
 
+std::string RsDirUtil::removeSymLinks(const std::string& path)
+{
+#warning (Mr.Alice): I don't know how to do this on windows. See https://msdn.microsoft.com/en-us/library/windows/desktop/hh707084(v=vs.85).aspx
+#ifdef WINDOWS_SYS
+    //if(!S_OK == PathCchCanonicalizeEx(tmp,...) ;
+    return path ;
+#else
+    char *tmp = canonicalize_file_name(path.c_str()) ;
+    std::string result(tmp) ;
+
+    free(tmp);
+    return result ;
+#endif
+}
+
 bool 	RsDirUtil::cleanupDirectory(const std::string& cleandir, const std::set<std::string> &keepFiles)
 {
     for(librs::util::FolderIterator it(cleandir,false);it.isValid();it.next())

--- a/libretroshare/src/util/rsdir.h
+++ b/libretroshare/src/util/rsdir.h
@@ -91,6 +91,10 @@ bool    	checkFile(const std::string& filename,uint64_t& file_size,bool disallow
 bool    	checkDirectory(const std::string& dir);
 bool    	checkCreateDirectory(const std::string& dir);
 
+// Removes all symbolic links along the path and computes the actual location of the file/dir passed as argument.
+
+std::string removeSymLinks(const std::string& path) ;
+
 bool    	cleanupDirectory(const std::string& dir, const std::set<std::string> &keepFiles);
 bool    	cleanupDirectoryFaster(const std::string& dir, const std::set<std::string> &keepFiles);
 

--- a/retroshare-gui/src/gui/settings/DirectoriesPage.cpp
+++ b/retroshare-gui/src/gui/settings/DirectoriesPage.cpp
@@ -68,6 +68,7 @@ bool DirectoriesPage::save(QString &/*errmsg*/)
     rsFiles->setWatchPeriod(ui.autoCheckDirectoriesDelay_SB->value());
 
 	rsFiles->shareDownloadDirectory(ui.shareDownloadDirectoryCB->isChecked());
+	rsFiles->setFollowSymLinks(ui.followSymLinks_CB->isChecked());
 
 	return true;
 }
@@ -83,6 +84,7 @@ void DirectoriesPage::load()
 
 	ui.incomingDir->setText(QString::fromUtf8(rsFiles->getDownloadDirectory().c_str()));
 	ui.partialsDir->setText(QString::fromUtf8(rsFiles->getPartialsDirectory().c_str()));
+	ui.followSymLinks_CB->setChecked(rsFiles->followSymLinks());
 }
 
 void DirectoriesPage::setIncomingDirectory()

--- a/retroshare-gui/src/gui/settings/DirectoriesPage.ui
+++ b/retroshare-gui/src/gui/settings/DirectoriesPage.ui
@@ -6,114 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>895</width>
+    <width>929</width>
     <height>549</height>
    </rect>
   </property>
-  <layout class="QGridLayout">
-   <property name="margin">
-    <number>6</number>
-   </property>
-   <property name="spacing">
-    <number>0</number>
-   </property>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Incoming Directory</string>
-     </property>
-     <layout class="QGridLayout">
-      <item row="0" column="0">
-       <widget class="QLineEdit" name="incomingDir">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="incomingButton">
-        <property name="minimumSize">
-         <size>
-          <width>31</width>
-          <height>31</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>31</width>
-          <height>31</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Browse</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset resource="../images.qrc">
-          <normaloff>:/images/directoryselect_24x24_shadow.png</normaloff>:/images/directoryselect_24x24_shadow.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Partials Directory</string>
-     </property>
-     <layout class="QGridLayout">
-      <item row="0" column="0">
-       <widget class="QLineEdit" name="partialsDir">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="partialButton">
-        <property name="minimumSize">
-         <size>
-          <width>31</width>
-          <height>31</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>31</width>
-          <height>31</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Browse</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset resource="../images.qrc">
-          <normaloff>:/images/directoryselect_24x24_shadow.png</normaloff>:/images/directoryselect_24x24_shadow.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Shared Directories</string>
@@ -176,10 +74,119 @@
         </item>
        </layout>
       </item>
+      <item>
+       <widget class="QCheckBox" name="followSymLinks_CB">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tells Retroshare to follow the links. Loops and duplicate directories are automatically taken care of. If unchecked, Retroshare will just ignore symbolic links to both files and directories.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>follow symbolic links</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Incoming Directory</string>
+     </property>
+     <layout class="QGridLayout">
+      <item row="0" column="0">
+       <widget class="QLineEdit" name="incomingDir">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="incomingButton">
+        <property name="minimumSize">
+         <size>
+          <width>31</width>
+          <height>31</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>31</width>
+          <height>31</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Browse</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../images.qrc">
+          <normaloff>:/images/directoryselect_24x24_shadow.png</normaloff>:/images/directoryselect_24x24_shadow.png</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Partials Directory</string>
+     </property>
+     <layout class="QGridLayout">
+      <item row="0" column="0">
+       <widget class="QLineEdit" name="partialsDir">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="partialButton">
+        <property name="minimumSize">
+         <size>
+          <width>31</width>
+          <height>31</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>31</width>
+          <height>31</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Browse</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../images.qrc">
+          <normaloff>:/images/directoryselect_24x24_shadow.png</normaloff>:/images/directoryselect_24x24_shadow.png</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/retroshare-gui/src/gui/settings/TransferPage.ui
+++ b/retroshare-gui/src/gui/settings/TransferPage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>741</width>
-    <height>372</height>
+    <height>422</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">


### PR DESCRIPTION
… during directories traversal

i solved the loop problem by keeping a set of visited directories, and checking every new directory w.r.t. that list, after expanding them to their real location using RsDirUtil::removeSymLnks(). I could not implement this function however for windows. Can anyone do it? (See comments in the code).