### PR TITLE
Fixed loading of external emoticons

### DIFF
--- a/retroshare-gui/src/gui/common/RSTextBrowser.cpp
+++ b/retroshare-gui/src/gui/common/RSTextBrowser.cpp
@@ -102,11 +102,14 @@ QVariant RSTextBrowser::loadResource(int type, const QUrl &name)
 
 	// case 2: always trust the image if it comes from local Config or Data directories.
 
-	if(name.scheme().compare("file",Qt::CaseInsensitive)==0 && type == QTextDocument::ImageResource) {
-		if (name.path().startsWith(QDir(QString::fromUtf8(RsAccounts::ConfigDirectory().c_str())).absolutePath().prepend("/"),Qt::CaseInsensitive)
-		    || name.path().startsWith(QDir(QString::fromUtf8(RsAccounts::DataDirectory().c_str())).absolutePath().prepend("/"),Qt::CaseInsensitive))
-			return QTextBrowser::loadResource(type, name);
-	}
+	if(type == QTextDocument::ImageResource) {
+		QFileInfo fi = QFileInfo(name.path());
+		if(fi.exists() && fi.isFile()) {
+			QString cpath = fi.canonicalFilePath();
+			if (cpath.startsWith(QDir(QString::fromUtf8(RsAccounts::ConfigDirectory().c_str())).canonicalPath(),Qt::CaseInsensitive)
+					|| cpath.startsWith(QDir(QString::fromUtf8(RsAccounts::DataDirectory().c_str())).canonicalPath(),Qt::CaseInsensitive))
+				return QTextBrowser::loadResource(type, name);
+		}}
 
 	// case 3: only display if the user allows it. Data resources can be bad (svg bombs) but we filter them out globally at the network layer.
 	//         It would be good to add here a home-made resource loader that only loads images and not svg crap, just in case.


### PR DESCRIPTION
- path comparison was Linux specific, also it had problems with relative paths
- name.scheme() returns empty string in this case, check if the url really points to a file instead