### PR TITLE
Made autologin optional at compile time

### DIFF
--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -151,7 +151,7 @@ HEADERS += $$PUBLIC_HEADERS
 
 ################################# Linux ##########################################
 linux-* {
-	CONFIG += link_pkgconfig
+    CONFIG += link_pkgconfig
 
 	QMAKE_CXXFLAGS *= -Wall -D_FILE_OFFSET_BITS=64
 	QMAKE_CC = $${QMAKE_CXX}
@@ -191,8 +191,6 @@ linux-* {
 		DEFINES *= PATCHED_LIBUPNP
 	}
 
-	DEFINES *= HAS_GNOME_KEYRING
-	PKGCONFIG *= gnome-keyring-1
 	PKGCONFIG *= libssl libupnp
 	PKGCONFIG *= libcrypto zlib
 	LIBS *= -lpthread -ldl

--- a/libretroshare/src/rsserver/p3face-config.cc
+++ b/libretroshare/src/rsserver/p3face-config.cc
@@ -60,14 +60,16 @@ const int p3facemsgzone = 11453;
 /* RsIface Config */
 /* Config */
 
-void    RsServer::ConfigFinalSave()
+void RsServer::ConfigFinalSave()
 {
-	/* force saving of transfers TODO */
+	//TODO: force saving of transfers
 	//ftserver->saveFileTransferStatus();
-	if(!RsInit::getAutoLogin())
-		RsInit::RsClearAutoLogin();
 
-        //AuthSSL::getAuthSSL()->FinalSaveCertificates();
+#ifdef RS_AUTOLOGIN
+	if(!RsInit::getAutoLogin()) RsInit::RsClearAutoLogin();
+#endif // RS_AUTOLOGIN
+
+	//AuthSSL::getAuthSSL()->FinalSaveCertificates();
 	mConfigMgr->completeConfiguration();
 }
 

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -725,6 +725,8 @@ int RsInit::LoadCertificates(bool autoLoginNT)
 		RsLoginHandler::enableAutoLogin(preferredId,rsInitConfig->passwd);
 		rsInitConfig->autoLogin = true ;
 	}
+#else
+	(void) autoLoginNT;
 #endif // RS_AUTOLOGIN
 
 	/* wipe out password */

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -717,14 +717,15 @@ int RsInit::LoadCertificates(bool autoLoginNT)
 		return 0 ;
 	}
 
+#ifdef RS_AUTOLOGIN
 	if(autoLoginNT)
 	{
-		std::cerr << "RetroShare will AutoLogin next time";
-		std::cerr << std::endl;
+		std::cerr << "RetroShare will AutoLogin next time" << std::endl;
 
 		RsLoginHandler::enableAutoLogin(preferredId,rsInitConfig->passwd);
 		rsInitConfig->autoLogin = true ;
 	}
+#endif // RS_AUTOLOGIN
 
 	/* wipe out password */
 
@@ -733,10 +734,11 @@ int RsInit::LoadCertificates(bool autoLoginNT)
 	rsInitConfig->gxs_passwd = rsInitConfig->passwd;
 	rsInitConfig->passwd = "";
 	
-	rsAccounts->storePreferredAccount();      
+	rsAccounts->storePreferredAccount();
 	return 1;
 }
 
+#ifdef RS_AUTOLOGIN
 bool RsInit::RsClearAutoLogin()
 {
 	RsPeerId preferredId;
@@ -747,6 +749,7 @@ bool RsInit::RsClearAutoLogin()
 	}
 	return	RsLoginHandler::clearAutoLogin(preferredId);
 }
+#endif // RS_AUTOLOGIN
 
 
 bool RsInit::isPortable()

--- a/libretroshare/src/rsserver/rsloginhandler.h
+++ b/libretroshare/src/rsserver/rsloginhandler.h
@@ -2,46 +2,60 @@
 
 #include <string>
 
-// This class handles login, meaning that it retrieves the SSL password from either
-// the keyring or help.dta file, if autologin is enabled, or from the ssl_passphrase.pgp
-// file, asking for the GPG password to decrypt it.
-//
-// This class should handle the following scenario:
-//
-// Normal login:
-// 	- SSL key is stored  ->  do autologin
-// 	- SSL key is not stored
-// 			- if we're actually in the login process, ask for the gpg passwd, and decrypt the key file
-// 			- if we're just trying for autologin, don't ask for the gpg passwd and return null
-//
-// Key creation:
-// 	- the key should be stored in the gpg file.
-//
+/**
+ * This class handles login, meaning that it retrieves the SSL password from
+ * either the keyring or help.dta file, if autologin is enabled, or from the
+ * ssl_passphrase.pgp file, asking for the GPG password to decrypt it.
+ *
+ * This class should handle the following scenario:
+ *
+ * Normal login:
+ *  - SSL key is stored  ->  do autologin
+ *  - SSL key is not stored
+ *     - if we're actually in the login process, ask for the gpg passwd, and
+ *       decrypt the key file
+ *     - if we're just trying for autologin, don't ask for the gpg passwd and
+ *       return null
+ *
+ * Key creation:
+ *  - the key should be stored in the gpg file.
+ */
 class RsLoginHandler
 {
-	public:
-		// Gets the SSL passwd by any means: try autologin, and look into gpg file if enable_gpg_key_callback==true
-		//
-		static bool getSSLPassword(const RsPeerId& ssl_id,bool enable_gpg_key_callback,std::string& ssl_password) ;
+public:
+	/**
+	 * Gets the SSL passwd by any means: try autologin, and look into gpg file
+	 * if enable_gpg_key_callback==true
+	 */
+	static bool getSSLPassword( const RsPeerId& ssl_id,
+	                            bool enable_gpg_key_callback,
+	                            std::string& ssl_password);
 
-		// Checks whether the ssl passwd is already in the gpg file. If the file's not here, the passwd is stored there, 
-		// encrypted with the current GPG key.
-		//
-		static bool checkAndStoreSSLPasswdIntoGPGFile(const RsPeerId& ssl_id,const std::string& ssl_passwd) ;
+	/**
+	 * Checks whether the ssl passwd is already in the gpg file. If the file's
+	 * not here, the passwd is stored there, encrypted with the current GPG key.
+	 */
+	static bool checkAndStoreSSLPasswdIntoGPGFile(
+	        const RsPeerId& ssl_id, const std::string& ssl_passwd );
 
-		// Stores the given ssl_id/passwd pair into the keyring, or by default into a file in /[ssl_id]/keys/help.dta
-		//
-		static bool enableAutoLogin(const RsPeerId& ssl_id,const std::string& passwd) ;
+#ifdef RS_AUTOLOGIN
+	/**
+	 * Stores the given ssl_id/passwd pair into the keyring, or by default into
+	 * a file in /[ssl_id]/keys/help.dta
+	 */
+	static bool enableAutoLogin(const RsPeerId& ssl_id,const std::string& passwd) ;
 
-		// Clears autologin entry. 
-		//
-		static bool clearAutoLogin(const RsPeerId& ssl_id) ;
+	/// Clears autologin entry.
+	static bool clearAutoLogin(const RsPeerId& ssl_id) ;
+#endif // RS_AUTOLOGIN
 
-	private:
-		static bool tryAutoLogin(const RsPeerId& ssl_id,std::string& ssl_passwd) ;
-		static bool getSSLPasswdFromGPGFile(const RsPeerId& ssl_id,std::string& sslPassword) ;
+private:
+	static bool getSSLPasswdFromGPGFile(const RsPeerId& ssl_id,std::string& sslPassword);
+	static std::string getSSLPasswdFileName(const RsPeerId& ssl_id);
 
-		static std::string getSSLPasswdFileName(const RsPeerId& ssl_id) ;
-		static std::string getAutologinFileName(const RsPeerId& ssl_id) ;
+#ifdef RS_AUTOLOGIN
+	static bool tryAutoLogin(const RsPeerId& ssl_id,std::string& ssl_passwd);
+	static std::string getAutologinFileName(const RsPeerId& ssl_id);
+#endif // RS_AUTOLOGIN
 };
 

--- a/retroshare-gui/src/gui/StartDialog.cpp
+++ b/retroshare-gui/src/gui/StartDialog.cpp
@@ -35,12 +35,17 @@ StartDialog::StartDialog(QWidget *parent)
 	/* Invoke Qt Designer generated QObject setup routine */
 	ui.setupUi(this);
 
+#ifdef RS_AUTOLOGIN
+	connect(ui.autologin_checkbox, SIGNAL(clicked()), this, SLOT(notSecureWarning()));
+#else
+	ui.autologin_checkbox->setHidden(true);
+#endif
+
 	Settings->loadWidgetInformation(this);
 
 	ui.loadButton->setFocus();
 
 	connect(ui.loadButton, SIGNAL(clicked()), this, SLOT(loadPerson()));
-	connect(ui.autologin_checkbox, SIGNAL(clicked()), this, SLOT(notSecureWarning()));
 
 	/* get all available pgp private certificates....
 	* mark last one as default.
@@ -115,6 +120,7 @@ bool StartDialog::requestedNewCert()
 	return reqNewCert;
 }
 
+#ifdef RS_AUTOLOGIN
 void StartDialog::notSecureWarning()
 {
 	/* some error msg */
@@ -130,3 +136,4 @@ void StartDialog::notSecureWarning()
 #endif
 #endif
 }
+#endif // RS_AUTOLOGIN

--- a/retroshare-gui/src/gui/StartDialog.h
+++ b/retroshare-gui/src/gui/StartDialog.h
@@ -40,10 +40,12 @@ protected:
 private slots:
 	void loadPerson();
 
+#ifdef RS_AUTOLOGIN
 	/**
 	 * Warns the user that autologin is not secure
 	 */
 	void notSecureWarning();
+#endif // RS_AUTOLOGIN
 
 	void on_labelProfile_linkActivated(QString link);
 

--- a/retroshare-gui/src/gui/StartDialog.ui
+++ b/retroshare-gui/src/gui/StartDialog.ui
@@ -18,7 +18,16 @@
     <normaloff>:/images/logo/logo_32.png</normaloff>:/images/logo/logo_32.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -197,6 +206,12 @@
       <widget class="QGroupBox" name="groupBox">
        <property name="enabled">
         <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="title">
         <string/>

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -70,7 +70,8 @@ INCLUDEPATH *= retroshare-gui
 ################################# Linux ##########################################
 # Put lib dir in QMAKE_LFLAGS so it appears before -L/usr/lib
 linux-* {
-	CONFIG += link_pkgconfig
+    CONFIG += link_pkgconfig
+
 	#CONFIG += version_detail_bash_script
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
@@ -78,7 +79,6 @@ linux-* {
 
 	LIBS *= -rdynamic 
 	DEFINES *= HAVE_XSS # for idle time, libx screensaver extensions
-	DEFINES *= HAS_GNOME_KEYRING
 }
 
 unix {

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -39,6 +39,12 @@ no_libresapihttpserver:CONFIG -= libresapihttpserver
 CONFIG *= sqlcipher
 no_sqlcipher:CONFIG -= sqlcipher
 
+# To enable autologin (this is higly discouraged as it may compromise your node
+# security in multiple ways) append the following assignation to qmake command
+# line "CONFIG+=rs_autologin"
+CONFIG *= no_rs_autologin
+rs_autologin:CONFIG -= no_rs_autologin
+
 # To disable GXS (General eXchange System) append the following
 # assignation to qmake command line "CONFIG+=no_rs_gxs"
 CONFIG *= rs_gxs
@@ -52,6 +58,13 @@ unix {
 	isEmpty(LIB_DIR)  { LIB_DIR  = "$${PREFIX}/lib" }
 	isEmpty(DATA_DIR) { DATA_DIR = "$${PREFIX}/share/RetroShare06" }
 	isEmpty(PLUGIN_DIR) { PLUGIN_DIR  = "$${LIB_DIR}/retroshare/extensions6" }
+
+    rs_autologin {
+        !macx {
+            DEFINES *= HAS_GNOME_KEYRING
+            PKGCONFIG *= gnome-keyring-1
+        }
+    }
 }
 
 android-g++ {
@@ -136,3 +149,7 @@ libresapilocalserver:DEFINES *= LIBRESAPI_LOCAL_SERVER
 libresapihttpserver:DEFINES *= ENABLE_WEBUI
 sqlcipher:DEFINES -= NO_SQLCIPHER
 no_sqlcipher:DEFINES *= NO_SQLCIPHER
+rs_autologin {
+    DEFINES *= RS_AUTOLOGIN
+    warning(You have enabled RetroShare autologin this is strongly discouraged as it may compromise your node security in multiple ways)
+}

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -151,5 +151,5 @@ sqlcipher:DEFINES -= NO_SQLCIPHER
 no_sqlcipher:DEFINES *= NO_SQLCIPHER
 rs_autologin {
     DEFINES *= RS_AUTOLOGIN
-    warning(You have enabled RetroShare autologin this is strongly discouraged as it may compromise your node security in multiple ways)
+    warning(You have enabled RetroShare auto-login, this is discouraged. The usage of auto-login on some linux distributions may allow someone having access to your session to steal the SSL keys of your node location and therefore compromise your security)
 }


### PR DESCRIPTION
Autologin is disabled by default at compile time, and a warning to
discourage it's usage is printed if it is enabled.
This will make default RetroShare build safer and reduce dependencies as
example we don't depends anymore on gnome keyring is not needed in default
build for linux anymore.