### PR TITLE
Expose libresapi for distant chat

### DIFF
--- a/libresapi/src/api/ApiTypes.h
+++ b/libresapi/src/api/ApiTypes.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <ostream>
 
+#include "util/rsdeprecate.h"
+
 namespace resource_api
 {
 // things to clean up:
@@ -181,18 +183,20 @@ private:
 class Request
 {
 public:
-    Request(StreamBase& stream): mStream(stream), mMethod(GET){}
+	Request(StreamBase& stream) : mStream(stream), mMethod(GET){}
 
-    bool isGet(){ return mMethod == GET;}
-    bool isPut(){ return mMethod == PUT;}
-    bool isDelete(){ return mMethod == DELETE_AA;}
-    bool isExec(){ return mMethod == EXEC;}
+	RS_DEPRECATED bool isGet(){ return mMethod == GET;}
+	RS_DEPRECATED bool isPut(){ return mMethod == PUT;}
+	RS_DEPRECATED bool isDelete(){ return mMethod == DELETE_AA;}
+	RS_DEPRECATED bool isExec(){ return mMethod == EXEC;}
 
-    // path is the adress to the resource
-    // if the path has multiple parts which get handled by different handlers,
-    // then each handler should pop the top element
-    std::stack<std::string> mPath;
-    std::string mFullPath;
+	/**
+	 * Path is the adress to the resource if the path has multiple parts which
+	 * get handled by different handlers, then each handler should pop the top
+	 * element
+	 */
+	std::stack<std::string> mPath;
+	std::string mFullPath;
 	bool setPath(const std::string &reqPath)
 	{
 		std::string str;
@@ -213,19 +217,16 @@ public:
 		return true;
 	}
 
-    // parameters should be used to influence the result
-    // for example include or exclude some information
-    // question: when to use parameters, and when to use the data field?
-    // it would be easier to have only one thing...
-    // UNUSED: was never implemented
-    //std::vector<std::pair<std::string, std::string> > mParameters;
+	/// Contains data for new resources
+	StreamBase& mStream;
 
-    // contains data for new resources
-    StreamBase& mStream;
-
-    // use the is*() methods to query the method type:
-    enum Method { GET, PUT, DELETE_AA, EXEC};// something is wrong with DELETE, it won't compile with it
-    Method mMethod;
+	/**
+	 * @deprecated
+	 * Method and derivated stuff usage is deprecated as it make implementation
+	 * more complex and less readable without advantage
+	 */
+	enum Method { GET, PUT, DELETE_AA, EXEC};
+	RS_DEPRECATED Method mMethod;
 };
 
 // new notes on responses

--- a/libresapi/src/api/ChatHandler.h
+++ b/libresapi/src/api/ChatHandler.h
@@ -11,9 +11,10 @@ class RsIdentity;
 namespace resource_api
 {
 
-class UnreadMsgNotify{
+class UnreadMsgNotify
+{
 public:
-    virtual void notifyUnreadMsgCountChanged(const RsPeerId& peer, uint32_t count) = 0;
+	virtual void notifyUnreadMsgCountChanged(const RsPeerId& peer, uint32_t count) = 0;
 };
 
 class ChatHandler: public ResourceRouter, NotifyClient, Tickable
@@ -128,6 +129,9 @@ private:
     ResponseTask *handleReceiveStatus(Request& req, Response& resp);
     void handleSendStatus(Request& req, Response& resp);
     void handleUnreadMsgs(Request& req, Response& resp);
+	void handleInitiateDistantChatConnexion(Request& req, Response& resp);
+	void handleDistantChatStatus(Request& req, Response& resp);
+	void handleCloseDistantChatConnexion(Request& req, Response& resp);
 
     void getPlainText(const std::string& in, std::string &out, std::vector<Triple> &links);
     // last parameter is only used for lobbies!

--- a/libretroshare/src/chat/distantchat.cc
+++ b/libretroshare/src/chat/distantchat.cc
@@ -275,31 +275,30 @@ bool DistantChatService::initiateDistantChatConnexion(const RsGxsId& to_gxs_id, 
 
 bool DistantChatService::getDistantChatStatus(const DistantChatPeerId& tunnel_id, DistantChatPeerInfo& cinfo) 
 {
-    RsStackMutex stack(mDistantChatMtx); /********** STACK LOCKED MTX ******/
+	RS_STACK_MUTEX(mDistantChatMtx);
 
-    RsGxsTunnelService::GxsTunnelInfo tinfo ;
+	RsGxsTunnelService::GxsTunnelInfo tinfo;
 
-    if(!mGxsTunnels->getTunnelInfo(RsGxsTunnelId(tunnel_id),tinfo))
-	    return false;
+	if(!mGxsTunnels->getTunnelInfo(RsGxsTunnelId(tunnel_id),tinfo)) return false;
 
-    cinfo.to_id  = tinfo.destination_gxs_id;
-    cinfo.own_id = tinfo.source_gxs_id;
-    cinfo.peer_id = tunnel_id;
+	cinfo.to_id  = tinfo.destination_gxs_id;
+	cinfo.own_id = tinfo.source_gxs_id;
+	cinfo.peer_id = tunnel_id;
 
-    switch(tinfo.tunnel_status)
-    {
-    case RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_CAN_TALK : 		cinfo.status = RS_DISTANT_CHAT_STATUS_CAN_TALK;		
-	    						break ;
-    case RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_TUNNEL_DN: 		cinfo.status = RS_DISTANT_CHAT_STATUS_TUNNEL_DN ;  		
-	    						break ;
-    case RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_REMOTELY_CLOSED: 	cinfo.status = RS_DISTANT_CHAT_STATUS_REMOTELY_CLOSED ;	
-	    						break ;
-    default:
-    case  RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_UNKNOWN: 		cinfo.status = RS_DISTANT_CHAT_STATUS_UNKNOWN;			
-	    						break ;
-    }
+	switch(tinfo.tunnel_status)
+	{
+	case RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_CAN_TALK :
+		cinfo.status = RS_DISTANT_CHAT_STATUS_CAN_TALK; break;
+	case RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_TUNNEL_DN:
+		cinfo.status = RS_DISTANT_CHAT_STATUS_TUNNEL_DN; break;
+	case RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_REMOTELY_CLOSED:
+		cinfo.status = RS_DISTANT_CHAT_STATUS_REMOTELY_CLOSED; break;
+	case RsGxsTunnelService::RS_GXS_TUNNEL_STATUS_UNKNOWN:
+	default:
+		cinfo.status = RS_DISTANT_CHAT_STATUS_UNKNOWN; break;
+	}
 
-    return true ;
+	return true;
 }
 
 bool DistantChatService::closeDistantChatConnexion(const DistantChatPeerId &tunnel_id)

--- a/libretroshare/src/chat/p3chatservice.cc
+++ b/libretroshare/src/chat/p3chatservice.cc
@@ -292,14 +292,11 @@ void p3ChatService::checkSizeAndSendMessage(RsChatMsgItem *msg)
 
 bool p3ChatService::isOnline(const RsPeerId& pid)
 {
-    // check if the id is a tunnel id or a peer id.
-    
-    DistantChatPeerInfo dcpinfo;
-
-    if(getDistantChatStatus(DistantChatPeerId(pid),dcpinfo))
-	    return dcpinfo.status == RS_DISTANT_CHAT_STATUS_CAN_TALK ;
-    else
-	    return mServiceCtrl->isPeerConnected(getServiceInfo().mServiceType, pid);
+	// check if the id is a tunnel id or a peer id.
+	DistantChatPeerInfo dcpinfo;
+	if(getDistantChatStatus(DistantChatPeerId(pid),dcpinfo))
+		return dcpinfo.status == RS_DISTANT_CHAT_STATUS_CAN_TALK;
+	else return mServiceCtrl->isPeerConnected(getServiceInfo().mServiceType, pid);
 }
 
 bool p3ChatService::sendChat(ChatId destination, std::string msg)
@@ -318,8 +315,7 @@ bool p3ChatService::sendChat(ChatId destination, std::string msg)
     }
     // destination is peer or distant
 #ifdef CHAT_DEBUG
-    std::cerr << "p3ChatService::sendChat()";
-    std::cerr << std::endl;
+	std::cerr << "p3ChatService::sendChat()" << std::endl;
 #endif
 
     RsPeerId vpid;
@@ -341,12 +337,12 @@ bool p3ChatService::sendChat(ChatId destination, std::string msg)
     message.online = true;
 
     if(!isOnline(vpid))
-    {
-        /* peer is offline, add to outgoing list */
-        {
-            RsStackMutex stack(mChatMtx); /********** STACK LOCKED MTX ******/
-            privateOutgoingList.push_back(ci);
-        }
+	{
+		/* peer is offline, add to outgoing list */
+		{
+			RS_STACK_MUTEX(mChatMtx);
+			privateOutgoingList.push_back(ci);
+		}
 
         message.online = false;
         RsServer::notify()->notifyChatMessage(message);

--- a/libretroshare/src/gxstunnel/p3gxstunnel.cc
+++ b/libretroshare/src/gxstunnel/p3gxstunnel.cc
@@ -1464,7 +1464,7 @@ RsGxsId p3GxsTunnelService::destinationGxsIdFromHash(const TurtleFileHash& sum)
 
 bool p3GxsTunnelService::getTunnelInfo(const RsGxsTunnelId& tunnel_id,GxsTunnelInfo& info)
 {
-    RsStackMutex stack(mGxsTunnelMtx); /********** STACK LOCKED MTX ******/
+	RS_STACK_MUTEX(mGxsTunnelMtx);
 
     std::map<RsGxsTunnelId,GxsTunnelPeerInfo>::const_iterator it = _gxs_tunnel_contacts.find(tunnel_id) ;
 

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -527,7 +527,8 @@ HEADERS +=	util/folderiterator.h \
 			util/rstickevent.h \
 			util/rsrecogn.h \
 			util/rsscopetimer.h \
-			util/stacktrace.h
+            util/stacktrace.h \
+            util/rsdeprecate.h
 
 SOURCES +=	ft/ftchunkmap.cc \
 			ft/ftcontroller.cc \
@@ -540,7 +541,7 @@ SOURCES +=	ft/ftchunkmap.cc \
 			ft/fttransfermodule.cc \
 			ft/ftturtlefiletransferitem.cc 
 
-SOURCES += crypto/chacha20.cpp 
+SOURCES += crypto/chacha20.cpp
 
 SOURCES += chat/distantchat.cc \
 			  chat/p3chatservice.cc \

--- a/libretroshare/src/rsserver/p3msgs.cc
+++ b/libretroshare/src/rsserver/p3msgs.cc
@@ -79,22 +79,21 @@ ChatId::ChatId(ChatLobbyId id):
     lobby_id = id;
 }
 
-ChatId::ChatId(std::string str):
-    lobby_id(0)
+ChatId::ChatId(std::string str) : lobby_id(0)
 {
-    type = TYPE_NOT_SET;
-    if(str.empty())
-        return;
+	type = TYPE_NOT_SET;
+	if(str.empty()) return;
+
     if(str[0] == 'P')
     {
         type = TYPE_PRIVATE;
         peer_id = RsPeerId(str.substr(1));
-    }
-    else if(str[0] == 'D')
-    {
-        type = TYPE_PRIVATE_DISTANT;
-        distant_chat_id == DistantChatPeerId(str.substr(1));
-    }
+	}
+	else if(str[0] == 'D')
+	{
+		type = TYPE_PRIVATE_DISTANT;
+		distant_chat_id = DistantChatPeerId(str.substr(1));
+	}
     else if(str[0] == 'L')
     {
         if(sizeof(ChatLobbyId) != 8)
@@ -401,7 +400,7 @@ bool    p3Msgs::resetMessageStandardTagTypes(MsgTagType& tags)
 /****************************************/
 bool p3Msgs::sendChat(ChatId destination, std::string msg)
 {
-    return mChatSrv->sendChat(destination, msg);
+	return mChatSrv->sendChat(destination, msg);
 }
 
 uint32_t p3Msgs::getMaxMessageSecuritySize(int type)

--- a/libretroshare/src/util/rsdeprecate.h
+++ b/libretroshare/src/util/rsdeprecate.h
@@ -1,0 +1,34 @@
+#pragma once
+/*
+ * RetroShare deprecation macros
+ * Copyright (C) 2016  Gioacchino Mazzurco <gio@eigenlab.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
+#	define RS_DEPRECATED __attribute__((__deprecated__))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1300)
+#	define RS_DEPRECATED __declspec(deprecated)
+#else
+#	define RS_DEPRECATED
+#endif
+
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+#	define RS_DEPRECATED_FOR(f) __attribute__((__deprecated__("Use '" #f "' instead")))
+#elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
+#	define RS_DEPRECATED_FOR(f) __declspec(deprecated("is deprecated. Use '" #f "' instead"))
+#else
+#	define RS_DEPRECATED_FOR(f) RS_DEPRECATED
+#endif


### PR DESCRIPTION
Added macro to deprecate symbols usage in a crossplatform way.
Deprecated Request::mMethod and related stuff that make implementation
 more complex without advantage.
Added /chat/{initiate_distant_chat, distant_chat_status,
 close_distant_chat} to libresapi.
Solved subtle bug in ChatId::ChatId(std::string str) that caused zeroed
 DistantChatPeerId being created.