### PR TITLE
small gui fixes in lobbies id menu and stats window

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -234,17 +234,16 @@ void ChatLobbyDialog::participantsTreeWidgetCustomPopupMenu(QPoint)
 	contextMnu.addAction(showinpeopleAct);
 
 	distantChatAct->setEnabled(false);
-	sendMessageAct->setEnabled(false);
+	sendMessageAct->setEnabled(selectedItems.count()==1);
 	muteAct->setCheckable(true);
     muteAct->setEnabled(false);
     muteAct->setChecked(false);
     votePositiveAct->setEnabled(false);
     voteNeutralAct->setEnabled(false);
     banAct->setEnabled(false);
+	showinpeopleAct->setEnabled(selectedItems.count()==1);
     if(selectedItems.count()==1)
     {
-		sendMessageAct->setEnabled(true);
-		showinpeopleAct->setEnabled(true);
         RsGxsId nickName;
         rsMsgs->getIdentityForChatLobby(lobbyId, nickName);
 		if(RsGxsId(selectedItems.at(0)->text(COLUMN_ID).toStdString())!=nickName)

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -110,9 +110,9 @@ ChatLobbyDialog::ChatLobbyDialog(const ChatLobbyId& lid, QWidget *parent, Qt::Wi
     connect(muteAct, SIGNAL(triggered()), this, SLOT(changePartipationState()));
     connect(distantChatAct, SIGNAL(triggered()), this, SLOT(distantChatParticipant()));
     connect(sendMessageAct, SIGNAL(triggered()), this, SLOT(sendMessage()));
-    connect(votePositiveAct, SIGNAL(triggered()), this, SLOT(voteParticipant(1)));
-    connect(voteNeutralAct, SIGNAL(triggered()), this, SLOT(voteParticipant(0)));
-    connect(banAct, SIGNAL(triggered()), this, SLOT(voteParticipant(-1)));
+    connect(votePositiveAct, SIGNAL(triggered()), this, SLOT(voteParticipantPositive()));
+    connect(voteNeutralAct, SIGNAL(triggered()), this, SLOT(voteParticipantNeutral()));
+    connect(banAct, SIGNAL(triggered()), this, SLOT(voteParticipantNegative()));
     connect(showinpeopleAct, SIGNAL(triggered()), this, SLOT(showInPeopleTab()));
 
     connect(actionSortByName, SIGNAL(triggered()), this, SLOT(sortParcipants()));
@@ -263,37 +263,70 @@ void ChatLobbyDialog::participantsTreeWidgetCustomPopupMenu(QPoint)
 	contextMnu.exec(QCursor::pos());
 }
 
+void ChatLobbyDialog::voteParticipantPositive()
+{
+    QList<QTreeWidgetItem*> selectedItems = ui.participantsList->selectedItems();
+    if (selectedItems.isEmpty())
+	    return;
+    QList<QTreeWidgetItem*>::iterator item;
+    for (item = selectedItems.begin(); item != selectedItems.end(); ++item)
+	{
+		RsGxsId nickname;
+	    dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->getId(nickname) ;
+	    RsGxsId gxs_id;
+	    rsMsgs->getIdentityForChatLobby(lobbyId, gxs_id);
+	    // This test avoids to mute/ban your own identity
+	    if (gxs_id!=nickname)
+        {
+			rsReputations->setOwnOpinion(nickname, RsReputations::OPINION_POSITIVE);
+            std::cerr << "Giving positive opinion to GXS id " << nickname << std::endl;
+            dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->forceUpdate();
+        }
+    }
+}
+
+void ChatLobbyDialog::voteParticipantNeutral()
+{
+    QList<QTreeWidgetItem*> selectedItems = ui.participantsList->selectedItems();
+    if (selectedItems.isEmpty())
+	    return;
+    QList<QTreeWidgetItem*>::iterator item;
+    for (item = selectedItems.begin(); item != selectedItems.end(); ++item)
+	{
+		RsGxsId nickname;
+	    dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->getId(nickname) ;
+	    RsGxsId gxs_id;
+	    rsMsgs->getIdentityForChatLobby(lobbyId, gxs_id);
+	    // This test avoids to mute/ban your own identity
+	    if (gxs_id!=nickname)
+        {
+            rsReputations->setOwnOpinion(nickname, RsReputations::OPINION_NEUTRAL);
+            std::cerr << "Giving neutral opinion to GXS id " << nickname << std::endl;
+            dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->forceUpdate();
+        }
+    }
+}
+
 /**
  * @brief Called when the "ban" menu is selected. Sets a negative reputation on the selected user.
  */
-void ChatLobbyDialog::voteParticipant(int vote)
+void ChatLobbyDialog::voteParticipantNegative()
 {
     QList<QTreeWidgetItem*> selectedItems = ui.participantsList->selectedItems();
-
-    if (selectedItems.isEmpty()) {
+    if (selectedItems.isEmpty())
 	    return;
-    }
-
     QList<QTreeWidgetItem*>::iterator item;
-    for (item = selectedItems.begin(); item != selectedItems.end(); ++item) {
-
-	    RsGxsId nickname;
+    for (item = selectedItems.begin(); item != selectedItems.end(); ++item)
+	{
+		RsGxsId nickname;
 	    dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->getId(nickname) ;
-
 	    RsGxsId gxs_id;
 	    rsMsgs->getIdentityForChatLobby(lobbyId, gxs_id);
-
 	    // This test avoids to mute/ban your own identity
-
 	    if (gxs_id!=nickname)
         {
-            switch(vote)
-            {
-                case 1: rsReputations->setOwnOpinion(nickname, RsReputations::OPINION_POSITIVE);
-                case -1: rsReputations->setOwnOpinion(nickname, RsReputations::OPINION_NEGATIVE);
-                default: rsReputations->setOwnOpinion(nickname, RsReputations::OPINION_NEUTRAL);
-            }
-            std::cerr << "Giving " << vote << " opinion to GXS id " << nickname << std::endl;
+            rsReputations->setOwnOpinion(nickname, RsReputations::OPINION_NEGATIVE);
+            std::cerr << "Giving negative opinion to GXS id " << nickname << std::endl;
             dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->forceUpdate();
         }
     }

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -222,7 +222,7 @@ void ChatLobbyDialog::participantsTreeWidgetCustomPopupMenu(QPoint)
 	QMenu contextMnu(this);
 
     contextMnu.addAction(distantChatAct);
-    contextMnu.addAction(sendMessageAct);
+	contextMnu.addAction(sendMessageAct);
     contextMnu.addSeparator();
     contextMnu.addAction(actionSortByActivity);
     contextMnu.addAction(actionSortByName);
@@ -233,40 +233,33 @@ void ChatLobbyDialog::participantsTreeWidgetCustomPopupMenu(QPoint)
     contextMnu.addAction(banAct);
 	contextMnu.addAction(showinpeopleAct);
 
+	distantChatAct->setEnabled(false);
+	sendMessageAct->setEnabled(false);
 	muteAct->setCheckable(true);
     muteAct->setEnabled(false);
     muteAct->setChecked(false);
     votePositiveAct->setEnabled(false);
     voteNeutralAct->setEnabled(false);
     banAct->setEnabled(false);
-    showinpeopleAct->setEnabled(true);
-
-    if (selectedItems.size())
+    if(selectedItems.count()==1)
     {
+		sendMessageAct->setEnabled(true);
+		showinpeopleAct->setEnabled(true);
         RsGxsId nickName;
         rsMsgs->getIdentityForChatLobby(lobbyId, nickName);
-
-        if(selectedItems.count()>1 || (RsGxsId(selectedItems.at(0)->text(COLUMN_ID).toStdString())!=nickName))
-        {
-            muteAct->setEnabled(true);
-            votePositiveAct->setEnabled(true);
-            voteNeutralAct->setEnabled(true);
-            banAct->setEnabled(true);
-
-            QList<QTreeWidgetItem*>::iterator item;
-            for (item = selectedItems.begin(); item != selectedItems.end(); ++item) {
-
-                RsGxsId gxsid ;
-                if ( dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->getId(gxsid) && isParticipantMuted(gxsid))
-                {
-                    muteAct->setChecked(true);
-                    break;
-                }
-            }
-        }
-    distantChatAct->setEnabled(selectedItems.count()==1 && RsGxsId(selectedItems.front()->text(COLUMN_ID).toStdString())!=nickName) ;
+		if(RsGxsId(selectedItems.at(0)->text(COLUMN_ID).toStdString())!=nickName)
+		{
+			distantChatAct->setEnabled(true);
+            RsGxsId gxsid ;
+			dynamic_cast<GxsIdRSTreeWidgetItem*>(*selectedItems.begin())->getId(gxsid);
+			votePositiveAct->setEnabled(rsIdentity->overallReputationLevel(gxsid) != RsReputations::REPUTATION_LOCALLY_POSITIVE);
+			voteNeutralAct->setEnabled((rsIdentity->overallReputationLevel(gxsid) == RsReputations::REPUTATION_LOCALLY_POSITIVE) || (rsIdentity->overallReputationLevel(gxsid) == RsReputations::REPUTATION_LOCALLY_NEGATIVE) );
+			banAct->setEnabled(rsIdentity->overallReputationLevel(gxsid) != RsReputations::REPUTATION_LOCALLY_NEGATIVE);
+			muteAct->setEnabled(true);
+            if(isParticipantMuted(gxsid))
+                muteAct->setChecked(true);
+		}
     }
-
 	contextMnu.exec(QCursor::pos());
 }
 

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -239,7 +239,7 @@ void ChatLobbyDialog::participantsTreeWidgetCustomPopupMenu(QPoint)
     votePositiveAct->setEnabled(false);
     voteNeutralAct->setEnabled(false);
     banAct->setEnabled(false);
-    showinpeopleAct->setEnabled(false);
+    showinpeopleAct->setEnabled(true);
 
     if (selectedItems.size())
     {
@@ -252,7 +252,6 @@ void ChatLobbyDialog::participantsTreeWidgetCustomPopupMenu(QPoint)
             votePositiveAct->setEnabled(true);
             voteNeutralAct->setEnabled(true);
             banAct->setEnabled(true);
-            showinpeopleAct->setEnabled(true);
 
             QList<QTreeWidgetItem*>::iterator item;
             for (item = selectedItems.begin(); item != selectedItems.end(); ++item) {
@@ -312,12 +311,8 @@ void ChatLobbyDialog::showInPeopleTab()
     QList<QTreeWidgetItem*> selectedItems = ui.participantsList->selectedItems();
     if (selectedItems.count()!=1)
         return;
-    QList<QTreeWidgetItem*>::iterator item;
     RsGxsId nickname;
-    for (item = selectedItems.begin(); item != selectedItems.end(); ++item)
-    {
-        dynamic_cast<GxsIdRSTreeWidgetItem*>(*item)->getId(nickname) ;
-    }
+    dynamic_cast<GxsIdRSTreeWidgetItem*>(*selectedItems.begin())->getId(nickname);
     IdDialog *idDialog = dynamic_cast<IdDialog*>(MainWindow::getPage(MainWindow::People));
     if (!idDialog)
         return ;

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -251,9 +251,9 @@ void ChatLobbyDialog::participantsTreeWidgetCustomPopupMenu(QPoint)
 			distantChatAct->setEnabled(true);
             RsGxsId gxsid ;
 			dynamic_cast<GxsIdRSTreeWidgetItem*>(*selectedItems.begin())->getId(gxsid);
-			votePositiveAct->setEnabled(rsIdentity->overallReputationLevel(gxsid) != RsReputations::REPUTATION_LOCALLY_POSITIVE);
-			voteNeutralAct->setEnabled((rsIdentity->overallReputationLevel(gxsid) == RsReputations::REPUTATION_LOCALLY_POSITIVE) || (rsIdentity->overallReputationLevel(gxsid) == RsReputations::REPUTATION_LOCALLY_NEGATIVE) );
-			banAct->setEnabled(rsIdentity->overallReputationLevel(gxsid) != RsReputations::REPUTATION_LOCALLY_NEGATIVE);
+			votePositiveAct->setEnabled(rsReputations->overallReputationLevel(gxsid) != RsReputations::REPUTATION_LOCALLY_POSITIVE);
+			voteNeutralAct->setEnabled((rsReputations->overallReputationLevel(gxsid) == RsReputations::REPUTATION_LOCALLY_POSITIVE) || (rsReputations->overallReputationLevel(gxsid) == RsReputations::REPUTATION_LOCALLY_NEGATIVE) );
+			banAct->setEnabled(rsReputations->overallReputationLevel(gxsid) != RsReputations::REPUTATION_LOCALLY_NEGATIVE);
 			muteAct->setEnabled(true);
             if(isParticipantMuted(gxsid))
                 muteAct->setChecked(true);

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
@@ -80,8 +80,7 @@ protected slots:
     void distantChatParticipant();
     void participantsTreeWidgetDoubleClicked(QTreeWidgetItem *item, int column);
     void sendMessage();
-    void banParticipant();
-	void voteParticipant();
+	void voteParticipant(int vote);
 
 private:
 	void updateParticipantsList();
@@ -109,8 +108,9 @@ private:
     std::set<RsGxsId> mutedParticipants;
 
     QAction *muteAct;
+	QAction *votePositiveAct;
+	QAction *voteNeutralAct;
     QAction *banAct;
-	QAction *voteAct;
     QAction *distantChatAct;
     QAction *actionSortByName;
     QAction *actionSortByActivity;

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
@@ -81,6 +81,7 @@ protected slots:
     void participantsTreeWidgetDoubleClicked(QTreeWidgetItem *item, int column);
     void sendMessage();
     void banParticipant();
+	void voteParticipant();
 
 private:
 	void updateParticipantsList();
@@ -109,6 +110,7 @@ private:
 
     QAction *muteAct;
     QAction *banAct;
+	QAction *voteAct;
     QAction *distantChatAct;
     QAction *actionSortByName;
     QAction *actionSortByActivity;

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
@@ -54,6 +54,7 @@ private slots:
 	void inviteFriends() ;
 	void leaveLobby() ;
 	void filterChanged(const QString &text);
+    void showInPeopleTab();
 
 signals:
 	void lobbyLeave(ChatLobbyId) ;
@@ -80,7 +81,7 @@ protected slots:
     void distantChatParticipant();
     void participantsTreeWidgetDoubleClicked(QTreeWidgetItem *item, int column);
     void sendMessage();
-	void voteParticipant(int vote);
+    void voteParticipant(int vote);
 
 private:
 	void updateParticipantsList();
@@ -108,15 +109,16 @@ private:
     std::set<RsGxsId> mutedParticipants;
 
     QAction *muteAct;
-	QAction *votePositiveAct;
-	QAction *voteNeutralAct;
+    QAction *votePositiveAct;
+    QAction *voteNeutralAct;
     QAction *banAct;
     QAction *distantChatAct;
     QAction *actionSortByName;
     QAction *actionSortByActivity;
     QWidgetAction *checkableAction;
     QAction *sendMessageAct;
-
+    QAction *showinpeopleAct;
+	
     GxsIdChooser *ownIdChooser ;
 };
 

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
@@ -81,7 +81,9 @@ protected slots:
     void distantChatParticipant();
     void participantsTreeWidgetDoubleClicked(QTreeWidgetItem *item, int column);
     void sendMessage();
-    void voteParticipant(int vote);
+	void voteParticipantPositive();
+	void voteParticipantNeutral();
+    void voteParticipantNegative();
 
 private:
 	void updateParticipantsList();

--- a/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
@@ -480,7 +480,10 @@ void GroupTreeWidget::fillGroupItems(QTreeWidgetItem *categoryItem, const QList<
 		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
 			tooltip += "\n" + QString::number(itemInfo.max_visible_posts) + " messages available" ;
 		// if(itemInfo.max_visible_posts)  // wtf? this=0 when there are some posts definitely exist - lastpost is recent
-		    tooltip += "\n" + tr("Last Post") + ": "  + DateTime::formatLongDateTime(itemInfo.lastpost) ;
+		if(itemInfo.lastpost == QDateTime::fromTime_t(0))
+		    tooltip += "\n" + tr("Last Post") + ": "  + tr("Never") ;
+		else
+			tooltip += "\n" + tr("Last Post") + ": "  + DateTime::formatLongDateTime(itemInfo.lastpost) ;
 		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
 			tooltip += "\n" + tr("Subscribe to download and read messages") ;
 

--- a/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
@@ -36,7 +36,6 @@
 #include "gui/common/ElidedLabel.h"
 #include "gui/settings/rsharesettings.h"
 #include "util/QtVersion.h"
-#include "util/DateTime.h"
 
 #include <stdint.h>
 
@@ -478,11 +477,10 @@ void GroupTreeWidget::fillGroupItems(QTreeWidgetItem *categoryItem, const QList<
 			tooltip += "\n" + tr("You have been granted as publisher (you can post here!)");
 
 		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
+		{
 			tooltip += "\n" + QString::number(itemInfo.max_visible_posts) + " messages available" ;
-        // if(itemInfo.max_visible_posts)  // wtf? this=0 when there are some posts definitely exist - lastpost is recent
-		    tooltip += "\n" + tr("Last Post") + ": "  + DateTime::formatLongDateTime(itemInfo.lastpost) ;
-		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
 			tooltip += "\n" + tr("Subscribe to download and read messages") ;
+		}
 
 		item->setToolTip(COLUMN_NAME, tooltip);
 		item->setToolTip(COLUMN_UNREAD, tooltip);

--- a/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
@@ -36,6 +36,7 @@
 #include "gui/common/ElidedLabel.h"
 #include "gui/settings/rsharesettings.h"
 #include "util/QtVersion.h"
+#include "util/DateTime.h"
 
 #include <stdint.h>
 
@@ -477,10 +478,11 @@ void GroupTreeWidget::fillGroupItems(QTreeWidgetItem *categoryItem, const QList<
 			tooltip += "\n" + tr("You have been granted as publisher (you can post here!)");
 
 		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
-		{
 			tooltip += "\n" + QString::number(itemInfo.max_visible_posts) + " messages available" ;
+        // if(itemInfo.max_visible_posts)  // wtf? this=0 when there are some posts definitely exist - lastpost is recent
+		    tooltip += "\n" + tr("Last Post") + ": "  + DateTime::formatLongDateTime(itemInfo.lastpost) ;
+		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
 			tooltip += "\n" + tr("Subscribe to download and read messages") ;
-		}
 
 		item->setToolTip(COLUMN_NAME, tooltip);
 		item->setToolTip(COLUMN_UNREAD, tooltip);

--- a/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
@@ -36,6 +36,7 @@
 #include "gui/common/ElidedLabel.h"
 #include "gui/settings/rsharesettings.h"
 #include "util/QtVersion.h"
+#include "util/DateTime.h"
 
 #include <stdint.h>
 
@@ -477,10 +478,11 @@ void GroupTreeWidget::fillGroupItems(QTreeWidgetItem *categoryItem, const QList<
 			tooltip += "\n" + tr("You have been granted as publisher (you can post here!)");
 
 		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
-		{
 			tooltip += "\n" + QString::number(itemInfo.max_visible_posts) + " messages available" ;
+		// if(itemInfo.max_visible_posts)  // wtf? this=0 when there are some posts definitely exist - lastpost is recent
+		    tooltip += "\n" + tr("Last Post") + ": "  + DateTime::formatLongDateTime(itemInfo.lastpost) ;
+		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
 			tooltip += "\n" + tr("Subscribe to download and read messages") ;
-		}
 
 		item->setToolTip(COLUMN_NAME, tooltip);
 		item->setToolTip(COLUMN_UNREAD, tooltip);

--- a/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
@@ -416,7 +416,10 @@ void GxsGroupDialog::updateFromExistingMeta(const QString &description)
     ui.nameline->setText(QString::fromUtf8(mGrpMeta.mGroupName.c_str()));
     ui.popline->setText(QString::number( mGrpMeta.mPop)) ;
     ui.postsline->setText(QString::number(mGrpMeta.mVisibleMsgCount));
-    ui.lastpostline->setText(DateTime::formatLongDateTime(mGrpMeta.mLastPost));
+    if(mGrpMeta.mLastPost==0)
+        ui.lastpostline->setText(tr("Never"));
+    else
+        ui.lastpostline->setText(DateTime::formatLongDateTime(mGrpMeta.mLastPost));
     ui.authorLabel->setId(mGrpMeta.mAuthorId);
     ui.IDline->setText(QString::fromStdString(mGrpMeta.mGroupId.toStdString()));
     ui.descriptiontextEdit->setPlainText(description);

--- a/retroshare-gui/src/gui/gxs/GxsIdDetails.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsIdDetails.cpp
@@ -991,9 +991,12 @@ QString nickname ;
 	else
         comment += QString("<br/>%1:&nbsp;%2").arg(QApplication::translate("GxsIdDetails", "Authentication"), QApplication::translate("GxsIdDetails", "anonymous"));
 	
-	if(details.mReputation.mFriendsPositiveVotes > 0) comment += "<br/><b>+" + QString::number(details.mReputation.mFriendsPositiveVotes) + "</b>";
-    if(details.mReputation.mFriendsNegativeVotes > 0) comment += "<br/><b>-" + QString::number(details.mReputation.mFriendsNegativeVotes) + "</b>";
-    
+	if(details.mReputation.mFriendsPositiveVotes || details.mReputation.mFriendsNegativeVotes)
+	{
+		comment += "<br/>Votes:";
+		if(details.mReputation.mFriendsPositiveVotes > 0) comment += " <b>+" + QString::number(details.mReputation.mFriendsPositiveVotes) + "</b>";
+		if(details.mReputation.mFriendsNegativeVotes > 0) comment += " <b>-" + QString::number(details.mReputation.mFriendsNegativeVotes) + "</b>";
+    }
 	return comment;
 }
 

--- a/retroshare-gui/src/gui/gxs/GxsIdDetails.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsIdDetails.cpp
@@ -990,7 +990,10 @@ QString nickname ;
 	}
 	else
         comment += QString("<br/>%1:&nbsp;%2").arg(QApplication::translate("GxsIdDetails", "Authentication"), QApplication::translate("GxsIdDetails", "anonymous"));
-
+	
+	if(details.mReputation.mFriendsPositiveVotes > 0) comment += "<br/><b>+" + QString::number(details.mReputation.mFriendsPositiveVotes) + "</b>";
+    if(details.mReputation.mFriendsNegativeVotes > 0) comment += "<br/><b>-" + QString::number(details.mReputation.mFriendsNegativeVotes) + "</b>";
+    
 	return comment;
 }
 

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.cpp
@@ -266,12 +266,12 @@ void GxsChannelPostsWidget::insertChannelDetails(const RsGxsChannelGroup &group)
 		ui->infoPosts->clear();
 		ui->infoDescription->clear();
 	} else {
-		ui->infoPosts->setText(QString::number(group.mMeta.mVisibleMsgCount));
-		
-		ui->infoLastPost->setText(DateTime::formatLongDateTime(group.mMeta.mLastPost));
-		
-		
-		ui->infoDescription->setText(QString::fromUtf8(group.mDescription.c_str()));
+        ui->infoPosts->setText(QString::number(group.mMeta.mVisibleMsgCount));
+		if(group.mMeta.mLastPost==0)
+            ui->infoLastPost->setText(tr("Never"));
+        else
+            ui->infoLastPost->setText(DateTime::formatLongDateTime(group.mMeta.mLastPost));
+        ui->infoDescription->setText(QString::fromUtf8(group.mDescription.c_str()));
         
         	ui->infoAdministrator->setId(group.mMeta.mAuthorId) ;
         

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.cpp
@@ -33,6 +33,7 @@
 #include "gui/feeds/SubFileItem.h"
 #include "gui/notifyqt.h"
 #include <algorithm>
+#include "util/DateTime.h"
 
 #define CHAN_DEFAULT_IMAGE ":/images/channels.png"
 
@@ -266,6 +267,10 @@ void GxsChannelPostsWidget::insertChannelDetails(const RsGxsChannelGroup &group)
 		ui->infoDescription->clear();
 	} else {
 		ui->infoPosts->setText(QString::number(group.mMeta.mVisibleMsgCount));
+		
+		ui->infoLastPost->setText(DateTime::formatLongDateTime(group.mMeta.mLastPost));
+		
+		
 		ui->infoDescription->setText(QString::fromUtf8(group.mDescription.c_str()));
         
         	ui->infoAdministrator->setId(group.mMeta.mAuthorId) ;

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.cpp
@@ -33,7 +33,6 @@
 #include "gui/feeds/SubFileItem.h"
 #include "gui/notifyqt.h"
 #include <algorithm>
-#include "util/DateTime.h"
 
 #define CHAN_DEFAULT_IMAGE ":/images/channels.png"
 
@@ -267,10 +266,6 @@ void GxsChannelPostsWidget::insertChannelDetails(const RsGxsChannelGroup &group)
 		ui->infoDescription->clear();
 	} else {
 		ui->infoPosts->setText(QString::number(group.mMeta.mVisibleMsgCount));
-		
-		ui->infoLastPost->setText(DateTime::formatLongDateTime(group.mMeta.mLastPost));
-		
-		
 		ui->infoDescription->setText(QString::fromUtf8(group.mDescription.c_str()));
         
         	ui->infoAdministrator->setId(group.mMeta.mAuthorId) ;

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.ui
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.ui
@@ -397,7 +397,7 @@
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="0" column="0">
           <layout class="QGridLayout" name="gridLayout">
-           <item row="1" column="0">
+           <item row="2" column="0">
             <widget class="QLabel" name="label">
              <property name="font">
               <font>
@@ -429,7 +429,26 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0" colspan="2">
+           <item row="1" column="0">
+            <widget class="QLabel" name="infoLastPostLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Last Post:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" colspan="2">
             <widget class="QTextBrowser" name="infoDescription">
              <property name="html">
               <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -446,7 +465,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="4" column="0">
             <widget class="QLabel" name="infoDescriptionLabel">
              <property name="font">
               <font>
@@ -459,7 +478,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="2" column="1">
             <widget class="GxsIdLabel" name="infoAdministrator">
              <property name="text">
               <string>unknown</string>
@@ -473,7 +492,14 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="1" column="1">
+            <widget class="QLabel" name="infoLastPost">
+             <property name="text">
+              <string notr="true">unknown</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
             <widget class="QLabel" name="label_3">
              <property name="font">
               <font>
@@ -486,7 +512,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="3" column="1">
             <widget class="QLabel" name="infoDistribution">
              <property name="text">
               <string>unknown</string>

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.ui
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.ui
@@ -14,16 +14,7 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -35,16 +26,7 @@
       <enum>QFrame::Sunken</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>4</number>
       </property>
       <item>
@@ -307,16 +289,7 @@
       <string notr="true"/>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="leftMargin">
-       <number>3</number>
-      </property>
-      <property name="topMargin">
-       <number>3</number>
-      </property>
-      <property name="rightMargin">
-       <number>3</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>3</number>
       </property>
       <item>
@@ -397,7 +370,7 @@
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="0" column="0">
           <layout class="QGridLayout" name="gridLayout">
-           <item row="1" column="0">
+           <item row="2" column="0">
             <widget class="QLabel" name="label">
              <property name="font">
               <font>
@@ -429,14 +402,33 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0" colspan="2">
+           <item row="1" column="0">
+            <widget class="QLabel" name="infoLastPostLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Last Post:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" colspan="2">
             <widget class="QTextBrowser" name="infoDescription">
              <property name="html">
               <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="textInteractionFlags">
               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -446,7 +438,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="4" column="0">
             <widget class="QLabel" name="infoDescriptionLabel">
              <property name="font">
               <font>
@@ -459,7 +451,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="2" column="1">
             <widget class="GxsIdLabel" name="infoAdministrator">
              <property name="text">
               <string>unknown</string>
@@ -473,7 +465,14 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="1" column="1">
+            <widget class="QLabel" name="infoLastPost">
+             <property name="text">
+              <string notr="true">unknown</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
             <widget class="QLabel" name="label_3">
              <property name="font">
               <font>
@@ -486,7 +485,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="3" column="1">
             <widget class="QLabel" name="infoDistribution">
              <property name="text">
               <string>unknown</string>

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.ui
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidget.ui
@@ -14,7 +14,16 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -26,7 +35,16 @@
       <enum>QFrame::Sunken</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
        <number>4</number>
       </property>
       <item>
@@ -289,7 +307,16 @@
       <string notr="true"/>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>3</number>
+      </property>
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
        <number>3</number>
       </property>
       <item>
@@ -370,7 +397,7 @@
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="0" column="0">
           <layout class="QGridLayout" name="gridLayout">
-           <item row="2" column="0">
+           <item row="1" column="0">
             <widget class="QLabel" name="label">
              <property name="font">
               <font>
@@ -402,33 +429,14 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="infoLastPostLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Last Post:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0" colspan="2">
+           <item row="4" column="0" colspan="2">
             <widget class="QTextBrowser" name="infoDescription">
              <property name="html">
               <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="textInteractionFlags">
               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -438,7 +446,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="3" column="0">
             <widget class="QLabel" name="infoDescriptionLabel">
              <property name="font">
               <font>
@@ -451,7 +459,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="1" column="1">
             <widget class="GxsIdLabel" name="infoAdministrator">
              <property name="text">
               <string>unknown</string>
@@ -465,14 +473,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
-            <widget class="QLabel" name="infoLastPost">
-             <property name="text">
-              <string notr="true">unknown</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
+           <item row="2" column="0">
             <widget class="QLabel" name="label_3">
              <property name="font">
               <font>
@@ -485,7 +486,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
+           <item row="2" column="1">
             <widget class="QLabel" name="infoDistribution">
              <property name="text">
               <string>unknown</string>

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -879,7 +879,6 @@ static QString getDurationString(uint32_t days)
     tw->mForumDescription = QString("<b>%1: \t</b>%2<br/>").arg(tr("Forum name"), QString::fromUtf8( group.mMeta.mGroupName.c_str()));
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Subscribers")).arg(group.mMeta.mPop);
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Posts (at neighbor nodes)")).arg(group.mMeta.mVisibleMsgCount);
-    tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post")).arg(DateTime::formatLongDateTime(group.mMeta.mLastPost));
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Synchronization")).arg(getDurationString( rsGxsForums->getSyncPeriod(group.mMeta.mGroupId)/86400 )) ;
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Storage")).arg(getDurationString( rsGxsForums->getStoragePeriod(group.mMeta.mGroupId)/86400));
 

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -879,6 +879,7 @@ static QString getDurationString(uint32_t days)
     tw->mForumDescription = QString("<b>%1: \t</b>%2<br/>").arg(tr("Forum name"), QString::fromUtf8( group.mMeta.mGroupName.c_str()));
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Subscribers")).arg(group.mMeta.mPop);
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Posts (at neighbor nodes)")).arg(group.mMeta.mVisibleMsgCount);
+    tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post")).arg(DateTime::formatLongDateTime(group.mMeta.mLastPost));
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Synchronization")).arg(getDurationString( rsGxsForums->getSyncPeriod(group.mMeta.mGroupId)/86400 )) ;
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Storage")).arg(getDurationString( rsGxsForums->getStoragePeriod(group.mMeta.mGroupId)/86400));
 

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -879,7 +879,10 @@ static QString getDurationString(uint32_t days)
     tw->mForumDescription = QString("<b>%1: \t</b>%2<br/>").arg(tr("Forum name"), QString::fromUtf8( group.mMeta.mGroupName.c_str()));
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Subscribers")).arg(group.mMeta.mPop);
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Posts (at neighbor nodes)")).arg(group.mMeta.mVisibleMsgCount);
-    tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post")).arg(DateTime::formatLongDateTime(group.mMeta.mLastPost));
+	if(group.mMeta.mLastPost==0)
+        tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post")).arg(tr("Never"));
+    else
+        tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post")).arg(DateTime::formatLongDateTime(group.mMeta.mLastPost));
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Synchronization")).arg(getDurationString( rsGxsForums->getSyncPeriod(group.mMeta.mGroupId)/86400 )) ;
     tw->mForumDescription += QString("<b>%1: \t</b>%2<br/>").arg(tr("Storage")).arg(getDurationString( rsGxsForums->getStoragePeriod(group.mMeta.mGroupId)/86400));
 

--- a/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
+++ b/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
@@ -124,9 +124,6 @@ void StatisticsWindow::initStackedPage()
   QActionGroup *grp = new QActionGroup(this);
   QAction *action;
   
-  ui->stackPages->add(dhtw = new DhtWindow(ui->stackPages),
-                   action = createPageAction(QIcon(IMAGE_DHT), tr("DHT"), grp));
-
   ui->stackPages->add(bwdlg = new BwCtrlWindow(ui->stackPages),
                    action = createPageAction(QIcon(IMAGE_BANDWIDTH), tr("Bandwidth"), grp));
                    
@@ -139,6 +136,9 @@ void StatisticsWindow::initStackedPage()
   ui->stackPages->add(rttdlg = new RttStatistics(ui->stackPages),
                       action = createPageAction(QIcon(IMAGE_RTT), tr("RTT Statistics"), grp));
                    
+  ui->stackPages->add(dhtw = new DhtWindow(ui->stackPages),
+                   action = createPageAction(QIcon(IMAGE_DHT), tr("DHT"), grp));
+
    /*std::cerr << "Looking for interfaces in existing plugins:" << std::endl;
 	 for(int i = 0;i<rsPlugins->nbPlugins();++i)
 	 {


### PR DESCRIPTION
small gui tweaks:
 chatlobby id contextmenu fix icon on ban option, add vote up option;
 chatlobbies - id tooltip - add votes counter;
 statistics dht page moved from first place - it freezes whole client