### PR TITLE
fixing compilation with openssl-1.1.0 (part 1)

### DIFF
--- a/libretroshare/src/crypto/chacha20.cpp
+++ b/libretroshare/src/crypto/chacha20.cpp
@@ -548,7 +548,7 @@ bool AEAD_chacha20_sha256(uint8_t key[32], uint8_t nonce[12],uint8_t *data,uint3
 #else
        HMAC_CTX *hmac_ctx = HMAC_CTX_new();
 
-       HMAC_Init_ex(hmac_ctx,key,32,EVP_sha256()) ;
+       HMAC_Init_ex(hmac_ctx,key,32,EVP_sha256(),NULL) ;
        HMAC_Update(hmac_ctx,aad,aad_size) ;
        HMAC_Update(hmac_ctx,data,data_size) ;
        HMAC_Final(hmac_ctx,computed_tag,&md_size) ;
@@ -579,7 +579,7 @@ bool AEAD_chacha20_sha256(uint8_t key[32], uint8_t nonce[12],uint8_t *data,uint3
 #else
        HMAC_CTX *hmac_ctx = HMAC_CTX_new();
 
-       HMAC_Init_ex(hmac_ctx,key,32,EVP_sha256()) ;
+       HMAC_Init_ex(hmac_ctx,key,32,EVP_sha256(),NULL) ;
        HMAC_Update(hmac_ctx,aad,aad_size) ;
        HMAC_Update(hmac_ctx,data,data_size) ;
        HMAC_Final(hmac_ctx,computed_tag,&md_size) ;

--- a/libretroshare/src/crypto/chacha20.cpp
+++ b/libretroshare/src/crypto/chacha20.cpp
@@ -537,6 +537,7 @@ bool AEAD_chacha20_sha256(uint8_t key[32], uint8_t nonce[12],uint8_t *data,uint3
        uint8_t computed_tag[EVP_MAX_MD_SIZE];
        unsigned int md_size ;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
        HMAC_CTX hmac_ctx ;
        HMAC_CTX_init(&hmac_ctx) ;
 
@@ -544,6 +545,17 @@ bool AEAD_chacha20_sha256(uint8_t key[32], uint8_t nonce[12],uint8_t *data,uint3
        HMAC_Update(&hmac_ctx,aad,aad_size) ;
        HMAC_Update(&hmac_ctx,data,data_size) ;
        HMAC_Final(&hmac_ctx,computed_tag,&md_size) ;
+#else
+       HMAC_CTX *hmac_ctx = HMAC_CTX_new();
+
+       HMAC_Init_ex(hmac_ctx,key,32,EVP_sha256()) ;
+       HMAC_Update(hmac_ctx,aad,aad_size) ;
+       HMAC_Update(hmac_ctx,data,data_size) ;
+       HMAC_Final(hmac_ctx,computed_tag,&md_size) ;
+
+       HMAC_CTX_free(hmac_ctx) ;
+       hmac_ctx=NULL;
+#endif
 
        assert(md_size >= 16);
 
@@ -556,6 +568,7 @@ bool AEAD_chacha20_sha256(uint8_t key[32], uint8_t nonce[12],uint8_t *data,uint3
        uint8_t computed_tag[EVP_MAX_MD_SIZE];
        unsigned int md_size ;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
        HMAC_CTX hmac_ctx ;
        HMAC_CTX_init(&hmac_ctx) ;
 
@@ -563,6 +576,14 @@ bool AEAD_chacha20_sha256(uint8_t key[32], uint8_t nonce[12],uint8_t *data,uint3
        HMAC_Update(&hmac_ctx,aad,aad_size) ;
        HMAC_Update(&hmac_ctx,data,data_size) ;
        HMAC_Final(&hmac_ctx,computed_tag,&md_size) ;
+#else
+       HMAC_CTX *hmac_ctx = HMAC_CTX_new();
+
+       HMAC_Init_ex(hmac_ctx,key,32,EVP_sha256()) ;
+       HMAC_Update(hmac_ctx,aad,aad_size) ;
+       HMAC_Update(hmac_ctx,data,data_size) ;
+       HMAC_Final(hmac_ctx,computed_tag,&md_size) ;
+#endif
 
        // decrypt
 

--- a/libretroshare/src/crypto/chacha20.cpp
+++ b/libretroshare/src/crypto/chacha20.cpp
@@ -583,6 +583,9 @@ bool AEAD_chacha20_sha256(uint8_t key[32], uint8_t nonce[12],uint8_t *data,uint3
        HMAC_Update(hmac_ctx,aad,aad_size) ;
        HMAC_Update(hmac_ctx,data,data_size) ;
        HMAC_Final(hmac_ctx,computed_tag,&md_size) ;
+
+       HMAC_CTX_free(hmac_ctx) ;
+       hmac_ctx=NULL;
 #endif
 
        // decrypt

--- a/libretroshare/src/gxs/gxssecurity.cc
+++ b/libretroshare/src/gxs/gxssecurity.cc
@@ -973,7 +973,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 			    succeed = EVP_OpenInit(ctx, EVP_aes_128_cbc(),in + encrypted_keys_offset + i*MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE , MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE, in+IV_offset, privateKey);
 
 			if(!succeed)
-					EVP_CIPHER_CTX_free(ctx);
+					EVP_CIPHER_CTX_reset(ctx);
                             
 #ifdef GXS_SECURITY_DEBUG
 			    std::cerr << "    encrypted key at offset " << encrypted_keys_offset + i*MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE << ": " << succeed << std::endl;

--- a/libretroshare/src/gxs/gxssecurity.cc
+++ b/libretroshare/src/gxs/gxssecurity.cc
@@ -973,7 +973,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 			    succeed = EVP_OpenInit(ctx, EVP_aes_128_cbc(),in + encrypted_keys_offset + i*MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE , MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE, in+IV_offset, privateKey);
 
 			if(!succeed)
-					EVP_CIPHER_CTX_reset(ctx);
+					EVP_CIPHER_CTX_cleanup(ctx);
                             
 #ifdef GXS_SECURITY_DEBUG
 			    std::cerr << "    encrypted key at offset " << encrypted_keys_offset + i*MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE << ": " << succeed << std::endl;

--- a/libretroshare/src/gxs/gxssecurity.cc
+++ b/libretroshare/src/gxs/gxssecurity.cc
@@ -41,20 +41,31 @@ static const uint32_t MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE  = 256 ;
         
 static RsGxsId getRsaKeyFingerprint_old_insecure_method(RSA *pubkey)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         int lenn = BN_num_bytes(pubkey -> n);
 
         RsTemporaryMemory tmp(lenn) ;
         BN_bn2bin(pubkey -> n, tmp);
+#else
+        const BIGNUM *nn=NULL,*ee=NULL ;
+        RSA_get0_key(pubkey,&nn,&ee,NULL) ;
+
+        int lenn = BN_num_bytes(nn);
+
+        RsTemporaryMemory tmp(lenn) ;
+        BN_bn2bin(nn, tmp);
+#endif
 
         // Copy first CERTSIGNLEN bytes from the hash of the public modulus and exponent
-	// We should not be using strings here, but a real ID. To be done later.
+		// We should not be using strings here, but a real ID. To be done later.
 
-	assert(lenn >= CERTSIGNLEN) ;
+		assert(lenn >= CERTSIGNLEN) ;
 
-        return RsGxsId((unsigned char*)tmp) ;
+		return RsGxsId((unsigned char*)tmp) ;
 }
 static RsGxsId getRsaKeyFingerprint(RSA *pubkey)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         int lenn = BN_num_bytes(pubkey -> n);
         int lene = BN_num_bytes(pubkey -> e);
 
@@ -62,6 +73,18 @@ static RsGxsId getRsaKeyFingerprint(RSA *pubkey)
 
         BN_bn2bin(pubkey -> n, tmp);
         BN_bn2bin(pubkey -> e, &tmp[lenn]);
+#else
+        const BIGNUM *nn=NULL,*ee=NULL ;
+        RSA_get0_key(pubkey,&nn,&ee,NULL) ;
+
+        int lenn = BN_num_bytes(nn);
+        int lene = BN_num_bytes(ee);
+
+        RsTemporaryMemory tmp(lenn+lene) ;
+
+        BN_bn2bin(nn, tmp);
+        BN_bn2bin(ee, &tmp[lenn]);
+#endif
 
 	Sha1CheckSum s = RsDirUtil::sha1sum(tmp,lenn+lene) ;
 
@@ -530,11 +553,10 @@ bool GxsSecurity::encrypt(uint8_t *& out, uint32_t &outlen, const uint8_t *in, u
 		return false;
 	}
 
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 	int eklen, net_ekl;
 	unsigned char *ek;
 	unsigned char iv[EVP_MAX_IV_LENGTH];
-	EVP_CIPHER_CTX_init(&ctx);
 	int out_currOffset = 0;
 	int out_offset = 0;
 
@@ -551,7 +573,7 @@ bool GxsSecurity::encrypt(uint8_t *& out, uint32_t &outlen, const uint8_t *in, u
 	int max_outlen = inlen + cipher_block_size + EVP_MAX_IV_LENGTH + max_evp_key_size + size_net_ekl;
 
 	// intialize context and send store encrypted cipher in ek
-	if(!EVP_SealInit(&ctx, EVP_aes_128_cbc(), &ek, &eklen, iv, &public_key, 1)) return false;
+	if(!EVP_SealInit(ctx, EVP_aes_128_cbc(), &ek, &eklen, iv, &public_key, 1)) return false;
 
 	// now assign memory to out accounting for data, and cipher block size, key length, and key length val
 	out = (uint8_t*)rs_malloc(inlen + cipher_block_size + size_net_ekl + eklen + EVP_MAX_IV_LENGTH) ;
@@ -570,7 +592,7 @@ bool GxsSecurity::encrypt(uint8_t *& out, uint32_t &outlen, const uint8_t *in, u
 	out_offset += EVP_MAX_IV_LENGTH;
 
 	// now encrypt actual data
-	if(!EVP_SealUpdate(&ctx, (unsigned char*) out + out_offset, &out_currOffset, (unsigned char*) in, inlen)) 
+	if(!EVP_SealUpdate(ctx, (unsigned char*) out + out_offset, &out_currOffset, (unsigned char*) in, inlen))
 	{
 		free(out) ;
 		out = NULL ;
@@ -581,7 +603,7 @@ bool GxsSecurity::encrypt(uint8_t *& out, uint32_t &outlen, const uint8_t *in, u
 	out_offset += out_currOffset;
 
 	// add padding
-	if(!EVP_SealFinal(&ctx, (unsigned char*) out + out_offset, &out_currOffset)) 
+	if(!EVP_SealFinal(ctx, (unsigned char*) out + out_offset, &out_currOffset))
 	{
 		free(out) ;
 		out = NULL ;
@@ -602,7 +624,7 @@ bool GxsSecurity::encrypt(uint8_t *& out, uint32_t &outlen, const uint8_t *in, u
 	// free encrypted key data
 	free(ek);
 
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_free(ctx);
     
 	outlen = out_offset;
 	return true;
@@ -613,152 +635,151 @@ bool GxsSecurity::encrypt(uint8_t *& out, uint32_t &outlen, const uint8_t *in, u
 #ifdef DISTRIB_DEBUG
 	std::cerr << "GxsSecurity::encrypt() " << std::endl;
 #endif
-        // Encrypts (in,inlen) into (out,outlen) using the given RSA public key.
-        // The format of the encrypted data is:
-        //
-        //   [--- ID ---|--- number of encrypted keys---|  n * (--- Encrypted session keys ---)    |---      IV     ---|---- Encrypted data ---]
-    	//      2 bytes              2 byte = n                            256 bytes                  EVP_MAX_IV_LENGTH       Rest of packet
-        //
+	// Encrypts (in,inlen) into (out,outlen) using the given RSA public key.
+	// The format of the encrypted data is:
+	//
+	//   [--- ID ---|--- number of encrypted keys---|  n * (--- Encrypted session keys ---)    |---      IV     ---|---- Encrypted data ---]
+	//      2 bytes              2 byte = n                            256 bytes                  EVP_MAX_IV_LENGTH       Rest of packet
+	//
 
-    out = NULL ;
-    EVP_CIPHER_CTX ctx;
-    EVP_CIPHER_CTX_init(&ctx);
-    std::vector<EVP_PKEY *> public_keys(keys.size(),NULL);
-    
-    try
-    {
-        for(uint32_t i=0;i<keys.size();++i)
-	{
-		RSA *tmpkey = ::extractPublicKey(keys[i]) ;
-		RSA *rsa_publish_pub = RSAPublicKey_dup(tmpkey) ;
-		RSA_free(tmpkey) ;
-
-		if(rsa_publish_pub  != NULL)
-		{
-			public_keys[i] = EVP_PKEY_new();
-			EVP_PKEY_assign_RSA(public_keys[i], rsa_publish_pub);
-		}
-		else
-		{
-			std::cerr << "GxsSecurity(): Could not generate public key for key id " << keys[i].keyId << std::endl;
-			throw std::runtime_error("Cannot extract public key") ;
-		}
-	}
-
-	unsigned char iv[EVP_MAX_IV_LENGTH];
-
-    	std::vector<unsigned char *> ek(keys.size(),NULL) ;
-        std::vector<int> eklen(keys.size(),0) ;
-        
-        for(uint32_t i=0;i<keys.size();++i)
-        {
-		int max_evp_key_size = EVP_PKEY_size(public_keys[i]);
-            
-            	if(max_evp_key_size != MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE)
-			throw std::runtime_error("EVP_PKEY_size should be equal to 256. It's not!") ;
-                
-		ek[i] = (unsigned char*)rs_malloc(max_evp_key_size);
-    		if(ek[i] == NULL)
-			throw std::runtime_error("malloc error on encrypted keys") ;
-        }
-        
-	const EVP_CIPHER *cipher = EVP_aes_128_cbc();
-	int cipher_block_size = EVP_CIPHER_block_size(cipher);
-
-	// intialize context and send store encrypted cipher in ek
-	if(!EVP_SealInit(&ctx, EVP_aes_128_cbc(), ek.data(), eklen.data(), iv, public_keys.data(), keys.size())) 
-       		 return false;
-
-    	// now we can release the encryption keys
-    	for(uint32_t i=0;i<public_keys.size();++i)
-            EVP_PKEY_free(public_keys[i]) ;
-        public_keys.clear() ;
-    
-    	int total_ek_size = MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE * keys.size() ;
-        
-	int max_outlen = MULTI_ENCRYPTION_FORMAT_v001_HEADER_SIZE + MULTI_ENCRYPTION_FORMAT_v001_NUMBER_OF_KEYS_SIZE + total_ek_size + EVP_MAX_IV_LENGTH + (inlen + cipher_block_size) ;
-    
-	// now assign memory to out accounting for data, and cipher block size, key length, and key length val
-	out = (uint8_t*)rs_malloc(max_outlen);
-
-	if(out == NULL)
-		return false ;
-
-	int out_offset = 0;
-    
-    	// header
-    
-    	out[out_offset++] =  MULTI_ENCRYPTION_FORMAT_v001_HEADER       & 0xff ;
-    	out[out_offset++] = (MULTI_ENCRYPTION_FORMAT_v001_HEADER >> 8) & 0xff ;
-        
-        // number of keys
-        
-        out[out_offset++] =   keys.size()       & 0xff ;
-        out[out_offset++] =  (keys.size() >> 8) & 0xff ;
-                
-        // encrypted keys, each preceeded with its length
-        
-        for(uint32_t i=0;i<keys.size();++i)
-        {
-            if(eklen[i] != MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE)
-            {
-                std::cerr << "(EE) eklen[i]=" << eklen[i] << " in " << __PRETTY_FUNCTION__ << " for key id " << keys[i].keyId << ". This is unexpected. Cannot encrypt." << std::endl;
-                throw std::runtime_error("Encryption error") ;
-            }
-            
-            memcpy((unsigned char*)out + out_offset, ek[i],eklen[i]) ;
-            out_offset += eklen[i] ;
-        }
-        
-	memcpy((unsigned char*)out + out_offset, iv, EVP_MAX_IV_LENGTH);
-	out_offset += EVP_MAX_IV_LENGTH;
-
-	int out_currOffset = 0;
-    
-	// now encrypt actual data
-	if(!EVP_SealUpdate(&ctx, (unsigned char*) out + out_offset, &out_currOffset, (unsigned char*) in, inlen)) 
-	    throw std::runtime_error("Encryption error in SealUpdate()") ;
-
-	// move along to partial block space
-	out_offset += out_currOffset;
-
-	// add padding
-	if(!EVP_SealFinal(&ctx, (unsigned char*) out + out_offset, &out_currOffset)) 
-	    throw std::runtime_error("Encryption error in SealFinal()") ;
-
-	// move to end
-	out_offset += out_currOffset;
-
-	// make sure offset has not gone passed valid memory bounds
-    
-	if(out_offset > max_outlen) 
-	    throw std::runtime_error("Memory used by encryption exceeds allocated memory block") ;
-
-	// free encrypted key data
-    
-    	for(uint32_t i=0;i<keys.size();++i)
-	    if(ek[i]) free(ek[i]);
-
-	outlen = out_offset;
-    
-	EVP_CIPHER_CTX_cleanup(&ctx);
-	return true;
-    }
-    catch(std::exception& e)
-    {
-        std::cerr << "(EE) Exception caught while encrypting: " << e.what() << std::endl;
-        
-	EVP_CIPHER_CTX_cleanup(&ctx);
-    
-	if(out) free(out) ;
 	out = NULL ;
-        
-    	for(uint32_t i=0;i<public_keys.size();++i)
-            EVP_PKEY_free(public_keys[i]) ;
-        public_keys.clear() ;
-        
-        return false ;
-    }
+	EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+	std::vector<EVP_PKEY *> public_keys(keys.size(),NULL);
+
+	try
+	{
+		for(uint32_t i=0;i<keys.size();++i)
+		{
+			RSA *tmpkey = ::extractPublicKey(keys[i]) ;
+			RSA *rsa_publish_pub = RSAPublicKey_dup(tmpkey) ;
+			RSA_free(tmpkey) ;
+
+			if(rsa_publish_pub  != NULL)
+			{
+				public_keys[i] = EVP_PKEY_new();
+				EVP_PKEY_assign_RSA(public_keys[i], rsa_publish_pub);
+			}
+			else
+			{
+				std::cerr << "GxsSecurity(): Could not generate public key for key id " << keys[i].keyId << std::endl;
+				throw std::runtime_error("Cannot extract public key") ;
+			}
+		}
+
+		unsigned char iv[EVP_MAX_IV_LENGTH];
+
+		std::vector<unsigned char *> ek(keys.size(),NULL) ;
+		std::vector<int> eklen(keys.size(),0) ;
+
+		for(uint32_t i=0;i<keys.size();++i)
+		{
+			int max_evp_key_size = EVP_PKEY_size(public_keys[i]);
+
+			if(max_evp_key_size != MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE)
+				throw std::runtime_error("EVP_PKEY_size should be equal to 256. It's not!") ;
+
+			ek[i] = (unsigned char*)rs_malloc(max_evp_key_size);
+			if(ek[i] == NULL)
+				throw std::runtime_error("malloc error on encrypted keys") ;
+		}
+
+		const EVP_CIPHER *cipher = EVP_aes_128_cbc();
+		int cipher_block_size = EVP_CIPHER_block_size(cipher);
+
+		// intialize context and send store encrypted cipher in ek
+		if(!EVP_SealInit(ctx, EVP_aes_128_cbc(), ek.data(), eklen.data(), iv, public_keys.data(), keys.size()))
+			return false;
+
+		// now we can release the encryption keys
+		for(uint32_t i=0;i<public_keys.size();++i)
+			EVP_PKEY_free(public_keys[i]) ;
+		public_keys.clear() ;
+
+		int total_ek_size = MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE * keys.size() ;
+
+		int max_outlen = MULTI_ENCRYPTION_FORMAT_v001_HEADER_SIZE + MULTI_ENCRYPTION_FORMAT_v001_NUMBER_OF_KEYS_SIZE + total_ek_size + EVP_MAX_IV_LENGTH + (inlen + cipher_block_size) ;
+
+		// now assign memory to out accounting for data, and cipher block size, key length, and key length val
+		out = (uint8_t*)rs_malloc(max_outlen);
+
+		if(out == NULL)
+			return false ;
+
+		int out_offset = 0;
+
+		// header
+
+		out[out_offset++] =  MULTI_ENCRYPTION_FORMAT_v001_HEADER       & 0xff ;
+		out[out_offset++] = (MULTI_ENCRYPTION_FORMAT_v001_HEADER >> 8) & 0xff ;
+
+		// number of keys
+
+		out[out_offset++] =   keys.size()       & 0xff ;
+		out[out_offset++] =  (keys.size() >> 8) & 0xff ;
+
+		// encrypted keys, each preceeded with its length
+
+		for(uint32_t i=0;i<keys.size();++i)
+		{
+			if(eklen[i] != MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE)
+			{
+				std::cerr << "(EE) eklen[i]=" << eklen[i] << " in " << __PRETTY_FUNCTION__ << " for key id " << keys[i].keyId << ". This is unexpected. Cannot encrypt." << std::endl;
+				throw std::runtime_error("Encryption error") ;
+			}
+
+			memcpy((unsigned char*)out + out_offset, ek[i],eklen[i]) ;
+			out_offset += eklen[i] ;
+		}
+
+		memcpy((unsigned char*)out + out_offset, iv, EVP_MAX_IV_LENGTH);
+		out_offset += EVP_MAX_IV_LENGTH;
+
+		int out_currOffset = 0;
+
+		// now encrypt actual data
+		if(!EVP_SealUpdate(ctx, (unsigned char*) out + out_offset, &out_currOffset, (unsigned char*) in, inlen))
+			throw std::runtime_error("Encryption error in SealUpdate()") ;
+
+		// move along to partial block space
+		out_offset += out_currOffset;
+
+		// add padding
+		if(!EVP_SealFinal(ctx, (unsigned char*) out + out_offset, &out_currOffset))
+			throw std::runtime_error("Encryption error in SealFinal()") ;
+
+		// move to end
+		out_offset += out_currOffset;
+
+		// make sure offset has not gone passed valid memory bounds
+
+		if(out_offset > max_outlen)
+			throw std::runtime_error("Memory used by encryption exceeds allocated memory block") ;
+
+		// free encrypted key data
+
+		for(uint32_t i=0;i<keys.size();++i)
+			if(ek[i]) free(ek[i]);
+
+		outlen = out_offset;
+
+		EVP_CIPHER_CTX_free(ctx);
+		return true;
+	}
+	catch(std::exception& e)
+	{
+		std::cerr << "(EE) Exception caught while encrypting: " << e.what() << std::endl;
+
+		EVP_CIPHER_CTX_free(ctx);
+
+		if(out) free(out) ;
+		out = NULL ;
+
+		for(uint32_t i=0;i<public_keys.size();++i)
+			EVP_PKEY_free(public_keys[i]) ;
+		public_keys.clear() ;
+
+		return false ;
+	}
 }
 
 bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, uint32_t inlen, const RsTlvPrivateRSAKey &key)
@@ -794,7 +815,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 	}
 
 
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     int eklen = 0, net_ekl = 0;
 	unsigned char *ek = (unsigned char*)rs_malloc(EVP_PKEY_size(privateKey));
     
@@ -802,7 +823,6 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
         return false ;
     
     unsigned char iv[EVP_MAX_IV_LENGTH];
-    EVP_CIPHER_CTX_init(&ctx);
 
     int in_offset = 0, out_currOffset = 0;
     int size_net_ekl = sizeof(net_ekl);
@@ -827,7 +847,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 
     const EVP_CIPHER* cipher = EVP_aes_128_cbc();
 
-    if(!EVP_OpenInit(&ctx, cipher, ek, eklen, iv, privateKey)) 
+    if(!EVP_OpenInit(ctx, cipher, ek, eklen, iv, privateKey))
     {
         std::cerr << "(EE) Cannot decrypt data. Most likely reason: private GXS key is missing." << std::endl;
         return false;
@@ -843,7 +863,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
     if(out == NULL)
          return false;
 
-    if(!EVP_OpenUpdate(&ctx, (unsigned char*) out, &out_currOffset, (unsigned char*)in + in_offset, inlen - in_offset)) 
+    if(!EVP_OpenUpdate(ctx, (unsigned char*) out, &out_currOffset, (unsigned char*)in + in_offset, inlen - in_offset))
 	 {
          free(out) ;
 		 out = NULL ;
@@ -852,7 +872,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 
     outlen = out_currOffset;
 
-    if(!EVP_OpenFinal(&ctx, (unsigned char*)out + out_currOffset, &out_currOffset)) 
+    if(!EVP_OpenFinal(ctx, (unsigned char*)out + out_currOffset, &out_currOffset))
 	 {
          free(out) ;
 		 out = NULL ;
@@ -862,7 +882,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
     outlen += out_currOffset;
     free(ek);
 
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_free(ctx);
 	 return true;
 }
 
@@ -879,8 +899,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 #ifdef DISTRIB_DEBUG
 	std::cerr << "GxsSecurity::decrypt() " << std::endl;
 #endif
-	EVP_CIPHER_CTX ctx;
-	    EVP_CIPHER_CTX_init(&ctx);
+	EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     
     try
     {
@@ -951,10 +970,10 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 
 		    for(uint32_t i=0;i<number_of_keys && !succeed;++i)
 		    {
-			    succeed = EVP_OpenInit(&ctx, EVP_aes_128_cbc(),in + encrypted_keys_offset + i*MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE , MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE, in+IV_offset, privateKey);
+			    succeed = EVP_OpenInit(ctx, EVP_aes_128_cbc(),in + encrypted_keys_offset + i*MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE , MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE, in+IV_offset, privateKey);
 
 			if(!succeed)
-					EVP_CIPHER_CTX_cleanup(&ctx);
+					EVP_CIPHER_CTX_free(ctx);
                             
 #ifdef GXS_SECURITY_DEBUG
 			    std::cerr << "    encrypted key at offset " << encrypted_keys_offset + i*MULTI_ENCRYPTION_FORMAT_v001_ENCRYPTED_KEY_SIZE << ": " << succeed << std::endl;
@@ -978,12 +997,12 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 
 	    int out_currOffset = 0 ;
 
-	    if(!EVP_OpenUpdate(&ctx, (unsigned char*) out, &out_currOffset, (unsigned char*)in + encrypted_block_offset, encrypted_block_size)) 
+	    if(!EVP_OpenUpdate(ctx, (unsigned char*) out, &out_currOffset, (unsigned char*)in + encrypted_block_offset, encrypted_block_size))
 		    throw std::runtime_error("Decryption error in EVP_OpenUpdate") ;
 
 	    outlen = out_currOffset;
 
-	    if(!EVP_OpenFinal(&ctx, (unsigned char*)out + out_currOffset, &out_currOffset)) 
+	    if(!EVP_OpenFinal(ctx, (unsigned char*)out + out_currOffset, &out_currOffset))
 		    throw std::runtime_error("Decryption error in EVP_OpenFinal") ;
 
 	    outlen += out_currOffset;
@@ -991,7 +1010,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
 #ifdef GXS_SECURITY_DEBUG
         	std::cerr << "  successfully decrypted block of size " << outlen << std::endl;
 #endif
-	    EVP_CIPHER_CTX_cleanup(&ctx);
+	    EVP_CIPHER_CTX_free(ctx);
 	    return true;
     }
     catch(std::exception& e)
@@ -1007,7 +1026,7 @@ bool GxsSecurity::decrypt(uint8_t *& out, uint32_t & outlen, const uint8_t *in, 
             out = NULL ;
         }
         
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_free(ctx);
         return false;
     }
 }

--- a/libretroshare/src/pqi/authssl.cc
+++ b/libretroshare/src/pqi/authssl.cc
@@ -814,14 +814,12 @@ X509 *AuthSSLimpl::SignX509ReqWithGPG(X509_REQ *req, long /*days*/)
         //EVP_PKEY *pkey = NULL;
         const EVP_MD *type = EVP_sha1();
 
-        EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+        EVP_MD_CTX *ctx = EVP_MD_CTX_create();
         unsigned char *p,*buf_in=NULL;
         unsigned char *buf_hashout=NULL,*buf_sigout=NULL;
         int inl=0,hashoutl=0;
         int sigoutl=0;
         X509_ALGOR *a;
-
-        EVP_MD_CTX_init(ctx);
 
         /* FIX ALGORITHMS */
 
@@ -923,7 +921,7 @@ X509 *AuthSSLimpl::SignX509ReqWithGPG(X509_REQ *req, long /*days*/)
 
         std::cerr << "Certificate Complete" << std::endl;
 
-        EVP_MD_CTX_free(ctx) ;
+        EVP_MD_CTX_destroy(ctx) ;
 
         return x509;
 
@@ -994,7 +992,7 @@ bool AuthSSLimpl::AuthX509WithGPG(X509 *x509,uint32_t& diagnostic)
 
 	const EVP_MD *type = EVP_sha1();
 
-	EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+	EVP_MD_CTX *ctx = EVP_MD_CTX_create();
 	unsigned char *p,*buf_in=NULL;
 	unsigned char *buf_hashout=NULL,*buf_sigout=NULL;
 	int inl=0,hashoutl=0;
@@ -1080,7 +1078,7 @@ bool AuthSSLimpl::AuthX509WithGPG(X509 *x509,uint32_t& diagnostic)
 #ifdef AUTHSSL_DEBUG
 	std::cerr << "AuthSSLimpl::AuthX509() X509 authenticated" << std::endl;
 #endif
-    EVP_MD_CTX_free(ctx) ;
+    EVP_MD_CTX_destroy(ctx) ;
 
 	OPENSSL_free(buf_in) ;
 	OPENSSL_free(buf_hashout) ;

--- a/libretroshare/src/pqi/authssl.cc
+++ b/libretroshare/src/pqi/authssl.cc
@@ -795,8 +795,8 @@ X509 *AuthSSLimpl::SignX509ReqWithGPG(X509_REQ *req, long /*days*/)
         // The code has been copied in order to use the PGP signing instead of supplying the
         // private EVP_KEY to ASN1_sign(), which would be another alternative.
 
-        int (*i2d)(X509_CINF*, unsigned char**) = i2d_X509_CINF;
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+        int (*i2d)(X509_CINF*, unsigned char**) = i2d_X509_CINF;
         X509_ALGOR *algor1 = x509->cert_info->signature;
         X509_ALGOR *algor2 = x509->sig_alg;
         ASN1_BIT_STRING *signature = x509->signature;

--- a/libretroshare/src/pqi/pqissllistener.cc
+++ b/libretroshare/src/pqi/pqissllistener.cc
@@ -494,8 +494,13 @@ int	pqissllistenbase::continueSSL(IncomingSSLInfo& incoming_connexion_info, bool
 #endif
     if(x509 != NULL)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         incoming_connexion_info.gpgid = RsPgpId(std::string(getX509CNString(x509->cert_info->issuer)));
         incoming_connexion_info.sslcn = getX509CNString(x509->cert_info->subject);
+#else
+        incoming_connexion_info.gpgid = RsPgpId(std::string(getX509CNString(X509_get_issuer_name(x509))));
+        incoming_connexion_info.sslcn = getX509CNString(X509_get_subject_name(x509));
+#endif
 
         getX509id(x509,incoming_connexion_info.sslid);
 
@@ -888,7 +893,11 @@ int pqissllistener::completeConnection(int fd, IncomingSSLInfo& info)
 		AuthSSL::getAuthSSL()->CheckCertificate(newPeerId, peercert);
 
 		/* now need to get GPG id too */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 		RsPgpId pgpid(std::string(getX509CNString(peercert->cert_info->issuer)));
+#else
+		RsPgpId pgpid(std::string(getX509CNString(X509_get_issuer_name(peercert))));
+#endif
 		mPeerMgr->addFriend(newPeerId, pgpid);
 	
 		X509_free(peercert);

--- a/libretroshare/src/pqi/pqistreamer.cc
+++ b/libretroshare/src/pqi/pqistreamer.cc
@@ -26,6 +26,7 @@
 
 #include "pqi/pqistreamer.h"
 
+#include <sys/time.h>             // for gettimeofday
 #include <stdlib.h>               // for free, realloc, exit
 #include <string.h>               // for memcpy, memset, memcmp
 #include <time.h>                 // for NULL, time, time_t

--- a/libretroshare/src/pqi/sslfns.cc
+++ b/libretroshare/src/pqi/sslfns.cc
@@ -242,6 +242,7 @@ X509_REQ *GenerateX509Req(
 
 #define SERIAL_RAND_BITS 	64
 
+#ifdef UNUSED_CODE
 X509 *SignX509Certificate(X509_NAME *issuer, EVP_PKEY *privkey, X509_REQ *req, long days)
 {
 	const EVP_MD *digest = EVP_sha1();
@@ -369,6 +370,7 @@ X509 *SignX509Certificate(X509_NAME *issuer, EVP_PKEY *privkey, X509_REQ *req, l
 
 	return x509;
 }
+#endif
 
 /********************************************************************************/
 /********************************************************************************/
@@ -600,7 +602,14 @@ bool getX509id(X509 *x509, RsPeerId& xid)
 	}
 
 	// get the signature from the cert, and copy to the array.
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ASN1_BIT_STRING *signature = x509->signature;
+#else
+	const ASN1_BIT_STRING *signature = NULL ;
+    const X509_ALGOR *algor ;
+
+    X509_get0_signature(&signature,&algor,x509);
+#endif
 	int signlen = ASN1_STRING_length(signature);
 	if (signlen < CERTSIGNLEN)
 	{
@@ -612,11 +621,13 @@ bool getX509id(X509 *x509, RsPeerId& xid)
 	}
 
 	// else copy in the first CERTSIGNLEN.
-	unsigned char *signdata = ASN1_STRING_data(signature);
+	unsigned char *signdata = ASN1_STRING_data(const_cast<ASN1_BIT_STRING*>(signature));
 
 	/* switched to the other end of the signature. for
 	 * more randomness
 	 */
+
+#warning this is cryptographically horrible. We should do a hash of the public key here!!!
 
 	xid = RsPeerId(&signdata[signlen - CERTSIGNLEN]) ;
 
@@ -689,8 +700,13 @@ int	LoadCheckX509(const char *cert_file, RsPgpId& issuerName, std::string &locat
 	if (valid)
 	{
 		// extract the name.
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 		issuerName = RsPgpId(std::string(getX509CNString(x509->cert_info->issuer)));
 		location = getX509LocString(x509->cert_info->subject);
+#else
+		issuerName = RsPgpId(std::string(getX509CNString(X509_get_issuer_name(x509))));
+		location = getX509LocString(X509_get_subject_name(x509));
+#endif
 	}
 
 #ifdef AUTHSSL_DEBUG

--- a/libretroshare/src/tcponudp/bss_tou.c
+++ b/libretroshare/src/tcponudp/bss_tou.c
@@ -234,7 +234,6 @@ static int tou_socket_write(BIO *b, const char *in, int inl)
 static long tou_socket_ctrl(BIO *b, int cmd, long num, void *ptr)
 	{
 	long ret=1;
-	int *ip;
 #ifdef DEBUG_TOU_BIO
 	fprintf(stderr, "tou_socket_ctrl(%p,%d,%ld)\n", b, cmd, num);
 #endif

--- a/libretroshare/src/tcponudp/bss_tou.c
+++ b/libretroshare/src/tcponudp/bss_tou.c
@@ -96,6 +96,20 @@ static void BIO_set_shutdown(BIO *a,int s) { a->shutdown=s; }
 static int  BIO_get_init(BIO *a) { return a->init; }
 static void BIO_set_init(BIO *a,int i) { a->init=i; }
 static void BIO_set_data(BIO *a,void *p) { a->ptr = p; }
+#else
+typedef struct bio_method_st {
+    int type;
+    const char *name;
+    int (*bwrite) (BIO *, const char *, int);
+    int (*bread) (BIO *, char *, int);
+    int (*bputs) (BIO *, const char *);
+    int (*bgets) (BIO *, char *, int);
+    long (*ctrl) (BIO *, int, long, void *);
+    int (*create) (BIO *);
+    int (*destroy) (BIO *);
+    long (*callback_ctrl) (BIO *, int, bio_info_cb *);
+} BIO_METHOD;
+
 #endif
 
 static BIO_METHOD methods_tou_sockp=

--- a/libretroshare/src/util/rsaes.cc
+++ b/libretroshare/src/util/rsaes.cc
@@ -52,9 +52,8 @@ bool RsAES::aes_crypt_8_16(const uint8_t *input_data,uint32_t input_data_length,
 		return false ;
 	}
 
-	EVP_CIPHER_CTX e_ctx ;
-	EVP_CIPHER_CTX_init(&e_ctx);
-	EVP_EncryptInit_ex(&e_ctx, EVP_aes_256_cbc(), NULL, key, iv);
+	EVP_CIPHER_CTX *e_ctx = EVP_CIPHER_CTX_new();
+	EVP_EncryptInit_ex(e_ctx, EVP_aes_256_cbc(), NULL, key, iv);
 
 	/* max ciphertext len for a n bytes of plaintext is n + AES_BLOCK_SIZE -1 bytes */
 	int c_len = input_data_length + AES_BLOCK_SIZE ;
@@ -62,31 +61,31 @@ bool RsAES::aes_crypt_8_16(const uint8_t *input_data,uint32_t input_data_length,
 
 	if(output_data_length < (uint32_t)c_len)
     {
-	    EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+	    EVP_CIPHER_CTX_free(e_ctx) ;
 	    return false ;
     }
 
 	/* update ciphertext, c_len is filled with the length of ciphertext generated,
 	 *len is the size of plaintext in bytes */
 
-	if(!EVP_EncryptUpdate(&e_ctx, output_data, &c_len, input_data, input_data_length))
+	if(!EVP_EncryptUpdate(e_ctx, output_data, &c_len, input_data, input_data_length))
 	{
 		std::cerr << "RsAES: decryption failed at end. Check padding." << std::endl;
-        	EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+        	EVP_CIPHER_CTX_free(e_ctx) ;
 		return false ;
 	}
 
 	/* update ciphertext with the final remaining bytes */
-	if(!EVP_EncryptFinal_ex(&e_ctx, output_data+c_len, &f_len))
+	if(!EVP_EncryptFinal_ex(e_ctx, output_data+c_len, &f_len))
 	{
 		std::cerr << "RsAES: decryption failed at end. Check padding." << std::endl;
-        	EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+        	EVP_CIPHER_CTX_free(e_ctx) ;
 		return false ;
 	}
 
 	output_data_length = c_len + f_len;
 
-	EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+	EVP_CIPHER_CTX_free(e_ctx) ;
 	return true;
 }
 
@@ -108,9 +107,8 @@ bool RsAES::aes_decrypt_8_16(const uint8_t *input_data,uint32_t input_data_lengt
 		return false ;
 	}
 
-	EVP_CIPHER_CTX e_ctx ;
-	EVP_CIPHER_CTX_init(&e_ctx);
-	EVP_DecryptInit_ex(&e_ctx, EVP_aes_256_cbc(), NULL, key, iv);
+	EVP_CIPHER_CTX *e_ctx = EVP_CIPHER_CTX_new();
+	EVP_DecryptInit_ex(e_ctx, EVP_aes_256_cbc(), NULL, key, iv);
 
 	/* max ciphertext len for a n bytes of plaintext is n + AES_BLOCK_SIZE -1 bytes */
 	int c_len = input_data_length + AES_BLOCK_SIZE ;
@@ -118,7 +116,7 @@ bool RsAES::aes_decrypt_8_16(const uint8_t *input_data,uint32_t input_data_lengt
 
 	if(output_data_length < (uint32_t)c_len)
     {
-        	EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+        	EVP_CIPHER_CTX_free(e_ctx) ;
 		return false ;
     }
 
@@ -127,24 +125,24 @@ bool RsAES::aes_decrypt_8_16(const uint8_t *input_data,uint32_t input_data_lengt
 	/* update ciphertext, c_len is filled with the length of ciphertext generated,
 	 *len is the size of plaintext in bytes */
 
-	if(! EVP_DecryptUpdate(&e_ctx, output_data, &c_len, input_data, input_data_length))
+	if(! EVP_DecryptUpdate(e_ctx, output_data, &c_len, input_data, input_data_length))
 	{
 		std::cerr << "RsAES: decryption failed." << std::endl;
-        	EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+        	EVP_CIPHER_CTX_free(e_ctx) ;
 		return false ;
 	}
 
 	/* update ciphertext with the final remaining bytes */
-	if(!EVP_DecryptFinal_ex(&e_ctx, output_data+c_len, &f_len))
+	if(!EVP_DecryptFinal_ex(e_ctx, output_data+c_len, &f_len))
 	{
 		std::cerr << "RsAES: decryption failed at end. Check padding." << std::endl;
-        	EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+        	EVP_CIPHER_CTX_free(e_ctx) ;
 		return false ;
 	}
 
 	output_data_length = c_len + f_len;
 
-	EVP_CIPHER_CTX_cleanup(&e_ctx) ;
+	EVP_CIPHER_CTX_free(e_ctx) ;
 	return true;
 }
 

--- a/openpgpsdk/src/openpgpsdk/openssl_crypto.c
+++ b/openpgpsdk/src/openpgpsdk/openssl_crypto.c
@@ -45,10 +45,17 @@ void test_secret_key(const ops_secret_key_t *skey)
     {
     RSA* test=RSA_new();
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     test->n=BN_dup(skey->public_key.key.rsa.n);
     test->e=BN_dup(skey->public_key.key.rsa.e);
-
     test->d=BN_dup(skey->key.rsa.d);
+#else
+    RSA_set0_key(test,
+		    BN_dup(skey->public_key.key.rsa.n),
+    		BN_dup(skey->public_key.key.rsa.e),
+		    BN_dup(skey->key.rsa.d));
+#endif
+
     test->p=BN_dup(skey->key.rsa.p);
     test->q=BN_dup(skey->key.rsa.q);
 
@@ -392,8 +399,13 @@ ops_boolean_t ops_dsa_verify(const unsigned char *hash,size_t hash_length,
     int ret;
 
     osig=DSA_SIG_new();
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     osig->r=sig->r;
     osig->s=sig->s;
+#else
+    DSA_SIG_set0(osig,sig->r,sig->s) ;
+#endif
 
 	 if(BN_num_bits(dsa->q) != 160)
 	 {

--- a/openpgpsdk/src/openpgpsdk/openssl_crypto.c
+++ b/openpgpsdk/src/openpgpsdk/openssl_crypto.c
@@ -749,7 +749,7 @@ ops_boolean_t ops_rsa_generate_keypair(const int numbits, const unsigned long e,
     skey->public_key.key.rsa.e=BN_dup(rsa->e);
     skey->key.rsa.d=BN_dup(rsa->d);
 #else
-    BIGNUM *nn=NULL,*ee=NULL,*dd=NULL ;
+    const BIGNUM *nn=NULL,*ee=NULL,*dd=NULL ;
 
     RSA_get0_key(rsa,&nn,&ee,&dd) ;
 
@@ -771,7 +771,7 @@ ops_boolean_t ops_rsa_generate_keypair(const int numbits, const unsigned long e,
     skey->key.rsa.q=BN_dup(rsa->q);
     skey->key.rsa.u=BN_mod_inverse(NULL,rsa->p, rsa->q, ctx);
 #else
-    BIGNUM *pp=NULL,*qq=NULL ;
+    const BIGNUM *pp=NULL,*qq=NULL ;
 
     RSA_get0_factors(rsa,&pp,&qq) ;
 

--- a/openpgpsdk/src/openpgpsdk/openssl_crypto.c
+++ b/openpgpsdk/src/openpgpsdk/openssl_crypto.c
@@ -755,7 +755,7 @@ ops_boolean_t ops_rsa_generate_keypair(const int numbits, const unsigned long e,
 
     skey->public_key.key.rsa.n=BN_dup(nn) ;
     skey->public_key.key.rsa.e=BN_dup(ee) ;
-    skey->public_key.key.rsa.e=BN_dup(dd) ;
+    skey->key.rsa.d=BN_dup(dd) ;
 #endif
 
     skey->s2k_usage=OPS_S2KU_ENCRYPTED_AND_HASHED;

--- a/openpgpsdk/src/openpgpsdk/openssl_crypto.c
+++ b/openpgpsdk/src/openpgpsdk/openssl_crypto.c
@@ -416,6 +416,12 @@ ops_boolean_t ops_dsa_verify(const unsigned char *hash,size_t hash_length,
 			 fprintf(stderr,"(WW) ops_dsa_verify: openssl does only supports 'q' of 160 bits. Current is %d bits.\n",BN_num_bits(dsa->q)) ;
 			 already_said=ops_true ;
 		 }
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+		 osig->r=NULL;			// in this case, the values are not copied.
+		 osig->s=NULL;
+#endif
+
 		 DSA_SIG_free(osig);
 		 return ops_false ;
 	 }

--- a/openpgpsdk/src/openpgpsdk/signature.c
+++ b/openpgpsdk/src/openpgpsdk/signature.c
@@ -302,7 +302,7 @@ static ops_boolean_t dsa_sign(ops_hash_t *hash, const ops_dsa_public_key_t *dsa,
 	ops_write_mpi(dsasig->r, cinfo);
 	ops_write_mpi(dsasig->s, cinfo);
 #else
-    BIGNUM *rr=NULL,*ss=NULL ;
+    const BIGNUM *rr=NULL,*ss=NULL ;
 
     DSA_SIG_get0(dsasig,&rr,&ss) ;
 

--- a/openpgpsdk/src/openpgpsdk/signature.c
+++ b/openpgpsdk/src/openpgpsdk/signature.c
@@ -302,7 +302,7 @@ static ops_boolean_t dsa_sign(ops_hash_t *hash, const ops_dsa_public_key_t *dsa,
 	ops_write_mpi(dsasig->r, cinfo);
 	ops_write_mpi(dsasig->s, cinfo);
 #else
-    const BIGNUM *rr=NULL,*ss=NULL ;
+    BIGNUM *rr=NULL,*ss=NULL ;
 
     DSA_SIG_get0(dsasig,&rr,&ss) ;
 

--- a/openpgpsdk/src/openpgpsdk/signature.c
+++ b/openpgpsdk/src/openpgpsdk/signature.c
@@ -302,9 +302,9 @@ static ops_boolean_t dsa_sign(ops_hash_t *hash, const ops_dsa_public_key_t *dsa,
 	ops_write_mpi(dsasig->r, cinfo);
 	ops_write_mpi(dsasig->s, cinfo);
 #else
-    BIGNUM *rr=NULL,*ss=NULL ;
+    const BIGNUM *rr=NULL,*ss=NULL ;
 
-    DSA_SIG_get0(&rr,&ss) ;
+    DSA_SIG_get0(dsasig,&rr,&ss) ;
 
 	ops_write_mpi(rr, cinfo);
 	ops_write_mpi(ss, cinfo);

--- a/openpgpsdk/src/openpgpsdk/signature.c
+++ b/openpgpsdk/src/openpgpsdk/signature.c
@@ -298,8 +298,18 @@ static ops_boolean_t dsa_sign(ops_hash_t *hash, const ops_dsa_public_key_t *dsa,
 	dsasig=ops_dsa_sign(hashbuf, hashsize, sdsa, dsa);
 
 	// convert and write the sig out to memory
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ops_write_mpi(dsasig->r, cinfo);
 	ops_write_mpi(dsasig->s, cinfo);
+#else
+    BIGNUM *rr=NULL,*ss=NULL ;
+
+    DSA_SIG_get0(&rr,&ss) ;
+
+	ops_write_mpi(rr, cinfo);
+	ops_write_mpi(ss, cinfo);
+#endif
+
 	DSA_SIG_free(dsasig);
 
 	return ops_true ;

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -60,6 +60,9 @@ rs_nodeprecatedwarning:CONFIG -= no_rs_nodeprecatedwarning
 CONFIG *= no_rs_nocppwarning
 rs_nocppwarning:CONFIG -= no_rs_nocppwarning
 
+INCLUDEPATH += /usr/local/openssl/include
+LIBS += -L/usr/local/openssl/lib
+
 unix {
 	isEmpty(PREFIX)   { PREFIX   = "/usr" }
 	isEmpty(BIN_DIR)  { BIN_DIR  = "$${PREFIX}/bin" }

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -60,9 +60,6 @@ rs_nodeprecatedwarning:CONFIG -= no_rs_nodeprecatedwarning
 CONFIG *= no_rs_nocppwarning
 rs_nocppwarning:CONFIG -= no_rs_nocppwarning
 
-INCLUDEPATH += /usr/local/openssl/include
-LIBS += -L/usr/local/openssl/lib
-
 unix {
 	isEmpty(PREFIX)   { PREFIX   = "/usr" }
 	isEmpty(BIN_DIR)  { BIN_DIR  = "$${PREFIX}/bin" }


### PR DESCRIPTION
I fixed the compilation with openssl-1.1.0. But I need someone to test the code for me. Here's a roadmap:

You'll need to have openssl1.1.0 installed on your system, as a normal package. Don't try to install it in /usr/local/openssl, or whatever in the same system than an existing openssl-1.0.0 version (I tried: it's a mess mainly because sqlcipher is compiled with 1.0.1 in his case).

- checkout PR/689, or github.com/csoler/Retroshare/ branch v0.6-SSL110Fix
- compile

Then check these:

1 - launch an existing node. Does it run? [this tests signature validation in your own certificate and PGP decryption of your pem file]

2 - does it connect to other nodes? Try both TCP-IN and TCP-OUT [this tests signature validation with PGP over SSL cert for friend's certs]

3 - try UDP. This takes more time, as TCP is used in priority. You can force listenning on udp only with -u, but you still will do TCP-out. [this tests tcp on udp code]

4 - try distant chat. Can you open it, send/recv messages? [this tests DH key echange]

5 - create a new node (node key + location). Can it connect to other nodes? [ this tests signature of own certificate and creation of PGP cert]

6 - create a second new node. Try to connect to the other new one [tests signature validation over new code for new signature]

7 - does options files load ok? If not you should lose your config when restarting. Easy to see. [tests ssl encryption/decryption code]

8 - create a signed GXS identity. Use it to chat. Does it work? [tests GXS sgnature by PGP key]

9 - try file transfer: does e2e encrypted tunnels work ok? Try in forced mode to make sure you get them only. [tests chacha20 code and HMAC authentication]

Many thx to anyone who can do that!
