### PR TITLE
Fix comment view when they have line return.

### DIFF
--- a/retroshare-gui/src/gui/gxs/GxsCommentTreeWidget.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsCommentTreeWidget.cpp
@@ -25,6 +25,7 @@
 #include <QDateTime>
 #include <QMenu>
 
+#include "gui/common/RSElidedItemDelegate.h"
 #include "gui/gxs/GxsCommentTreeWidget.h"
 #include "gui/gxs/GxsCreateCommentDialog.h"
 #include "gui/gxs/GxsIdTreeWidgetItem.h"
@@ -57,6 +58,10 @@ GxsCommentTreeWidget::GxsCommentTreeWidget(QWidget *parent)
 //	QTreeWidget* widget = this;
 
 	setContextMenuPolicy(Qt::CustomContextMenu);
+	RSElidedItemDelegate *itemDelegate = new RSElidedItemDelegate(this);
+	itemDelegate->setSpacing(QSize(0, 2));
+	setItemDelegate(itemDelegate);
+	setWordWrap(true);
 //	QFont font = QFont("ARIAL", 10);
 //	font.setBold(true);
 

--- a/retroshare-gui/src/gui/gxs/GxsCreateCommentDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsCreateCommentDialog.cpp
@@ -25,6 +25,8 @@
 #include "GxsCreateCommentDialog.h"
 #include "ui_GxsCreateCommentDialog.h"
 
+#include "util/HandleRichText.h"
+
 #include <QMessageBox>
 #include <iostream>
 
@@ -45,7 +47,11 @@ void GxsCreateCommentDialog::createComment()
 {
 	RsGxsComment comment;
 
-	comment.mComment = std::string(ui->commentTextEdit->document()->toPlainText().toUtf8());
+	QString text = ui->commentTextEdit->toHtml();
+	RsHtml::optimizeHtml(text);
+	std::string msg = text.toUtf8().constData();
+
+	comment.mComment = msg;
 	comment.mMeta.mParentId = mParentId.second;
 	comment.mMeta.mGroupId = mParentId.first;
 	comment.mMeta.mThreadId = mThreadId;


### PR DESCRIPTION
Before, they grow row height but only show 1 line if it is elided.
Now, height stay at one line, but tooltip show the correct message.