### PR TITLE
Fix Missing messages when mark all as read.

### DIFF
--- a/libretroshare/src/gxs/rsgxsdata.cc
+++ b/libretroshare/src/gxs/rsgxsdata.cc
@@ -239,17 +239,21 @@ void RsGxsMsgMetaData::clear()
     mMsgId.clear();
     mThreadId.clear();
     mParentId.clear();
-    mAuthorId.clear();
     mOrigMsgId.clear();
-    mMsgName.clear();
-    mServiceString.clear();
+    mAuthorId.clear();
 
     signSet.TlvClear();
+    mMsgName.clear();
     mPublishTs = 0;
     mMsgFlags = 0;
+
+    mServiceString.clear();
     mMsgStatus = 0;
+    mMsgSize = 0;
     mChildTs = 0;
     recvTS = 0;
+    mHash.clear();
+    validated = false;
 }
 
 bool RsGxsMsgMetaData::serialise(void *data, uint32_t *size)

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1844,10 +1844,22 @@ void GxsForumThreadWidget::setMsgReadStatus(QList<QTreeWidgetItem*> &rows, bool 
 			// LIKE THIS BELOW...
 			//std::string grpId = (*Row)->data(COLUMN_THREAD_DATA, ROLE_THREAD_GROUPID).toString().toStdString();
 
-            RsGxsGrpMsgIdPair msgPair = std::make_pair(groupId(), RsGxsMessageId(msgId));
+			RsGxsGrpMsgIdPair msgPair = std::make_pair( groupId(), RsGxsMessageId(msgId) );
 
 			uint32_t token;
 			rsGxsForums->setMessageReadStatus(token, msgPair, read);
+
+			// Look if older version exist to mark them too
+			QMap<RsGxsMessageId,QVector<QPair<time_t,RsGxsMessageId> > >::const_iterator it = mPostVersions.find(mOrigThreadId) ;
+			if(it != mPostVersions.end())
+			{
+				std::cerr << (*it).size() << " versions found " << std::endl;
+				for(int i=0;i<(*it).size();++i)
+				{
+					msgPair = std::make_pair( groupId(), (*it)[i].second );
+					rsGxsForums->setMessageReadStatus(token, msgPair, read);
+				}
+			}
 
 			/* Add message id to ignore list for the next updateDisplay */
 			mIgnoredMsgId.push_back(RsGxsMessageId(msgId));


### PR DESCRIPTION
If message get olders versions, these ones was not marked as read. So it
left unread messages on thread despite nothing appears on tree view.