### PR TITLE
Changed: Initial message is added only when retroshare_gui is defined

### DIFF
--- a/libresapi/src/api/ChatHandler.cpp
+++ b/libresapi/src/api/ChatHandler.cpp
@@ -333,7 +333,7 @@ void ChatHandler::tick()
             }
 
             RsIdentityDetails details;
-            if(!gxs_id_failed && mRsIdentity->getIdDetails(msg.incoming? dcpinfo.to_id: dcpinfo.own_id, details))
+			if(!gxs_id_failed && mRsIdentity->getIdDetails( !msg.incoming ? dcpinfo.to_id: dcpinfo.own_id, details))
             {
                 author_id = details.mId.toStdString();
                 author_name = details.mNickname;
@@ -400,7 +400,7 @@ void ChatHandler::tick()
                 DistantChatPeerInfo dcpinfo ;
                 
                 if(!gxs_id_failed && rsMsgs->getDistantChatStatus(msg.chat_id.toDistantChatId(),dcpinfo)
-                                  && mRsIdentity->getIdDetails(msg.incoming? dcpinfo.to_id: dcpinfo.own_id, details))
+				                  && mRsIdentity->getIdDetails( !msg.incoming ? dcpinfo.to_id: dcpinfo.own_id, details))
                 {
                     info.remote_author_id = details.mId.toStdString();
                     info.remote_author_name = details.mNickname;

--- a/libretroshare/src/chat/distantchat.cc
+++ b/libretroshare/src/chat/distantchat.cc
@@ -259,8 +259,9 @@ bool DistantChatService::initiateDistantChatConnexion(const RsGxsId& to_gxs_id, 
 
     error_code = RS_DISTANT_CHAT_ERROR_NO_ERROR ;
 
-    // Make a self message to raise the chat window
-    
+#ifdef RETROSHARE_GUI
+	// Make a self message to raise the chat window
+
     RsChatMsgItem *item = new RsChatMsgItem;
     item->message = "[Starting distant chat. Please wait for secure tunnel to be established]" ;
     item->chatFlags = RS_CHAT_FLAG_PRIVATE ;
@@ -269,7 +270,8 @@ bool DistantChatService::initiateDistantChatConnexion(const RsGxsId& to_gxs_id, 
     handleRecvChatMsgItem(item) ;
     
     delete item ;	// item is replaced by NULL if partial, but this is not the case here.
-    
+#endif
+
     return true ;
 }
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -157,6 +157,7 @@ unfinished {
 	CONFIG += wikipoos
 }
 
+retroshare_gui:DEFINES *= RETROSHARE_GUI
 wikipoos:DEFINES *= RS_USE_WIKI
 rs_gxs:DEFINES *= RS_ENABLE_GXS
 libresapilocalserver:DEFINES *= LIBRESAPI_LOCAL_SERVER


### PR DESCRIPTION
This kind of messages should not be added to chat history in libretroshare. However, if they have to be, their author name should be a "system" or "application".