### PR TITLE
libresapi: silent /chat/initiate_distant_chat

### DIFF
--- a/libresapi/src/api/ChatHandler.cpp
+++ b/libresapi/src/api/ChatHandler.cpp
@@ -1199,9 +1199,9 @@ void ChatHandler::handleInitiateDistantChatConnexion(Request& req, Response& res
 	DistantChatPeerId distant_chat_id;
 	uint32_t error_code;
 
-	if(mRsMsgs->initiateDistantChatConnexion(receiver_id, sender_id,
-	                                         distant_chat_id, error_code))
-		resp.setOk();
+	if(mRsMsgs->initiateDistantChatConnexion( receiver_id, sender_id,
+	                                          distant_chat_id, error_code,
+	                                          false )) resp.setOk();
 	else resp.setFail("Failed to initiate distant chat");
 
 	ChatId chat_id(distant_chat_id);

--- a/libresapi/src/api/ChatHandler.cpp
+++ b/libresapi/src/api/ChatHandler.cpp
@@ -414,16 +414,18 @@ void ChatHandler::tick()
                 }
             }
             else if(msg.chat_id.isDistantChatId())
-            {
-                RsIdentityDetails details;
-                DistantChatPeerInfo dcpinfo ;
-                
-                if(!gxs_id_failed && rsMsgs->getDistantChatStatus(msg.chat_id.toDistantChatId(),dcpinfo)
-                                  && mRsIdentity->getIdDetails(msg.incoming? dcpinfo.to_id: dcpinfo.own_id, details))
-                {
-                    info.remote_author_id = details.mId.toStdString();
-                    info.remote_author_name = details.mNickname;
-                }
+			{
+				RsIdentityDetails details;
+				DistantChatPeerInfo dcpinfo;
+
+				if( !gxs_id_failed &&
+				        rsMsgs->getDistantChatStatus(
+				            msg.chat_id.toDistantChatId(), dcpinfo ) &&
+				        mRsIdentity->getIdDetails(dcpinfo.to_id, details) )
+				{
+					info.remote_author_id = details.mId.toStdString();
+					info.remote_author_name = details.mNickname;
+				}
                 else
                 {
                     gxs_id_failed = true;

--- a/libretroshare/src/retroshare/rsmsgs.h
+++ b/libretroshare/src/retroshare/rsmsgs.h
@@ -490,7 +490,10 @@ virtual ChatLobbyId createChatLobby(const std::string& lobby_name,const RsGxsId&
     virtual uint32_t getDistantChatPermissionFlags()=0 ;
     virtual bool setDistantChatPermissionFlags(uint32_t flags)=0 ;
     
-virtual bool initiateDistantChatConnexion(const RsGxsId& to_pid,const RsGxsId& from_pid,DistantChatPeerId& pid,uint32_t& error_code) = 0;
+virtual bool initiateDistantChatConnexion(
+	        const RsGxsId& to_pid, const RsGxsId& from_pid,
+	        DistantChatPeerId& pid, uint32_t& error_code,
+	        bool notify = true ) = 0;
 virtual bool getDistantChatStatus(const DistantChatPeerId& pid,DistantChatPeerInfo& info)=0;
 virtual bool closeDistantChatConnexion(const DistantChatPeerId& pid)=0;
 

--- a/libretroshare/src/rsserver/p3msgs.cc
+++ b/libretroshare/src/rsserver/p3msgs.cc
@@ -520,9 +520,12 @@ void p3Msgs::getPendingChatLobbyInvites(std::list<ChatLobbyInvite>& invites)
 {
 	mChatSrv->getPendingChatLobbyInvites(invites) ;
 }
-bool p3Msgs::initiateDistantChatConnexion(const RsGxsId& to_gxs_id,const RsGxsId& from_gxs_id,DistantChatPeerId& pid,uint32_t& error_code)
+bool p3Msgs::initiateDistantChatConnexion(
+        const RsGxsId& to_gxs_id, const RsGxsId& from_gxs_id,
+        DistantChatPeerId& pid, uint32_t& error_code, bool notify )
 {
-    return mChatSrv->initiateDistantChatConnexion(to_gxs_id,from_gxs_id,pid,error_code) ;
+	return mChatSrv->initiateDistantChatConnexion( to_gxs_id, from_gxs_id,
+	                                               pid, error_code, notify );
 }
 bool p3Msgs::getDistantChatStatus(const DistantChatPeerId& pid,DistantChatPeerInfo& info)
 {

--- a/libretroshare/src/rsserver/p3msgs.h
+++ b/libretroshare/src/rsserver/p3msgs.h
@@ -159,7 +159,11 @@ class p3Msgs: public RsMsgs
     virtual bool getLobbyAutoSubscribe(const ChatLobbyId& lobby_id);
       virtual ChatLobbyId createChatLobby(const std::string& lobby_name,const RsGxsId& lobby_identity,const std::string& lobby_topic,const std::set<RsPeerId>& invited_friends,ChatLobbyFlags privacy_type) ;
 
-      virtual bool initiateDistantChatConnexion(const RsGxsId& to_gxs_id, const RsGxsId& from_gxs_id, DistantChatPeerId &pid, uint32_t& error_code) ;
+	virtual bool initiateDistantChatConnexion(
+		          const RsGxsId& to_gxs_id, const RsGxsId& from_gxs_id,
+		          DistantChatPeerId &pid, uint32_t& error_code,
+		          bool notify = true );
+
       virtual bool getDistantChatStatus(const DistantChatPeerId& gxs_id,DistantChatPeerInfo& info);
       virtual bool closeDistantChatConnexion(const DistantChatPeerId &pid) ;
 


### PR DESCRIPTION
Avoid to forge the
[Starting distant chat. Please wait for secure tunnel to be established]
message on requesting chat id from API as it is a nuisance in most
libresapi use cases

Superseedes https://github.com/RetroShare/RetroShare/pull/818