### PR TITLE
fix bug in BOB settings

### DIFF
--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -34,7 +34,7 @@ static const int sleepFactorDefault   = 10; // 0.5s
 static const int sleepFactorFast      = 1;  // 0.05s
 static const int sleepFactorSlow      = 20; // 1s
 
-static struct RsLog::logInfo i2pBobLogInfo = {RsLog::Debug_All, "p3I2pBob"};
+static struct RsLog::logInfo i2pBobLogInfo = {RsLog::Default, "p3I2pBob"};
 
 static const time_t selfCheckPeroid = 30;
 

--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -1635,7 +1635,7 @@ void ServerPage::updateStatusBob()
         ui.pbBobStart->setToolTip("BOB is not accessible");
         ui.pbBobRestart->setEnabled(false);
         ui.pbBobRestart->setToolTip("BOB is not accessible");
-        ui.pbBobStop->setEnabled(false);
+        // don't disable the stop button! (in case bob is running you are otherwise unable to stop and disable it)
         ui.pbBobStop->setToolTip("BOB is not accessible");
     } else {
         ui.pbBobStart->setToolTip("");


### PR DESCRIPTION
The stop button is disabled when RS can't reach I2P/BOB. This leads to the problem that you cannot stop an ongoing start up attempt. Which then makes you unable to disable BOB.