### PR TITLE
hide hidden service port for I2P instead of just disabling it 

### DIFF
--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -1076,7 +1076,7 @@ void ServerPage::loadHiddenNode()
     whileBlocking(ui.hiddenpage_serviceAddress)->setText(QString::fromStdString(detail.hiddenNodeAddress));
     whileBlocking(ui.hiddenpage_servicePort) -> setValue(detail.hiddenNodePort);
     /* in I2P there is no port - there is only the address */
-    whileBlocking(ui.hiddenpage_servicePort)->setEnabled(detail.hiddenType != RS_HIDDEN_TYPE_I2P);
+    whileBlocking(ui.hiddenpage_servicePort)->setHidden(detail.hiddenType == RS_HIDDEN_TYPE_I2P);
 
     /* out proxy settings */
     std::string proxyaddr;


### PR DESCRIPTION
it's not used for I2P