### PR TITLE
Always allow Friend Time Offset Feed item.

### DIFF
--- a/retroshare-gui/src/gui/NewsFeed.cpp
+++ b/retroshare-gui/src/gui/NewsFeed.cpp
@@ -229,7 +229,7 @@ void NewsFeed::updateDisplay()
 					addFeedItemPeerNew(fi);
 				break;
 			case RS_FEED_ITEM_PEER_OFFSET:
-				if (flags & RS_FEED_TYPE_PEER)
+				//if (flags & RS_FEED_TYPE_PEER) //Always allow this feed even if Friend notify is disabled.
 					addFeedItemPeerOffset(fi);
 				break;
 


### PR DESCRIPTION
Even if "Friend Connected" is uncheck in Notify setting page.