### PR TITLE
removed QFileDialog::DontUseNativeDialog from src, to enable thumbnai…

### DIFF
--- a/retroshare-gui/src/gui/ShareManager.cpp
+++ b/retroshare-gui/src/gui/ShareManager.cpp
@@ -124,7 +124,7 @@ void ShareManager::doubleClickedCell(int row,int column)
 {
     if(column == COLUMN_PATH)
     {
-        QString dirname = QFileDialog::getExistingDirectory(NULL,tr("Choose directory"),QString(),QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
+        QString dirname = QFileDialog::getExistingDirectory(NULL,tr("Choose directory"),QString(),QFileDialog::ShowDirsOnly);
 
         if(!dirname.isNull())
         {
@@ -358,7 +358,7 @@ void ShareManager::showEvent(QShowEvent *event)
 
 void ShareManager::addShare()
 {
-    QString fname = QFileDialog::getExistingDirectory(NULL,tr("Choose a directory to share"),QString(),QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
+    QString fname = QFileDialog::getExistingDirectory(NULL,tr("Choose a directory to share"),QString(),QFileDialog::ShowDirsOnly);
 
     if(fname.isNull())
         return;

--- a/retroshare-gui/src/gui/help/version.html
+++ b/retroshare-gui/src/gui/help/version.html
@@ -1,5 +1,7 @@
 Retroshare Gui version : 
-Svn version : 8013
-Fr 13. Mär 16:32:53 CET 2015
+Git version : branch master commit 7bbb993769c231eb2871eba60939e215f787553f
+Svn version : 
+Svn version : 
+Sat Jan 21 09:54:22 CET 2017
 
 

--- a/retroshare-gui/src/main.cpp
+++ b/retroshare-gui/src/main.cpp
@@ -129,12 +129,12 @@ QStringList filedialog_open_filenames_hook(QWidget * parent, const QString &capt
 
 QString filedialog_open_filename_hook(QWidget * parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options)
 {
-	return QFileDialog::getOpenFileName(parent, caption, dir, filter, selectedFilter, options | QFileDialog::DontUseNativeDialog);
+	return QFileDialog::getOpenFileName(parent, caption, dir, filter, selectedFilter, options);
 }
 
 QString filedialog_save_filename_hook(QWidget * parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options)
 {
-	return QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options | QFileDialog::DontUseNativeDialog);
+	return QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options);
 }
 
 QString filedialog_existing_directory_hook(QWidget *parent, const QString &caption, const QString &dir, QFileDialog::Options options)

--- a/retroshare-gui/src/util/misc.cpp
+++ b/retroshare-gui/src/util/misc.cpp
@@ -316,7 +316,7 @@ bool misc::getOpenFileName(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type);
 
-    file = QFileDialog::getOpenFileName(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog | options);
+    file = QFileDialog::getOpenFileName(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | options);
 
     if (file.isEmpty())
         return false;
@@ -339,7 +339,7 @@ bool misc::getOpenFileNames(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type);
 
-    files = QFileDialog::getOpenFileNames(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog | options);
+    files = QFileDialog::getOpenFileNames(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | options);
 
     if (files.isEmpty())
         return false;


### PR DESCRIPTION
…ls from native load picture dialog

regarding https://github.com/RetroShare/RetroShare/issues/933

before dontUserNative
https://www.pictshare.net/rbtigq2gaj.png

after with native 
https://www.pictshare.net/jejxwcs0p9.png

but i am not sure if QFileDialog::DontUseNativeDialog has been in use for a reason
