### PR TITLE
Change RetroShareLink creation methodes as static

### DIFF
--- a/retroshare-gui/src/gui/FileTransfer/DetailsDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/DetailsDialog.cpp
@@ -110,9 +110,7 @@ void DetailsDialog::setFileHash(const RsFileHash & hash)
 	if(!rsFiles->FileDetails(hash, RS_FILE_HINTS_DOWNLOAD, nfo)) 
 		return ;
 
-	RetroShareLink link ;
-    link.createFile(QString::fromUtf8(nfo.fname.c_str()),nfo.size,QString::fromStdString(nfo.hash.toStdString())) ;
-
+	RetroShareLink link = RetroShareLink::createFile(QString::fromUtf8(nfo.fname.c_str()),nfo.size,QString::fromStdString(nfo.hash.toStdString()));
 	ui.Linktext->setText(link.toString()) ;
 }
 

--- a/retroshare-gui/src/gui/FileTransfer/SearchDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/SearchDialog.cpp
@@ -712,8 +712,8 @@ void SearchDialog::copySearchLink()
     std::cerr << "SearchDialog::copySearchLink(): keywords: " << keywords.toStdString();
     std::cerr << std::endl;
 
-    RetroShareLink link;
-    if (link.createSearch(keywords)) {
+    RetroShareLink link = RetroShareLink::createSearch(keywords);
+    if (link.valid()) {
         QList<RetroShareLink> urls;
         urls.push_back(link);
         RSLinkClipboard::copyLinks(urls);
@@ -1443,11 +1443,11 @@ void SearchDialog::copyResultLink()
 			 qulonglong fsize = item->text(SR_SIZE_COL).toULongLong();
 			 QString fname = item->text(SR_NAME_COL);
 
-			 RetroShareLink link;
-			 if (link.createFile(fname, fsize, fhash)) {
-				 std::cerr << "new link added to clipboard: " << link.toString().toStdString() << std::endl ;
-				 urls.push_back(link) ;
-			 }
+			RetroShareLink link = RetroShareLink::createFile(fname, fsize, fhash);
+			if (link.valid()) {
+				std::cerr << "new link added to clipboard: " << link.toString().toStdString() << std::endl ;
+				urls.push_back(link) ;
+			}
 		 } 
 	 }
 	 RSLinkClipboard::copyLinks(urls) ;

--- a/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
@@ -1464,8 +1464,8 @@ void TransfersDialog::copyLink ()
 			continue;
 		}
 
-		RetroShareLink link;
-        if (link.createFile(QString::fromUtf8(info.fname.c_str()), info.size, QString::fromStdString(info.hash.toStdString()))) {
+		RetroShareLink link = RetroShareLink::createFile(QString::fromUtf8(info.fname.c_str()), info.size, QString::fromStdString(info.hash.toStdString()));
+		if (link.valid()) {
 			links.push_back(link) ;
 		}
 	}
@@ -1487,8 +1487,8 @@ void TransfersDialog::ulCopyLink ()
             continue;
         }
 
-        RetroShareLink link;
-        if (link.createFile(QString::fromUtf8(info.fname.c_str()), info.size, QString::fromStdString(info.hash.toStdString()))) {
+        RetroShareLink link = RetroShareLink::createFile(QString::fromUtf8(info.fname.c_str()), info.size, QString::fromStdString(info.hash.toStdString()));
+        if (link.valid()) {
             links.push_back(link) ;
         }
     }

--- a/retroshare-gui/src/gui/Identity/IdDetailsDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDetailsDialog.cpp
@@ -467,8 +467,7 @@ void IdDetailsDialog::sendInvite()
     composer->setTitleText(tr("You have a friend invite"));
     
     RsPeerId ownId = rsPeers->getOwnId();
-    RetroShareLink link;
-    link.createCertificate(ownId);
+    RetroShareLink link = RetroShareLink::createCertificate(ownId);
     
     RsGxsId keyId(ui->lineEdit_KeyId->text().toStdString());
     

--- a/retroshare-gui/src/gui/Identity/IdDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDialog.cpp
@@ -1943,8 +1943,7 @@ QString IdDialog::createUsageString(const RsIdentityUsage& u) const
     case RsIdentityUsage::MESSAGE_AUTHOR_SIGNATURE_VALIDATION:
     case RsIdentityUsage::MESSAGE_AUTHOR_KEEP_ALIVE:             // Identities are stamped regularly by crawlign the set of messages for all groups. That helps keepign the useful identities in hand.
 	{
-		RetroShareLink l;
-		l.createGxsMessageLink(service_type,u.mGrpId,u.mMsgId,tr("Message/vote/comment"));
+		RetroShareLink l = RetroShareLink::createGxsMessageLink(service_type,u.mGrpId,u.mMsgId,tr("Message/vote/comment"));
 		return tr("%1 in %2 tab").arg(l.toHtml()).arg(service_name) ;
 	}
     case RsIdentityUsage::CHAT_LOBBY_MSG_VALIDATION:             // Chat lobby msgs are signed, so each time one comes, or a chat lobby event comes, a signature verificaiton happens.
@@ -2207,9 +2206,8 @@ void IdDialog::handleSerializedGroupData(uint32_t token)
 
     QList<RetroShareLink> urls ;
 
-    RetroShareLink link ;
-    link.createIdentity(gxs_id,QString::fromUtf8(details.mNickname.c_str()),QString::fromStdString(radix)) ;
-    urls.push_back(link);
+	RetroShareLink link = RetroShareLink::createIdentity(gxs_id,QString::fromUtf8(details.mNickname.c_str()),QString::fromStdString(radix)) ;
+	urls.push_back(link);
 
 	RSLinkClipboard::copyLinks(urls) ;
 

--- a/retroshare-gui/src/gui/NetworkDialog.cpp
+++ b/retroshare-gui/src/gui/NetworkDialog.cpp
@@ -323,8 +323,8 @@ void NetworkDialog::copyLink()
     RsPgpId peer_id ( wi->text(COLUMN_PEERID).toStdString() ) ;
 
 	QList<RetroShareLink> urls;
-	RetroShareLink link;
-	if (link.createPerson(peer_id)) {
+	RetroShareLink link = RetroShareLink::createPerson(peer_id);
+	if (link.valid()) {
 		urls.push_back(link);
 	}
 

--- a/retroshare-gui/src/gui/RetroShareLink.cpp
+++ b/retroshare-gui/src/gui/RetroShareLink.cpp
@@ -352,211 +352,235 @@ RetroShareLink::RetroShareLink()
 	clear();
 }
 
-bool RetroShareLink::createIdentity(const RsGxsId& id, const QString& name, const QString& radix_data)
+RetroShareLink RetroShareLink::createIdentity(const RsGxsId& id, const QString& name, const QString& radix_data)
 {
-	clear();
+	RetroShareLink link;
+	link.clear();
 
-	_name = name;
-	_hash = QString::fromStdString(id.toStdString());
-    _radix_group_data = radix_data ;
+	link._name = name;
+	link._hash = QString::fromStdString(id.toStdString());
+	link._radix_group_data = radix_data ;
 
-	_type = TYPE_IDENTITY;
+	link._type = TYPE_IDENTITY;
 
-	check();
+	link.check();
 
-	return valid();
+	return link;
 }
 
-bool RetroShareLink::createExtraFile(const QString& name, uint64_t size, const QString& hash,const QString& ssl_id)
+RetroShareLink RetroShareLink::createExtraFile(const QString& name, uint64_t size, const QString& hash,const QString& ssl_id)
 {
-	clear();
+	RetroShareLink link;
+	link.clear();
 
-	_name = name;
-	_size = size;
-	_hash = hash;
-	_SSLid = ssl_id;
+	link._name = name;
+	link._size = size;
+	link._hash = hash;
+	link._SSLid = ssl_id;
 
-	_type = TYPE_EXTRAFILE;
+	link._type = TYPE_EXTRAFILE;
 
-	check();
+	link.check();
 
-	return valid();
-}
-bool RetroShareLink::createFile(const QString& name, uint64_t size, const QString& hash)
-{
-	clear();
-
-	_name = name;
-	_size = size;
-	_hash = hash;
-
-	_type = TYPE_FILE;
-
-	check();
-
-	return valid();
+	return link;
 }
 
-bool RetroShareLink::createPublicMsgInvite(time_t time_stamp,const QString& issuer_pgp_id,const QString& hash) 
+RetroShareLink RetroShareLink::createFile(const QString& name, uint64_t size, const QString& hash)
 {
-	clear() ;
+	RetroShareLink link;
+	link.clear();
 
-	_type = TYPE_PUBLIC_MSG ;
-	_time_stamp = time_stamp ;
-	_hash = hash ;
-	_GPGid = issuer_pgp_id ;
+	link._name = name;
+	link._size = size;
+	link._hash = hash;
 
-	check() ;
+	link._type = TYPE_FILE;
 
-	return valid() ;
+	link.check();
+
+	return link;
 }
 
-bool RetroShareLink::createPerson(const RsPgpId& id)
+RetroShareLink RetroShareLink::createPublicMsgInvite(time_t time_stamp,const QString& issuer_pgp_id,const QString& hash)
 {
-	clear();
+	RetroShareLink link;
+	link.clear() ;
+
+	link._type = TYPE_PUBLIC_MSG ;
+	link._time_stamp = time_stamp ;
+	link._hash = hash ;
+	link._GPGid = issuer_pgp_id ;
+
+	link.check() ;
+
+	return link;
+}
+
+RetroShareLink RetroShareLink::createPerson(const RsPgpId& id)
+{
+	RetroShareLink link;
+	link.clear();
 
 	RsPeerDetails detail;
 	if (rsPeers->getGPGDetails(id, detail) == false) {
 		std::cerr << "RetroShareLink::createPerson() Couldn't find peer id " << id << std::endl;
-		return false;
+	} else {
+
+		link._hash = QString::fromStdString(id.toStdString());
+		link._name = QString::fromUtf8(detail.name.c_str());
+
+		link._type = TYPE_PERSON;
 	}
 
-	_hash = QString::fromStdString(id.toStdString());
-	_name = QString::fromUtf8(detail.name.c_str());
+	link.check();
 
-	_type = TYPE_PERSON;
-
-	check();
-
-	return valid();
+	return link;
 }
 
-bool RetroShareLink::createCertificate(const RsPeerId& ssl_id)
+RetroShareLink RetroShareLink::createCertificate(const RsPeerId& ssl_id)
 {
-	// This is baaaaaad code:
+	RetroShareLink link;
+	link.clear();
+
+#warning csoler 2012-08-14: This is baaaaaad code:
 	// 	- we should not need to parse and re-read a cert in old format.
 	//
 	RsPeerDetails detail;
 	if (rsPeers->getPeerDetails(ssl_id, detail) == false) {
 		std::cerr << "RetroShareLink::createPerson() Couldn't find peer id " << ssl_id << std::endl;
-		return false;
+	} else {
+
+		link._type = TYPE_CERTIFICATE;
+		link._radix = QString::fromUtf8(rsPeers->GetRetroshareInvite(ssl_id,false).c_str());
+		link._name = QString::fromUtf8(detail.name.c_str());
+		link._location = QString::fromUtf8(detail.location.c_str());
+		link._radix.replace("\n","");
+
+		std::cerr << "Found radix                = " << link._radix.toStdString() << std::endl;
 	}
 
-	_type = TYPE_CERTIFICATE;
-	_radix = QString::fromUtf8(rsPeers->GetRetroshareInvite(ssl_id,false).c_str());
-	_name = QString::fromUtf8(detail.name.c_str());
-	_location = QString::fromUtf8(detail.location.c_str());
-	_radix.replace("\n","");
+	link.check();
 
-	std::cerr << "Found radix                = " << _radix.toStdString() << std::endl;
-
-	return true;
+	return link;
 }
 
-bool RetroShareLink::createUnknwonSslCertificate(const RsPeerId& sslId, const RsPgpId& gpgId)
+RetroShareLink RetroShareLink::createUnknwonSslCertificate(const RsPeerId& sslId, const RsPgpId& gpgId)
 {
+	RetroShareLink link;
+	link.clear();
+
 	// first try ssl id
-	if (createCertificate(sslId)) {
-		if (gpgId.isNull() || _GPGid.toStdString() == gpgId.toStdString()) {
-			return true;
+	link = createCertificate(sslId);
+	if (link.valid()) {
+		if (gpgId.isNull() || link._GPGid.toStdString() == gpgId.toStdString()) {
+			return link;
 		}
 		// wrong gpg id
-		return false;
+		link.clear();
+		return link;
 	}
 
 	// then gpg id
-	if (createPerson(gpgId)) {
-		if (!_SSLid.isEmpty()) {
-			return false;
+	link = createPerson(gpgId);
+	if (link.valid()) {
+		if (!link._SSLid.isEmpty()) {
+			link.clear();
+			return link;
 		}
 		if (sslId.isNull()) {
-			return true;
+			link.check();
+			return link;
 		}
-		_SSLid = QString::fromStdString(sslId.toStdString());
-		if (_location.isEmpty()) {
-			_location = _name;
+		link._SSLid = QString::fromStdString(sslId.toStdString());
+		if (link._location.isEmpty()) {
+			link._location = link._name;
 		}
-		return true;
+		link.check();
+		return link;
 	}
 
-	return false;
+	link.clear();
+	return link;
 }
 
-bool RetroShareLink::createGxsGroupLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const QString &groupName)
+RetroShareLink RetroShareLink::createGxsGroupLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const QString &groupName)
 {
-	clear();
+	RetroShareLink link;
+	link.clear();
 
 	if (!groupId.isNull()) {
-		_hash = QString::fromStdString(groupId.toStdString());
-		_type = linkType;
-		_name = groupName;
+		link._hash = QString::fromStdString(groupId.toStdString());
+		link._type = linkType;
+		link._name = groupName;
 	}
 
-	check();
+	link.check();
 
-	return valid();
+	return link;
 }
 
-bool RetroShareLink::createGxsMessageLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const RsGxsMessageId &msgId, const QString &msgName)
+RetroShareLink RetroShareLink::createGxsMessageLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const RsGxsMessageId &msgId, const QString &msgName)
 {
-	clear();
+	RetroShareLink link;
+	link.clear();
 
 	if (!groupId.isNull() && !msgId.isNull()) {
-		_hash = QString::fromStdString(groupId.toStdString());
-		_msgId = QString::fromStdString(msgId.toStdString());
-		_type = linkType;
-		_name = msgName;
+		link._hash = QString::fromStdString(groupId.toStdString());
+		link._msgId = QString::fromStdString(msgId.toStdString());
+		link._type = linkType;
+		link._name = msgName;
 	}
 
-	check();
+	link.check();
 
-	return valid();
+	return link;
 }
 
-bool RetroShareLink::createSearch(const QString& keywords)
+RetroShareLink RetroShareLink::createSearch(const QString& keywords)
 {
-	clear();
+	RetroShareLink link;
+	link.clear();
 
-	_name = keywords;
+	link._name = keywords;
 
-	_type = TYPE_SEARCH;
+	link._type = TYPE_SEARCH;
 
-	check();
+	link.check();
 
-	return valid();
+	return link;
 }
 
-bool RetroShareLink::createMessage(const RsPeerId& peerId, const QString& subject)
+RetroShareLink RetroShareLink::createMessage(const RsPeerId& peerId, const QString& subject)
 {
-	clear();
+	RetroShareLink link;
+	link.clear();
 
-	_hash = QString::fromStdString(peerId.toStdString());
-	PeerDefs::rsidFromId(peerId, &_name);
-	_subject = subject;
+	link._hash = QString::fromStdString(peerId.toStdString());
+	PeerDefs::rsidFromId(peerId, &link._name);
+	link._subject = subject;
 
-	_type = TYPE_MESSAGE;
+	link._type = TYPE_MESSAGE;
 
-	check();
+	link.check();
 
-	return valid();
+	return link;
 }
-bool RetroShareLink::createMessage(const RsGxsId& peerId, const QString& subject)
+RetroShareLink RetroShareLink::createMessage(const RsGxsId& peerId, const QString& subject)
 {
-	clear();
+	RetroShareLink link;
+	link.clear();
 
-	_hash = QString::fromStdString(peerId.toStdString());
+	link._hash = QString::fromStdString(peerId.toStdString());
+	PeerDefs::rsidFromId(peerId, &link._name);
+	link._subject = subject;
 
-	PeerDefs::rsidFromId(peerId, &_name);
-	//_name = QString::fromStdString("GXS_id("+peerId.toStdString()+")") ;
-	// do something better here!!
-	_subject = subject;
+	link._type = TYPE_MESSAGE;
 
-	_type = TYPE_MESSAGE;
+	link.check();
 
-	check();
-
-	return valid();
+	return link;
 }
+
 void RetroShareLink::clear()
 {
 	_valid = false;
@@ -1639,6 +1663,8 @@ static void processList(const QStringList &list, const QString &textSingular, co
 
 	return process(links, flag);
 }
+
+/**** RSLinkClipboard ********************************************/
 
 void RSLinkClipboard::copyLinks(const QList<RetroShareLink>& links)
 {

--- a/retroshare-gui/src/gui/RetroShareLink.h
+++ b/retroshare-gui/src/gui/RetroShareLink.h
@@ -77,19 +77,18 @@ class RetroShareLink
 		RetroShareLink(const QUrl& url);
 		RetroShareLink(const QString& url);
 
-#warning csoler 2017-01-04: These methods should be static and return a created link
-		bool createFile(const QString& name, uint64_t size, const QString& hash);
-		bool createExtraFile(const QString& name, uint64_t size, const QString& hash, const QString& ssl_id);
-		bool createPerson(const RsPgpId &id);
-		bool createGxsGroupLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const QString &groupName);
-		bool createGxsMessageLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const RsGxsMessageId &msgId, const QString &msgName);
-		bool createSearch(const QString& keywords);
-		bool createMessage(const RsPeerId &peerId, const QString& subject);
-		bool createMessage(const RsGxsId &peerId, const QString& subject);
-		bool createIdentity(const RsGxsId& gxs_id,const QString& name,const QString& radix_data) ;
-		bool createCertificate(const RsPeerId &ssl_id) ;
-		bool createPublicMsgInvite(time_t time_stamp,const QString& pgp_id,const QString& hash) ;
-		bool createUnknwonSslCertificate(const RsPeerId &sslId, const RsPgpId &gpgId = RsPgpId()) ;
+		static RetroShareLink createIdentity(const RsGxsId& gxs_id,const QString& name,const QString& radix_data) ;
+		static RetroShareLink createExtraFile(const QString& name, uint64_t size, const QString& hash, const QString& ssl_id);
+		static RetroShareLink createFile(const QString& name, uint64_t size, const QString& hash);
+		static RetroShareLink createPublicMsgInvite(time_t time_stamp,const QString& pgp_id,const QString& hash) ;
+		static RetroShareLink createPerson(const RsPgpId &id);
+		static RetroShareLink createCertificate(const RsPeerId &ssl_id) ;
+		static RetroShareLink createUnknwonSslCertificate(const RsPeerId &sslId, const RsPgpId &gpgId = RsPgpId()) ;
+		static RetroShareLink createGxsGroupLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const QString &groupName);
+		static RetroShareLink createGxsMessageLink(const RetroShareLink::enumType &linkType, const RsGxsGroupId &groupId, const RsGxsMessageId &msgId, const QString &msgName);
+		static RetroShareLink createSearch(const QString& keywords);
+		static RetroShareLink createMessage(const RsPeerId &peerId, const QString& subject);
+		static RetroShareLink createMessage(const RsGxsId &peerId, const QString& subject);
 
 		enumType type() const {return _type; }
 		uint64_t size() const { return _size ; }

--- a/retroshare-gui/src/gui/SharedFilesDialog.cpp
+++ b/retroshare-gui/src/gui/SharedFilesDialog.cpp
@@ -609,8 +609,8 @@ void SharedFilesDialog::copyLink (const QModelIndexList& lst, bool remote)
                     continue;
                 }
 
-                RetroShareLink link;
-                if (link.createFile(QString::fromUtf8(details.name.c_str()), details.count, details.hash.toStdString().c_str())) {
+                RetroShareLink link = RetroShareLink::createFile(QString::fromUtf8(details.name.c_str()), details.count, details.hash.toStdString().c_str());
+                if (link.valid()) {
                     urls.push_back(link) ;
                 }
             }
@@ -622,8 +622,8 @@ void SharedFilesDialog::copyLink (const QModelIndexList& lst, bool remote)
 				has_unhashed_files = true;
 				continue;
 			}
-            RetroShareLink link;
-            if (link.createFile(QString::fromUtf8(details.name.c_str()), details.count, details.hash.toStdString().c_str())) {
+            RetroShareLink link = RetroShareLink::createFile(QString::fromUtf8(details.name.c_str()), details.count, details.hash.toStdString().c_str());
+            if (link.valid()) {
                 urls.push_back(link) ;
             }
         }

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -1556,14 +1556,14 @@ void ChatWidget::fileHashingFinished(QList<HashedFile> hashedFiles)
 	QList<HashedFile>::iterator it;
 	for (it = hashedFiles.begin(); it != hashedFiles.end(); ++it) {
 		HashedFile& hashedFile = *it;
-		QString ext = QFileInfo(hashedFile.filename).suffix();
+		//QString ext = QFileInfo(hashedFile.filename).suffix();
 
 		RetroShareLink link;
 
 		if(mDefaultExtraFileFlags & RS_FILE_REQ_ANONYMOUS_ROUTING)
-            link.createFile(hashedFile.filename, hashedFile.size, QString::fromStdString(hashedFile.hash.toStdString()));
+			link = RetroShareLink::createFile(hashedFile.filename, hashedFile.size, QString::fromStdString(hashedFile.hash.toStdString()));
 		else
-            link.createExtraFile(hashedFile.filename, hashedFile.size, QString::fromStdString(hashedFile.hash.toStdString()),QString::fromStdString(rsPeers->getOwnId().toStdString()));
+			link = RetroShareLink::createExtraFile(hashedFile.filename, hashedFile.size, QString::fromStdString(hashedFile.hash.toStdString()),QString::fromStdString(rsPeers->getOwnId().toStdString()));
 
 		if (hashedFile.flag & HashedFile::Picture) {
 			message += QString("<img src=\"file:///%1\" width=\"100\" height=\"100\">").arg(hashedFile.filepath);
@@ -1575,6 +1575,7 @@ void ChatWidget::fileHashingFinished(QList<HashedFile> hashedFiles)
 			}
 		}
 		message += link.toHtmlSize();
+
 		if (it != hashedFiles.end()) {
 			message += "<BR>";
 		}

--- a/retroshare-gui/src/gui/common/FriendList.cpp
+++ b/retroshare-gui/src/gui/common/FriendList.cpp
@@ -1394,14 +1394,12 @@ void FriendList::copyFullCertificate()
 {
 	QTreeWidgetItem *c = getCurrentPeer();
 	QList<RetroShareLink> urls;
-    RetroShareLink link ;
-
-    link.createCertificate(RsPeerId(getRsId(c))) ;
+	RetroShareLink link = RetroShareLink::createCertificate(RsPeerId(getRsId(c)));
 	urls.push_back(link);
 
 	std::cerr << "link: " << std::endl;
-
 	std::cerr<< link.toString().toStdString() << std::endl;
+
 	RSLinkClipboard::copyLinks(urls);
 }
 

--- a/retroshare-gui/src/gui/common/MimeTextEdit.cpp
+++ b/retroshare-gui/src/gui/common/MimeTextEdit.cpp
@@ -271,10 +271,10 @@ void MimeTextEdit::pasteLink()
 
 void MimeTextEdit::pasteOwnCertificateLink()
 {
-	RetroShareLink link;
 	RsPeerId ownId = rsPeers->getOwnId();
+	RetroShareLink link = RetroShareLink::createCertificate(ownId);
 
-	if (link.createCertificate(ownId)) {
+	if (link.valid()) {
 		insertHtml(link.toHtml() + " ");
 	}
 }

--- a/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
+++ b/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
@@ -142,11 +142,9 @@ void ConfCertDialog::load()
       ui.headerFrame->setHeaderText(nameAndLocation);
 
 
-      RetroShareLink link;
-      link.createPerson(detail.gpg_id);
-
-      ui.pgpfingerprint->setText(link.toHtml());
-      ui.pgpfingerprint->setToolTip(link.title());
+	RetroShareLink link = RetroShareLink::createPerson(detail.gpg_id);
+	ui.pgpfingerprint->setText(link.toHtml());
+	ui.pgpfingerprint->setToolTip(link.title());
 
       ui.avatar->setId(ChatId(peerId));
 

--- a/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
+++ b/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
@@ -267,7 +267,7 @@ void PGPKeyDialog::load()
     RetroShareLink link ;
 
     for(std::list<RsPgpId>::const_iterator it(detail.gpgSigners.begin());it!=detail.gpgSigners.end();++it) {
-        link.createPerson(*it);
+        link = RetroShareLink::createPerson(*it);
         if (link.valid()) {
             text += link.toHtml() + "<BR>";
         }

--- a/retroshare-gui/src/gui/feeds/GxsChannelGroupItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsChannelGroupItem.cpp
@@ -127,8 +127,7 @@ void GxsChannelGroupItem::fill()
 	std::cerr << std::endl;
 #endif
 
-	RetroShareLink link;
-	link.createGxsGroupLink(RetroShareLink::TYPE_CHANNEL, mGroup.mMeta.mGroupId, groupName());
+	RetroShareLink link = RetroShareLink::createGxsGroupLink(RetroShareLink::TYPE_CHANNEL, mGroup.mMeta.mGroupId, groupName());
 	ui->nameLabel->setText(link.toHtml());
 
 	ui->descLabel->setText(QString::fromUtf8(mGroup.mDescription.c_str()));

--- a/retroshare-gui/src/gui/feeds/GxsChannelPostItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsChannelPostItem.cpp
@@ -398,13 +398,11 @@ void GxsChannelPostItem::fill()
 		}
 
 		title = tr("Channel Feed") + ": ";
-		RetroShareLink link;
-		link.createGxsGroupLink(RetroShareLink::TYPE_CHANNEL, mPost.mMeta.mGroupId, groupName());
+		RetroShareLink link = RetroShareLink::createGxsGroupLink(RetroShareLink::TYPE_CHANNEL, mPost.mMeta.mGroupId, groupName());
 		title += link.toHtml();
 		ui->titleLabel->setText(title);
 
-		RetroShareLink msgLink;
-		msgLink.createGxsMessageLink(RetroShareLink::TYPE_CHANNEL, mPost.mMeta.mGroupId, mPost.mMeta.mMsgId, messageName());
+		RetroShareLink msgLink = RetroShareLink::createGxsMessageLink(RetroShareLink::TYPE_CHANNEL, mPost.mMeta.mGroupId, mPost.mMeta.mMsgId, messageName());
 		ui->subjectLabel->setText(msgLink.toHtml());
 
 		if (IS_GROUP_SUBSCRIBED(mGroup.mMeta.mSubscribeFlags) || IS_GROUP_ADMIN(mGroup.mMeta.mSubscribeFlags))

--- a/retroshare-gui/src/gui/feeds/GxsForumGroupItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsForumGroupItem.cpp
@@ -127,8 +127,7 @@ void GxsForumGroupItem::fill()
 	std::cerr << std::endl;
 #endif
 
-	RetroShareLink link;
-	link.createGxsGroupLink(RetroShareLink::TYPE_FORUM, mGroup.mMeta.mGroupId, groupName());
+	RetroShareLink link = RetroShareLink::createGxsGroupLink(RetroShareLink::TYPE_FORUM, mGroup.mMeta.mGroupId, groupName());
 	ui->nameLabel->setText(link.toHtml());
 
 	ui->descLabel->setText(QString::fromUtf8(mGroup.mDescription.c_str()));

--- a/retroshare-gui/src/gui/feeds/GxsForumMsgItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsForumMsgItem.cpp
@@ -271,8 +271,7 @@ void GxsForumMsgItem::fill()
 	}
 
 	QString title = tr("Forum Feed") + ": ";
-	RetroShareLink link;
-	link.createGxsGroupLink(RetroShareLink::TYPE_FORUM, mMessage.mMeta.mGroupId, groupName());
+	RetroShareLink link = RetroShareLink::createGxsGroupLink(RetroShareLink::TYPE_FORUM, mMessage.mMeta.mGroupId, groupName());
 	title += link.toHtml();
 	ui->titleLabel->setText(title);
 
@@ -310,8 +309,7 @@ void GxsForumMsgItem::fill()
 //		nameLabel->setText(tr("Anonymous"));
 //	}
 
-	RetroShareLink msgLink;
-	msgLink.createGxsMessageLink(RetroShareLink::TYPE_FORUM, mMessage.mMeta.mGroupId, mMessage.mMeta.mMsgId, messageName());
+	RetroShareLink msgLink = RetroShareLink::createGxsMessageLink(RetroShareLink::TYPE_FORUM, mMessage.mMeta.mGroupId, mMessage.mMeta.mMsgId, messageName());
 	ui->subLabel->setText(msgLink.toHtml());
 	if (wasExpanded() || ui->expandFrame->isVisible()) {
 		fillExpandFrame();
@@ -324,8 +322,7 @@ void GxsForumMsgItem::fill()
 	} else {
 //		ui->parentAvatar->setId(msgParent.srcId, true);
 
-		RetroShareLink linkParent;
-		linkParent.createGxsMessageLink(RetroShareLink::TYPE_FORUM, mParentMessage.mMeta.mGroupId, mParentMessage.mMeta.mMsgId, QString::fromUtf8(mParentMessage.mMeta.mMsgName.c_str()));
+		RetroShareLink linkParent = RetroShareLink::createGxsMessageLink(RetroShareLink::TYPE_FORUM, mParentMessage.mMeta.mGroupId, mParentMessage.mMeta.mMsgId, QString::fromUtf8(mParentMessage.mMeta.mMsgName.c_str()));
 		ui->parentSubLabel->setText(linkParent.toHtml());
 		ui->parentMsgLabel->setText(RsHtml().formatText(NULL, QString::fromUtf8(mParentMessage.mMsg.c_str()), RSHTML_FORMATTEXT_EMBED_SMILEYS | RSHTML_FORMATTEXT_EMBED_LINKS));
 

--- a/retroshare-gui/src/gui/feeds/PostedGroupItem.cpp
+++ b/retroshare-gui/src/gui/feeds/PostedGroupItem.cpp
@@ -130,9 +130,8 @@ void PostedGroupItem::fill()
 #endif
 
 	// No link type at this moment
-    RetroShareLink link;
-    link.createGxsGroupLink(RetroShareLink::TYPE_POSTED, mGroup.mMeta.mGroupId, groupName());
-    ui->nameLabel->setText(link.toHtml());
+	RetroShareLink link = RetroShareLink::createGxsGroupLink(RetroShareLink::TYPE_POSTED, mGroup.mMeta.mGroupId, groupName());
+	ui->nameLabel->setText(link.toHtml());
 //	ui->nameLabel->setText(groupName());
 
 	ui->descLabel->setText(QString::fromUtf8(mGroup.mDescription.c_str()));

--- a/retroshare-gui/src/gui/feeds/SubFileItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SubFileItem.cpp
@@ -727,8 +727,8 @@ void SubFileItem::copyLink()
 		return;
 	}
 
-	RetroShareLink link;
-    if (link.createFile(QString::fromUtf8(mFileName.c_str()), mFileSize, QString::fromStdString(mFileHash.toStdString()))) {
+	RetroShareLink link = RetroShareLink::createFile(QString::fromUtf8(mFileName.c_str()), mFileSize, QString::fromStdString(mFileHash.toStdString()));
+	if (link.valid()) {
 		QList<RetroShareLink> urls;
 		urls.push_back(link);
 		RSLinkClipboard::copyLinks(urls);

--- a/retroshare-gui/src/gui/gxs/GxsFeedItem.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsFeedItem.cpp
@@ -81,8 +81,8 @@ void GxsFeedItem::copyMessageLink()
 		return;
 	}
 
-	RetroShareLink link;
-	if (link.createGxsMessageLink(getLinkType(), groupId(), mMessageId, messageName())) {
+	RetroShareLink link = RetroShareLink::createGxsMessageLink(getLinkType(), groupId(), mMessageId, messageName());
+	if (link.valid()) {
 		QList<RetroShareLink> urls;
 		urls.push_back(link);
 		RSLinkClipboard::copyLinks(urls);

--- a/retroshare-gui/src/gui/gxs/GxsGroupFeedItem.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFeedItem.cpp
@@ -155,8 +155,8 @@ void GxsGroupFeedItem::copyGroupLink()
 		return;
 	}
 
-	RetroShareLink link;
-	if (link.createGxsGroupLink(getLinkType(), mGroupId, groupName())) {
+	RetroShareLink link = RetroShareLink::createGxsGroupLink(getLinkType(), mGroupId, groupName());
+	if (link.valid()) {
 		QList<RetroShareLink> urls;
 		urls.push_back(link);
 		RSLinkClipboard::copyLinks(urls);

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
@@ -480,12 +480,12 @@ void GxsGroupFrameDialog::copyGroupLink()
 		return;
 	}
 
-	RetroShareLink link;
-
 	QString name;
 	if(!getCurrentGroupName(name)) return;
 
-	if (link.createGxsGroupLink(getLinkType(), mGroupId, name)) {
+	RetroShareLink link = RetroShareLink::createGxsGroupLink(getLinkType(), mGroupId, name);
+
+	if (link.valid()) {
 		QList<RetroShareLink> urls;
 		urls.push_back(link);
 		RSLinkClipboard::copyLinks(urls);

--- a/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
+++ b/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
@@ -498,9 +498,9 @@ void CreateGxsForumMsg::fileHashingFinished(QList<HashedFile> hashedFiles)
 	QList<HashedFile>::iterator it;
 	for (it = hashedFiles.begin(); it != hashedFiles.end(); ++it) {
 		HashedFile& hashedFile = *it;
-		RetroShareLink link;
-                if (link.createFile(hashedFile.filename, hashedFile.size,
-                                    QString::fromStdString(hashedFile.hash.toStdString()))) {
+		RetroShareLink link = RetroShareLink::createFile(hashedFile.filename, hashedFile.size,
+		                                                 QString::fromStdString(hashedFile.hash.toStdString()));
+		if (link.valid()) {
 			mesgString += link.toHtmlSize() + "<br>";
 		}
 	}

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -2018,12 +2018,13 @@ void GxsForumThreadWidget::copyMessageLink()
 		return;
 	}
 
-	RetroShareLink link;
-    QTreeWidgetItem *item = ui->threadTreeWidget->currentItem();
+	QTreeWidgetItem *item = ui->threadTreeWidget->currentItem();
 
-    QString thread_title = (item != NULL)?item->text(COLUMN_THREAD_TITLE):QString() ;
+	QString thread_title = (item != NULL)?item->text(COLUMN_THREAD_TITLE):QString() ;
 
-    if (link.createGxsMessageLink(RetroShareLink::TYPE_FORUM, groupId(), mThreadId, thread_title)) {
+	RetroShareLink link = RetroShareLink::createGxsMessageLink(RetroShareLink::TYPE_FORUM, groupId(), mThreadId, thread_title);
+
+	if (link.valid()) {
 		QList<RetroShareLink> urls;
 		urls.push_back(link);
 		RSLinkClipboard::copyLinks(urls);
@@ -2068,8 +2069,7 @@ void GxsForumThreadWidget::createthread()
 
 static QString buildReplyHeader(const RsMsgMetaData &meta)
 {
-	RetroShareLink link;
-	link.createMessage(meta.mAuthorId, "");
+	RetroShareLink link = RetroShareLink::createMessage(meta.mAuthorId, "");
 	QString from = link.toHtml();
 
 	QString header = QString("<span>-----%1-----").arg(QApplication::translate("GxsForumThreadWidget", "Original Message"));

--- a/retroshare-gui/src/gui/msgs/MessageComposer.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageComposer.cpp
@@ -521,8 +521,8 @@ static QString buildRecommendHtml(const std::set<RsPeerId> &sslIds, const RsPeer
         if (*sslIt == excludeId) {
             continue;
         }
-        RetroShareLink link;
-        if (link.createCertificate(*sslIt)) {
+        RetroShareLink link = RetroShareLink::createCertificate(*sslIt);
+        if (link.valid()) {
             text += link.toHtml() + "<br>";
         }
     }
@@ -558,8 +558,7 @@ void MessageComposer::recommendFriend(const std::set <RsPeerId> &sslIds, const R
         composer->addRecipient(TO, to);
     }
     RsPgpId ownPgpId = rsPeers->getGPGOwnId();
-    RetroShareLink link;
-    link.createPerson(ownPgpId);
+    RetroShareLink link = RetroShareLink::createPerson(ownPgpId);
     
     QString sMsgText = msg.isEmpty() ? recommendMessage() : msg;
     sMsgText += "<br><br>";
@@ -595,8 +594,8 @@ void MessageComposer::sendConnectAttemptMsg(const RsPgpId &gpgId, const RsPeerId
         return;
     }
 
-    RetroShareLink link;
-    if (link.createUnknwonSslCertificate(sslId, gpgId) == false) {
+    RetroShareLink link = RetroShareLink::createUnknwonSslCertificate(sslId, gpgId);
+    if (link.valid() == false) {
         return;
     }
 
@@ -1053,44 +1052,52 @@ MessageComposer *MessageComposer::newMsg(const std::string &msgId /* = ""*/)
 
 QString MessageComposer::buildReplyHeader(const MessageInfo &msgInfo)
 {
-    RetroShareLink link;
-    link.createMessage(msgInfo.rspeerid_srcId, "");
+    RetroShareLink link = RetroShareLink::createMessage(msgInfo.rspeerid_srcId, "");
     QString from = link.toHtml();
 
     QString to;
     for ( std::set<RsPeerId>::const_iterator  it = msgInfo.rspeerid_msgto.begin(); it != msgInfo.rspeerid_msgto.end(); ++it)
-        if (link.createMessage(*it, ""))
+    {
+        link = RetroShareLink::createMessage(*it, "");
+        if (link.valid())
         {
             if (!to.isEmpty())
                 to += ", ";
 
             to += link.toHtml();
         }
+    }
     for ( std::set<RsGxsId>::const_iterator  it = msgInfo.rsgxsid_msgto.begin(); it != msgInfo.rsgxsid_msgto.end(); ++it)
-        if (link.createMessage(*it, ""))
+    {
+        link = RetroShareLink::createMessage(*it, "");
+        if (link.valid())
         {
             if (!to.isEmpty())
                 to += ", ";
 
             to += link.toHtml();
         }
-
+    }
 
     QString cc;
-    for (std::set<RsPeerId>::const_iterator it = msgInfo.rspeerid_msgcc.begin(); it != msgInfo.rspeerid_msgcc.end(); ++it)
-        if (link.createMessage(*it, "")) {
+    for (std::set<RsPeerId>::const_iterator it = msgInfo.rspeerid_msgcc.begin(); it != msgInfo.rspeerid_msgcc.end(); ++it) {
+        link = RetroShareLink::createMessage(*it, "");
+        if (link.valid()) {
             if (!cc.isEmpty()) {
                 cc += ", ";
             }
             cc += link.toHtml();
         }
-    for (std::set<RsGxsId>::const_iterator it = msgInfo.rsgxsid_msgcc.begin(); it != msgInfo.rsgxsid_msgcc.end(); ++it)
-        if (link.createMessage(*it, "")) {
+    }
+    for (std::set<RsGxsId>::const_iterator it = msgInfo.rsgxsid_msgcc.begin(); it != msgInfo.rsgxsid_msgcc.end(); ++it) {
+        link = RetroShareLink::createMessage(*it, "");
+        if (link.valid()) {
             if (!cc.isEmpty()) {
                 cc += ", ";
             }
             cc += link.toHtml();
         }
+    }
 
 
     QString header = QString("<span>-----%1-----").arg(tr("Original Message"));
@@ -2780,8 +2787,7 @@ void MessageComposer::sendInvite(const RsGxsId &to, const QString &/*msg*/, bool
 
 
     RsPeerId ownId = rsPeers->getOwnId();
-    RetroShareLink link;
-    link.createCertificate(ownId);
+    RetroShareLink link = RetroShareLink::createCertificate(ownId);
         
     QString sMsgText = inviteMessage();
     sMsgText += "<br><br>";

--- a/retroshare-gui/src/gui/msgs/MessageWidget.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageWidget.cpp
@@ -515,8 +515,16 @@ void MessageWidget::fill(const std::string &msgId)
 	RetroShareLink link;
 	QString text;
 
-    for(std::set<RsPeerId>::const_iterator pit = msgInfo.rspeerid_msgto.begin(); pit != msgInfo.rspeerid_msgto.end(); ++pit)  if (link.createMessage(*pit, ""))  text += link.toHtml() + "   ";
-    for(std::set<RsGxsId >::const_iterator pit = msgInfo.rsgxsid_msgto.begin(); pit != msgInfo.rsgxsid_msgto.end(); ++pit)  if (link.createMessage(*pit, ""))  text += link.toHtml() + "   ";
+	for(std::set<RsPeerId>::const_iterator pit = msgInfo.rspeerid_msgto.begin(); pit != msgInfo.rspeerid_msgto.end(); ++pit) {
+		link = RetroShareLink::createMessage(*pit, "");
+		if (link.valid())
+			text += link.toHtml() + "   ";
+	}
+	for(std::set<RsGxsId >::const_iterator pit = msgInfo.rsgxsid_msgto.begin(); pit != msgInfo.rsgxsid_msgto.end(); ++pit) {
+		link = RetroShareLink::createMessage(*pit, "");
+		if (link.valid())
+			text += link.toHtml() + "   ";
+	}
 
 	ui.toText->setText(text);
 
@@ -526,8 +534,16 @@ void MessageWidget::fill(const std::string &msgId)
 		ui.ccText->setVisible(true);
 
 		text.clear();
-        for(std::set<RsPeerId>::const_iterator pit = msgInfo.rspeerid_msgcc.begin(); pit != msgInfo.rspeerid_msgcc.end(); ++pit)  if (link.createMessage(*pit, ""))  text += link.toHtml() + "   ";
-        for(std::set<RsGxsId>::const_iterator pit = msgInfo.rsgxsid_msgcc.begin(); pit != msgInfo.rsgxsid_msgcc.end(); ++pit)  if (link.createMessage(*pit, ""))  text += link.toHtml() + "   ";
+		for(std::set<RsPeerId>::const_iterator pit = msgInfo.rspeerid_msgcc.begin(); pit != msgInfo.rspeerid_msgcc.end(); ++pit) {
+			link = RetroShareLink::createMessage(*pit, "");
+			if (link.valid())
+				text += link.toHtml() + "   ";
+		}
+		for(std::set<RsGxsId>::const_iterator pit = msgInfo.rsgxsid_msgcc.begin(); pit != msgInfo.rsgxsid_msgcc.end(); ++pit) {
+			link = RetroShareLink::createMessage(*pit, "");
+			if (link.valid())
+				text += link.toHtml() + "   ";
+		}
 
 		ui.ccText->setText(text);
 	} else {
@@ -536,14 +552,22 @@ void MessageWidget::fill(const std::string &msgId)
 		ui.ccText->clear();
 	}
 
-    if (!msgInfo.rspeerid_msgbcc.empty() || !msgInfo.rsgxsid_msgbcc.empty())
-    {
-        ui.bccLabel->setVisible(true);
-        ui.bccText->setVisible(true);
+	if (!msgInfo.rspeerid_msgbcc.empty() || !msgInfo.rsgxsid_msgbcc.empty())
+	{
+		ui.bccLabel->setVisible(true);
+		ui.bccText->setVisible(true);
 
-        text.clear();
-        for(std::set<RsPeerId>::const_iterator pit = msgInfo.rspeerid_msgbcc.begin(); pit != msgInfo.rspeerid_msgbcc.end(); ++pit)  if (link.createMessage(*pit, ""))  text += link.toHtml() + "   ";
-        for(std::set<RsGxsId>::const_iterator pit = msgInfo.rsgxsid_msgbcc.begin(); pit != msgInfo.rsgxsid_msgbcc.end(); ++pit)  if (link.createMessage(*pit, ""))  text += link.toHtml() + "   ";
+		text.clear();
+		for(std::set<RsPeerId>::const_iterator pit = msgInfo.rspeerid_msgbcc.begin(); pit != msgInfo.rspeerid_msgbcc.end(); ++pit) {
+			link = RetroShareLink::createMessage(*pit, "");
+			if (link.valid())
+				text += link.toHtml() + "   ";
+		}
+		for(std::set<RsGxsId>::const_iterator pit = msgInfo.rsgxsid_msgbcc.begin(); pit != msgInfo.rsgxsid_msgbcc.end(); ++pit) {
+			link = RetroShareLink::createMessage(*pit, "");
+			if (link.valid())
+				text += link.toHtml() + "   ";
+		}
 
 		ui.bccText->setText(text);
 	} else {

--- a/retroshare-gui/src/gui/settings/CryptoPage.cpp
+++ b/retroshare-gui/src/gui/settings/CryptoPage.cpp
@@ -102,10 +102,10 @@ CryptoPage::load()
 void
 CryptoPage::copyRSLink()
 {
-	RetroShareLink link ;
 	RsPeerId ownId = rsPeers->getOwnId() ;
+	RetroShareLink link = RetroShareLink::createCertificate(ownId);
 
-	if( link.createCertificate(ownId) )
+	if( link.valid() )
 	{
 		QList<RetroShareLink> urls ;
 


### PR DESCRIPTION
And remove this warning:
#warning csoler 2017-01-04: These methods should be static and return a created link
