### PR TITLE
Fic Gcc warnings:

### DIFF
--- a/libretroshare/src/file_sharing/p3filelists.cc
+++ b/libretroshare/src/file_sharing/p3filelists.cc
@@ -704,8 +704,10 @@ bool p3FileDatabase::convertPointerToEntryIndex(const void *p, EntryIndex& e, ui
 {
     // trust me, I can do this ;-)
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     e   = EntryIndex(  *reinterpret_cast<uint32_t*>(&p) & ENTRY_INDEX_BIT_MASK ) ;
     friend_index = (*reinterpret_cast<uint32_t*>(&p)) >> NB_ENTRY_INDEX_BITS ;
+#pragma GCC diagnostic pop
 
     if(friend_index == 0)
     {

--- a/libretroshare/src/serialiser/rstypeserializer.h
+++ b/libretroshare/src/serialiser/rstypeserializer.h
@@ -57,9 +57,11 @@
  * C++ dynamic dispatching that may have a noticeable impact on runtime
  * performances.
  */
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #define RS_REGISTER_SERIAL_MEMBER_TYPED(I, T) do {\
 	RsTypeSerializer::serial_process<T>(j, ctx, reinterpret_cast<T&>(I), #I);\
 	} while(0)
+#pragma GCC diagnostic pop
 
 /** @def RS_REGISTER_ITEM_TYPE(T)
  * Use this macro into `youritem.cc` only if you need to process members of

--- a/retroshare-gui/src/gui/advsearch/advancedsearchdialog.cpp
+++ b/retroshare-gui/src/gui/advsearch/advancedsearchdialog.cpp
@@ -128,7 +128,7 @@ RsRegularExpression::Expression * AdvancedSearchDialog::getRsExpr()
     
 
     // iterate through the items in elements and
-#warning Phenom (2017-07-21): I don't know if it is a real memLeak for wholeExpression. If not remove this warning and add a comment how it is deleted.
+#warning Phenom (2017-07-21): I don t know if it is a real memLeak for wholeExpression. If not remove this warning and add a comment how it is deleted.
     // cppcheck-suppress memleak
     for (int i = 1; i < expressions->size(); ++i) {
         // extract the expression information and compound it with the

--- a/retroshare-gui/src/gui/common/RsBanListToolButton.cpp
+++ b/retroshare-gui/src/gui/common/RsBanListToolButton.cpp
@@ -144,11 +144,12 @@ void RsBanListToolButton::applyIp()
 
 	uint32_t list_type;
 	switch (mList) {
-	case LIST_WHITELIST:
-		list_type = RSBANLIST_TYPE_WHITELIST;
+		case LIST_BLACKLIST:
+			list_type = RSBANLIST_TYPE_BLACKLIST;
 		break;
-	case LIST_BLACKLIST:
-		list_type = RSBANLIST_TYPE_BLACKLIST;
+		case LIST_WHITELIST:
+		default:
+			list_type = RSBANLIST_TYPE_WHITELIST;
 		break;
 	}
 
@@ -156,11 +157,12 @@ void RsBanListToolButton::applyIp()
 	bool changed = false;
 
 	switch (mMode) {
-	case MODE_ADD:
-		changed = rsBanList->addIpRange(addr, masked_bytes, list_type, "");
+		case MODE_REMOVE:
+			changed = rsBanList->removeIpRange(addr, masked_bytes, list_type);
 		break;
-	case MODE_REMOVE:
-		changed = rsBanList->removeIpRange(addr, masked_bytes, list_type);
+		case MODE_ADD:
+		default:
+			changed = rsBanList->addIpRange(addr, masked_bytes, list_type, "");
 		break;
 	}
 


### PR DESCRIPTION
/libretroshare/src/file_sharing/p3filelists.cc:-1: In static member
function ‘static bool p3FileDatabase::convertPointerToEntryIndex(const
void*, p3FileDatabase::EntryIndex&, uint32_t&)’:
/libretroshare/src/file_sharing/p3filelists.cc:624: warning:
dereferencing type-punned pointer will break strict-aliasing rules [-
Wstrict-aliasing]
     e   = EntryIndex(  *reinterpret_cast<uint32_t*>(&p) &
ENTRY_INDEX_BIT_MASK ) ;
/home/phenom/GIT/RetroShare/trunk/libretroshare/src/file_sharing/
p3filelists.cc:625: warning: dereferencing type-punned pointer will
break strict-aliasing rules [-Wstrict-aliasing]
     friend_index = (*reinterpret_cast<uint32_t*>(&p)) >>
NB_ENTRY_INDEX_BITS ;

/libretroshare/src/gxstrans/p3gxstransitems.h:29: In file included from
../../../trunk/libretroshare/src/gxstrans/p3gxstransitems.h:29:0,
/libretroshare/src/gxstrans/p3gxstransitems.cc:19: from ../../../trunk/
libretroshare/src/gxstrans/p3gxstransitems.cc:19:
/libretroshare/src/gxstrans/p3gxstransitems.cc:-1: In member function
‘virtual void
OutgoingRecord_deprecated::serial_process(RsGenericSerializer::SerializeJob,
RsGenericSerializer::SerializeContext&)’:
/libretroshare/src/serialiser/rstypeserializer.h:61: warning:
dereferencing type-punned pointer will break strict-aliasing rules [-
Wstrict-aliasing]
  RsTypeSerializer::serial_process<T>(j, ctx, reinterpret_cast<T&>(I),
#I);\

/libretroshare/src/gxstrans/p3gxstransitems.cc:51: in expansion of macro
‘RS_REGISTER_SERIAL_MEMBER_TYPED’
  RS_REGISTER_SERIAL_MEMBER_TYPED(clientService, uint16_t);
/libretroshare/src/gxstrans/p3gxstransitems.cc:-1: In member function
‘virtual void
OutgoingRecord::serial_process(RsGenericSerializer::SerializeJob,
RsGenericSerializer::SerializeContext&)’:
/libretroshare/src/serialiser/rstypeserializer.h:61: warning:
dereferencing type-punned pointer will break strict-aliasing rules [-
Wstrict-aliasing]
  RsTypeSerializer::serial_process<T>(j, ctx, reinterpret_cast<T&>(I),
#I);\

/libretroshare/src/gxstrans/p3gxstransitems.cc:65: in expansion of macro
‘RS_REGISTER_SERIAL_MEMBER_TYPED’
  RS_REGISTER_SERIAL_MEMBER_TYPED(clientService, uint16_t);
/retroshare-gui/src/gui/common/RsBanListToolButton.cpp:-1: In member
function ‘void RsBanListToolButton::applyIp()’:
/retroshare-gui/src/gui/common/RsBanListToolButton.cpp:163: warning:
‘list_type’ may be used uninitialized in this function [-Wmaybe-
uninitialized]
   changed = rsBanList->removeIpRange(addr, masked_bytes, list_type);