### PR TITLE
fix C++ comment to avoid compilation error (fix #983)

### DIFF
--- a/supportlibs/pegmarkdown/utility_functions.c
+++ b/supportlibs/pegmarkdown/utility_functions.c
@@ -26,7 +26,7 @@ element *reverse(element *list) {
     element *new = NULL;
     element *next = NULL;
 #warning Phenom (2017-07-21): I don't know if it is a real memLeak for new. If not remove this warning and add a comment how it is deleted.
-    // cppcheck-suppress memleak
+    /* cppcheck-suppress memleak */
     while (list != NULL) {
         next = list->next;
         new = cons(list, new);


### PR DESCRIPTION
After fixing the comment, compilation completed without any issues.

Related to issue #983