### PR TITLE
Changed prefixes and sufixes for starting with and ending with …

### DIFF
--- a/retroshare-gui/src/gui/settings/TransferPage.ui
+++ b/retroshare-gui/src/gui/settings/TransferPage.ui
@@ -126,7 +126,7 @@
         <item>
          <widget class="QCheckBox" name="suffixesIgnoreList_CB">
           <property name="text">
-           <string>ignore files with these suffixes:</string>
+           <string>Ignore files ending with... :</string>
           </property>
          </widget>
         </item>
@@ -144,7 +144,7 @@
         <item>
          <widget class="QCheckBox" name="prefixesIgnoreList_CB">
           <property name="text">
-           <string>ignore files with these prefixes:</string>
+           <string>ignore files starting with... :</string>
           </property>
          </widget>
         </item>

--- a/retroshare-gui/src/gui/settings/TransferPage.ui
+++ b/retroshare-gui/src/gui/settings/TransferPage.ui
@@ -126,7 +126,7 @@
         <item>
          <widget class="QCheckBox" name="suffixesIgnoreList_CB">
           <property name="text">
-           <string>Ignore files ending with :</string>
+           <string>Ignore files ending with:</string>
           </property>
          </widget>
         </item>
@@ -144,7 +144,7 @@
         <item>
          <widget class="QCheckBox" name="prefixesIgnoreList_CB">
           <property name="text">
-           <string>ignore files starting with :</string>
+           <string>ignore files starting with:</string>
           </property>
          </widget>
         </item>

--- a/retroshare-gui/src/gui/settings/TransferPage.ui
+++ b/retroshare-gui/src/gui/settings/TransferPage.ui
@@ -126,7 +126,7 @@
         <item>
          <widget class="QCheckBox" name="suffixesIgnoreList_CB">
           <property name="text">
-           <string>Ignore files ending with... :</string>
+           <string>Ignore files ending with :</string>
           </property>
          </widget>
         </item>
@@ -144,7 +144,7 @@
         <item>
          <widget class="QCheckBox" name="prefixesIgnoreList_CB">
           <property name="text">
-           <string>ignore files starting with... :</string>
+           <string>ignore files starting with :</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
On internet people use "starting with" and "ending with" instead of prefixes and sufixes, in literature is ok even on internet sometimes, but when you search for files or filter files you use the filter starting with and ending with, is not prefixes is wrong but less understandable in internet language talking about files.

I tested with 2 rs users and they understood how it works with this text.