### PR TITLE
Fix bug causing RS to crash at startup

### DIFF
--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -207,8 +207,9 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     connect(ui->listWidget, SIGNAL(currentRowChanged(int)), this, SLOT(setNewPage(int)));
     connect(ui->stackPages, SIGNAL(currentChanged(int)), this, SLOT(setNewPage(int)));
 
-    //ui->stackPages->setCurrentIndex(Settings->getLastPageInMainWindow());
-    setNewPage(Settings->getLastPageInMainWindow());
+	int lastpageindex = Settings->getLastPageInMainWindow();
+	if(lastpageindex < ui->stackPages->count())	//Do not crash when a page was removed after last run
+		setNewPage(lastpageindex);
 
     ui->splitter->setStretchFactor(0, 0);
     ui->splitter->setStretchFactor(1, 1);


### PR DESCRIPTION
Fix bug causing RS to crash at startup when some icons were removed from toolbar

For example: Have some plugin icons on toolbar, disable plugins, make sure that the last page is selected (Preferences), quit RS.