### PR TITLE
Part of the forum title is not displayed when it is enclosed in < >

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -231,6 +231,7 @@ GxsForumThreadWidget::GxsForumThreadWidget(const RsGxsGroupId &forumId, QWidget 
 	/* Set own item delegate */
 	RSElidedItemDelegate *itemDelegate = new RSElidedItemDelegate(this);
 	itemDelegate->setSpacing(QSize(0, 2));
+	itemDelegate->setOnlyPlainText(true);
 	ui->threadTreeWidget->setItemDelegate(itemDelegate);
 
 	/* Set header resize modes and initial section sizes */


### PR DESCRIPTION
RS may threat some parts of the forum title as html, and remove it before displaying in it on TreeWidget, but it is visible on the post forum message window.

Fix: display forum title as-is, without trying to interpret it as html.

To reproduce: make a forum title like this:
`somthing <ThisWillBeHidden> other thing`
