### PR TITLE
network cleanup: split unix/windows code

### DIFF
--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -553,7 +553,7 @@ SOURCES +=	ft/ftchunkmap.cc \
 			ft/ftfilesearch.cc \
 			ft/ftserver.cc \
 			ft/fttransfermodule.cc \
-			ft/ftturtlefiletransferitem.cc 
+                        ft/ftturtlefiletransferitem.cc
 
 SOURCES += crypto/chacha20.cpp \
 			  crypto/hashstream.cc
@@ -583,6 +583,8 @@ SOURCES +=	pqi/authgpg.cc \
 			pqi/pqiloopback.cc \
 			pqi/pqimonitor.cc \
 			pqi/pqinetwork.cc \
+                        pqi/pqinetwork_unix.cc \
+                        pqi/pqinetwork_win.cc \
 			pqi/pqiperson.cc \
 			pqi/pqipersongrp.cc \
 			pqi/pqiservice.cc \

--- a/libretroshare/src/pqi/pqinetwork.cc
+++ b/libretroshare/src/pqi/pqinetwork.cc
@@ -56,15 +56,6 @@ static struct RsLog::logInfo pqinetzoneInfo = {RsLog::Default, "pqinet"};
 
 #include <sys/types.h>
 
-struct pqinetworkOps {
-	bool	(*getLocalAddresses)(std::list<sockaddr_storage>&);
-	int	(*unix_close)(int);
-	int	(*unix_connect)(int);
-	int	(*unix_fcntl_nonblock)(int);
-	int	(*unix_getsockopt_error)(int, int*);
-	void	(*unix_socket)(int);
-};
-
 #ifdef WINDOWS_SYS
 // moved to pqinetwork_win.cc
 #elif defined(__ANDROID__)
@@ -102,7 +93,7 @@ bool getLocalAddresses(std::list<sockaddr_storage> & addrs)
 			addrs.push_back(tmpAddr);
 	}
 #else
-	ret = netOps.getLocalAddresses(addrs);
+	ret = _getLocalAddresses(addrs);
 
 	// the functions have internal checks that may result in "return false"
 	// handle it here
@@ -133,7 +124,7 @@ int unix_close(int fd)
 	std::cerr << "unix_close()" << std::endl;
 #endif
 
-	return netOps.unix_close(fd);
+	return _unix_close(fd);
 }
 
 int unix_socket(int domain, int type, int protocol)
@@ -144,14 +135,14 @@ int unix_socket(int domain, int type, int protocol)
 
 	int osock = socket(domain, type, protocol);
 
-	netOps.unix_socket(osock);
+	_unix_socket(osock);
 
 	return osock;
 }
 
 int unix_fcntl_nonblock(int fd)
 {
-	return netOps.unix_fcntl_nonblock(fd);
+	return _unix_fcntl_nonblock(fd);
 }
 
 int unix_connect(int fd, const struct sockaddr *serv_addr, socklen_t socklen)
@@ -185,7 +176,7 @@ int unix_connect(int fd, const struct sockaddr *serv_addr, socklen_t socklen)
 
 	int ret = connect(fd, serv_addr, len);
 
-	ret = netOps.unix_connect(ret);
+	ret = _unix_connect(ret);
 
 	return ret;
 }
@@ -194,5 +185,5 @@ int unix_getsockopt_error(int sockfd, int *err)
 {
 	*err = 1;
 
-	return netOps.unix_getsockopt_error(sockfd, err);
+	return _unix_getsockopt_error(sockfd, err);
 }

--- a/libretroshare/src/pqi/pqinetwork.cc
+++ b/libretroshare/src/pqi/pqinetwork.cc
@@ -23,6 +23,7 @@
  *
  */
 
+// is the order here impotant? otherwise this can be moved to pqinetwork_win.cc
 #ifdef WINDOWS_SYS
 #	include "util/rswin.h"
 #	include "util/rsmemory.h"
@@ -48,281 +49,51 @@ static struct RsLog::logInfo pqinetzoneInfo = {RsLog::Default, "pqinet"};
  * #define NET_DEBUG 1
  ****/
 
-#ifdef WINDOWS_SYS   /* Windows - define errno */
-
-int errno;
-
-#else /* Windows - define errno */
-
-#include <netdb.h>
-
-#endif               
-
 #ifdef __HAIKU__
  #include <sys/sockio.h>
  #define IFF_RUNNING 0x0001
 #endif
 
-/********************************** WINDOWS/UNIX SPECIFIC PART ******************/
-#ifndef WINDOWS_SYS
-
-void showSocketError(std::string &out)
-{
-	int err = errno;
-	rs_sprintf_append(out, "\tSocket Error(%d) : %s\n", err, socket_errorType(err).c_str());
-}
-
-std::string socket_errorType(int err)
-{
-	if (err == EBADF)
-	{
-		return std::string("EBADF");
-	}
-	else if (err == EINVAL)
-	{
-		return std::string("EINVAL");
-	}
-	else if (err == EFAULT)
-	{
-		return std::string("EFAULT");
-	}
-	else if (err == ENOTSOCK)
-	{
-		return std::string("ENOTSOCK");
-	}
-	else if (err == EISCONN)
-	{
-		return std::string("EISCONN");
-	}
-	else if (err == ECONNREFUSED)
-	{
-		return std::string("ECONNREFUSED");
-	}
-	else if (err == ETIMEDOUT)
-	{
-		return std::string("ETIMEDOUT");
-	}
-	else if (err == ENETUNREACH)
-	{
-		return std::string("ENETUNREACH");
-	}
-	else if (err == EADDRINUSE)
-	{
-		return std::string("EADDRINUSE");
-	}
-	else if (err == EINPROGRESS)
-	{
-		return std::string("EINPROGRESS");
-	}
-	else if (err == EALREADY)
-	{
-		return std::string("EALREADY");
-	}
-	else if (err == EAGAIN)
-	{
-		return std::string("EAGAIN");
-	}
-	else if (err == EISCONN)
-	{
-		return std::string("EISCONN");
-	}
-	else if (err == ENOTCONN)
-	{
-		return std::string("ENOTCONN");
-	}
-	// These ones have been turning up in SSL CONNECTION FAILURES.
-	else if (err == EPIPE)
-	{
-		return std::string("EPIPE");
-	}
-	else if (err == ECONNRESET)
-	{
-		return std::string("ECONNRESET");
-	}
-	else if (err == EHOSTUNREACH)
-	{
-		return std::string("EHOSTUNREACH");
-	}
-	else if (err == EADDRNOTAVAIL)
-	{
-		return std::string("EADDRNOTAVAIL");
-	}
-	//
-
-	return std::string("UNKNOWN ERROR CODE - ASK RS-DEVS TO ADD IT!");
-}
-
-/********************************** WINDOWS/UNIX SPECIFIC PART ******************/
-#else
-
-void showSocketError(std::string &out)
-{
-	int err = WSAGetLastError();
-	rs_sprintf_append(out, "\tSocket Error(%d) : %s\n", err, socket_errorType(err).c_str());
-}
-
-
-std::string socket_errorType(int err)
-{
-	if (err == WSAEBADF)
-	{
-		return std::string("WSABADF");
-	}
-
-
-	else if (err == WSAEINTR)
-	{
-		return std::string("WSAEINTR");
-	}
-	else if (err == WSAEACCES)
-	{
-		return std::string("WSAEACCES");
-	}
-	else if (err == WSAEFAULT)
-	{
-		return std::string("WSAEFAULT");
-	}
-	else if (err == WSAEINVAL)
-	{
-		return std::string("WSAEINVAL");
-	}
-	else if (err == WSAEMFILE)
-	{
-		return std::string("WSAEMFILE");
-	}
-	else if (err == WSAEWOULDBLOCK)
-	{
-		return std::string("WSAEWOULDBLOCK");
-	}
-	else if (err == WSAEINPROGRESS)
-	{
-		return std::string("WSAEINPROGRESS");
-	}
-	else if (err == WSAEALREADY)
-	{
-		return std::string("WSAEALREADY");
-	}
-	else if (err == WSAENOTSOCK)
-	{
-		return std::string("WSAENOTSOCK");
-	}
-	else if (err == WSAEDESTADDRREQ)
-	{
-		return std::string("WSAEDESTADDRREQ");
-	}
-	else if (err == WSAEMSGSIZE)
-	{
-		return std::string("WSAEMSGSIZE");
-	}
-	else if (err == WSAEPROTOTYPE)
-	{
-		return std::string("WSAEPROTOTYPE");
-	}
-	else if (err == WSAENOPROTOOPT)
-	{
-		return std::string("WSAENOPROTOOPT");
-	}
-	else if (err == WSAENOTSOCK)
-	{
-		return std::string("WSAENOTSOCK");
-	}
-	else if (err == WSAEISCONN)
-	{
-		return std::string("WSAISCONN");
-	}
-	else if (err == WSAECONNREFUSED)
-	{
-		return std::string("WSACONNREFUSED");
-	}
-	else if (err == WSAECONNRESET)
-	{
-		return std::string("WSACONNRESET");
-	}
-	else if (err == WSAETIMEDOUT)
-	{
-		return std::string("WSATIMEDOUT");
-	}
-	else if (err == WSAENETUNREACH)
-	{
-		return std::string("WSANETUNREACH");
-	}
-	else if (err == WSAEADDRINUSE)
-	{
-		return std::string("WSAADDRINUSE");
-	}
-	else if (err == WSAEAFNOSUPPORT)
-	{
-		return std::string("WSAEAFNOSUPPORT (normally UDP related!)");
-	}
-
-	return std::string("----WINDOWS OPERATING SYSTEM FAILURE----");
-}
-
-// implement the improved unix inet address fn.
-// using old one.
-int inet_aton(const char *name, struct in_addr *addr)
-{
-	return (((*addr).s_addr = inet_addr(name)) != INADDR_NONE);
-}
-
-#endif
-/********************************** WINDOWS/UNIX SPECIFIC PART ******************/
-
-
 #include <sys/types.h>
+
+struct pqinetworkOps {
+	bool	(*getLocalAddresses)(std::list<sockaddr_storage>&);
+	int	(*unix_close)(int);
+	int	(*unix_connect)(int);
+	int	(*unix_fcntl_nonblock)(int);
+	int	(*unix_getsockopt_error)(int, int*);
+	void	(*unix_socket)(int);
+};
+
 #ifdef WINDOWS_SYS
-#	include <winsock2.h>
-#	include <iphlpapi.h>
-#	pragma comment(lib, "IPHLPAPI.lib")
+// moved to pqinetwork_win.cc
 #elif defined(__ANDROID__)
 #	include <string>
 #	include <QString>
 #	include <QHostAddress>
 #	include <QNetworkInterface>
 #else // not __ANDROID__ nor WINDOWS => Linux and other unixes
-#	include <ifaddrs.h>
-#	include <net/if.h>
+// moved to pqinetwork_linux.cc
 #endif // WINDOWS_SYS
+
+/********************************** WINDOWS/UNIX SPECIFIC PART ******************/
+#ifndef WINDOWS_SYS
+#include "pqinetwork_unix.cc"
+/********************************** WINDOWS/UNIX SPECIFIC PART ******************/
+#else
+#include "pqinetwork_win.cc"
+#endif
+/********************************** WINDOWS/UNIX SPECIFIC PART ******************/
+
 
 bool getLocalAddresses(std::list<sockaddr_storage> & addrs)
 {
+	bool ret;
+
 	addrs.clear();
 
-#ifdef WINDOWS_SYS
-	// Seems strange to me but M$ documentation suggests to allocate this way...
-	DWORD bf_size = 16000;
-	IP_ADAPTER_ADDRESSES* adapter_addresses = (IP_ADAPTER_ADDRESSES*) rs_malloc(bf_size);
-    
-    	if(adapter_addresses == NULL)
-            return false ;
-        
-	DWORD error = GetAdaptersAddresses(AF_UNSPEC,
-									   GAA_FLAG_SKIP_MULTICAST |
-									   GAA_FLAG_SKIP_DNS_SERVER |
-									   GAA_FLAG_SKIP_FRIENDLY_NAME,
-									   NULL,
-									   adapter_addresses,
-									   &bf_size);
-	if (error != ERROR_SUCCESS)
-	{
-	   std::cerr << "FATAL ERROR: getLocalAddresses failed!" << std::endl;
-	   return false ;
-	}
-
-	IP_ADAPTER_ADDRESSES* adapter(NULL);
-	for(adapter = adapter_addresses; NULL != adapter; adapter = adapter->Next)
-	{
-		IP_ADAPTER_UNICAST_ADDRESS* address;
-		for ( address = adapter->FirstUnicastAddress; address; address = address->Next)
-		{
-			sockaddr_storage tmp;
-			sockaddr_storage_clear(tmp);
-			if (sockaddr_storage_copyip(tmp, * reinterpret_cast<sockaddr_storage*>(address->Address.lpSockaddr)))
-				addrs.push_back(tmp);
-		}
-	}
-	free(adapter_addresses);
-#elif defined(__ANDROID__)
+	// currently there is no dedicated netOps for android
+#ifdef __ANDROID__
 	foreach(QHostAddress qAddr, QNetworkInterface::allAddresses())
 	{
 		sockaddr_storage tmpAddr;
@@ -330,23 +101,14 @@ bool getLocalAddresses(std::list<sockaddr_storage> & addrs)
 		if(sockaddr_storage_ipv4_aton(tmpAddr, qAddr.toString().toStdString().c_str()))
 			addrs.push_back(tmpAddr);
 	}
-#else // not  WINDOWS_SYS not ANDROID => Linux and other unixes
-	struct ifaddrs *ifsaddrs, *ifa;
-	if(getifaddrs(&ifsaddrs) != 0) 
-	{
-	   std::cerr << "FATAL ERROR: getLocalAddresses failed!" << std::endl;
-	   return false ;
-	}
-	for ( ifa = ifsaddrs; ifa; ifa = ifa->ifa_next )
-		if ( ifa->ifa_addr && (ifa->ifa_flags & IFF_UP) )
-		{
-			sockaddr_storage tmp;
-			sockaddr_storage_clear(tmp);
-			if (sockaddr_storage_copyip(tmp, * reinterpret_cast<sockaddr_storage*>(ifa->ifa_addr)))
-				addrs.push_back(tmp);
-		}
-	freeifaddrs(ifsaddrs);
-#endif // WINDOWS_SYS
+#else
+	ret = netOps.getLocalAddresses(addrs);
+
+	// the functions have internal checks that may result in "return false"
+	// handle it here
+	if(!ret)
+		return false;
+#endif
 
 #ifdef NET_DEBUG
 	std::list<sockaddr_storage>::iterator it;
@@ -365,77 +127,32 @@ bool getLocalAddresses(std::list<sockaddr_storage> & addrs)
  * to get over the crapness of the windows.
  *
  */
-
 int unix_close(int fd)
 {
-	int ret;
-/******************* WINDOWS SPECIFIC PART ******************/
-#ifndef WINDOWS_SYS // ie UNIX
-	ret = close(fd);
-#else
-
 #ifdef NET_DEBUG
 	std::cerr << "unix_close()" << std::endl;
 #endif
-	ret = closesocket(fd);
-	/* translate error */
-#endif
-/******************* WINDOWS SPECIFIC PART ******************/
-	return ret;
+
+	return netOps.unix_close(fd);
 }
 
 int unix_socket(int domain, int type, int protocol)
 {
-	int osock = socket(domain, type, protocol);
-
-#ifdef WINDOWS_SYS
 #ifdef NET_DEBUG
 	std::cerr << "unix_socket()" << std::endl;
 #endif // NET_DEBUG
 
-	if ((unsigned) osock == INVALID_SOCKET)
-	{
-		// Invalidate socket Unix style.
-		osock = -1;
-		errno = WinToUnixError(WSAGetLastError());
-	}
-#endif // WINDOWS_SYS
+	int osock = socket(domain, type, protocol);
+
+	netOps.unix_socket(osock);
 
 	return osock;
 }
 
-
 int unix_fcntl_nonblock(int fd)
 {
-        int ret;
-
-/******************* WINDOWS SPECIFIC PART ******************/
-#ifndef WINDOWS_SYS // ie UNIX
-	ret = fcntl(fd, F_SETFL, O_NONBLOCK);
-
-#ifdef NET_DEBUG
-	std::cerr << "unix_fcntl_nonblock():" << ret << " errno:" << errno << std::endl;
-#endif
-
-#else
-	unsigned long int on = 1;
-	ret = ioctlsocket(fd, FIONBIO, &on);
-
-#ifdef NET_DEBUG
-	std::cerr << "unix_fcntl_nonblock()" << std::endl;
-#endif
-	if (ret != 0)
-	{
-		/* store unix-style error
-		 */
-		ret = -1;
-		errno = WinToUnixError(WSAGetLastError());
-	}
-#endif
-/******************* WINDOWS SPECIFIC PART ******************/
-	return ret;
+	return netOps.unix_fcntl_nonblock(fd);
 }
-
 
 int unix_connect(int fd, const struct sockaddr *serv_addr, socklen_t socklen)
 {
@@ -468,87 +185,14 @@ int unix_connect(int fd, const struct sockaddr *serv_addr, socklen_t socklen)
 
 	int ret = connect(fd, serv_addr, len);
 
-/******************* WINDOWS SPECIFIC PART ******************/
-#ifdef WINDOWS_SYS // WINDOWS
+	ret = netOps.unix_connect(ret);
 
-#ifdef NET_DEBUG
-	std::cerr << "unix_connect()" << std::endl;
-#endif
-	if (ret != 0)
-	{
-		errno = WinToUnixError(WSAGetLastError());
-		ret = -1;
-	}
-#endif
-/******************* WINDOWS SPECIFIC PART ******************/
 	return ret;
 }
-
 
 int unix_getsockopt_error(int sockfd, int *err)
 {
-	int ret;
 	*err = 1;
-/******************* WINDOWS SPECIFIC PART ******************/
-#ifndef WINDOWS_SYS // ie UNIX
-	socklen_t optlen = 4;
-	ret=getsockopt(sockfd, SOL_SOCKET, SO_ERROR, err, &optlen);
-#else // WINDOWS_SYS
-	int optlen = 4;
-	ret=getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char *) err, &optlen);
-	/* translate */
-#ifdef NET_DEBUG
-	std::cerr << "unix_getsockopt_error() returned: " << (int) err << std::endl;
-#endif
-	if (*err != 0)
-	{
-		*err = WinToUnixError(*err);
-	}
-#endif
-/******************* WINDOWS SPECIFIC PART ******************/
-	return ret;
+
+	return netOps.unix_getsockopt_error(sockfd, err);
 }
-
-/******************* WINDOWS SPECIFIC PART ******************/
-#ifdef WINDOWS_SYS // ie WINDOWS.
-
-int	WinToUnixError(int error)
-{
-#ifdef NET_DEBUG
-	std::cerr << "WinToUnixError(" << error << ")" << std::endl;
-#endif
-	switch(error)
-	{
-		case WSAEINPROGRESS:
-			return EINPROGRESS;
-			break;
-		case WSAEWOULDBLOCK:
-			return EINPROGRESS;
-			break;
-		case WSAENETUNREACH:
-			return ENETUNREACH;
-			break;
-		case WSAETIMEDOUT:
-			return ETIMEDOUT;
-			break;
-		case WSAEHOSTDOWN:
-			return EHOSTDOWN;
-			break;
-		case WSAECONNREFUSED:
-			return ECONNREFUSED;
-			break;
-		case WSAECONNRESET:
-			return ECONNRESET;
-			break;
-		default:
-#ifdef NET_DEBUG
-			std::cerr << "WinToUnixError(" << error << ") Code Unknown!";
-			std::cerr << std::endl;
-#endif
-			break;
-	}
-	return ECONNREFUSED; /* sensible default? */
-}
-
-#endif
-/******************* WINDOWS SPECIFIC PART ******************/

--- a/libretroshare/src/pqi/pqinetwork_unix.cc
+++ b/libretroshare/src/pqi/pqinetwork_unix.cc
@@ -89,7 +89,7 @@ std::string socket_errorType(int err)
 	return std::string("UNKNOWN ERROR CODE - ASK RS-DEVS TO ADD IT!");
 }
 
-bool getLocalAddresses_unix(std::list<sockaddr_storage> &addrs) {
+bool _getLocalAddresses(std::list<sockaddr_storage> &addrs) {
 	struct ifaddrs *ifsaddrs, *ifa;
 
 	if(getifaddrs(&ifsaddrs) != 0)
@@ -112,34 +112,25 @@ bool getLocalAddresses_unix(std::list<sockaddr_storage> &addrs) {
 	return true;
 }
 
-int unix_close_unix(int fd) {
+int _unix_close(int fd) {
 	return close(fd);
 }
 
-int unix_connect_unix(int ret) {
+int _unix_connect(int ret) {
 	// emtpy
 	return ret;
 }
 
-int unix_fcntl_nonblock_unix(int fd) {
+int _unix_fcntl_nonblock(int fd) {
 	return fcntl(fd, F_SETFL, O_NONBLOCK);
 }
 
-int unix_getsockopt_error_unix(int sockfd, int *err) {
+int _unix_getsockopt_error(int sockfd, int *err) {
 	socklen_t optlen = 4;
 	return getsockopt(sockfd, SOL_SOCKET, SO_ERROR, err, &optlen);
 }
 
-void unix_socket_unix(int fd)  {
+void _unix_socket(int fd)  {
 	// empty
 	(void) fd;
 }
-
-const struct pqinetworkOps netOps = {
-	.getLocalAddresses = getLocalAddresses_unix,
-	.unix_close = unix_close_unix,
-	.unix_connect = unix_connect_unix,
-	.unix_fcntl_nonblock = unix_fcntl_nonblock_unix,
-	.unix_getsockopt_error = unix_getsockopt_error_unix,
-	.unix_socket = unix_socket_unix
-};

--- a/libretroshare/src/pqi/pqinetwork_unix.cc
+++ b/libretroshare/src/pqi/pqinetwork_unix.cc
@@ -1,0 +1,145 @@
+#include <netdb.h>
+
+#include <ifaddrs.h>
+#include <net/if.h>
+
+void showSocketError(std::string &out)
+{
+	int err = errno;
+	rs_sprintf_append(out, "\tSocket Error(%d) : %s\n", err, socket_errorType(err).c_str());
+}
+
+std::string socket_errorType(int err)
+{
+	if (err == EBADF)
+	{
+		return std::string("EBADF");
+	}
+	else if (err == EINVAL)
+	{
+		return std::string("EINVAL");
+	}
+	else if (err == EFAULT)
+	{
+		return std::string("EFAULT");
+	}
+	else if (err == ENOTSOCK)
+	{
+		return std::string("ENOTSOCK");
+	}
+	else if (err == EISCONN)
+	{
+		return std::string("EISCONN");
+	}
+	else if (err == ECONNREFUSED)
+	{
+		return std::string("ECONNREFUSED");
+	}
+	else if (err == ETIMEDOUT)
+	{
+		return std::string("ETIMEDOUT");
+	}
+	else if (err == ENETUNREACH)
+	{
+		return std::string("ENETUNREACH");
+	}
+	else if (err == EADDRINUSE)
+	{
+		return std::string("EADDRINUSE");
+	}
+	else if (err == EINPROGRESS)
+	{
+		return std::string("EINPROGRESS");
+	}
+	else if (err == EALREADY)
+	{
+		return std::string("EALREADY");
+	}
+	else if (err == EAGAIN)
+	{
+		return std::string("EAGAIN");
+	}
+	else if (err == EISCONN)
+	{
+		return std::string("EISCONN");
+	}
+	else if (err == ENOTCONN)
+	{
+		return std::string("ENOTCONN");
+	}
+	// These ones have been turning up in SSL CONNECTION FAILURES.
+	else if (err == EPIPE)
+	{
+		return std::string("EPIPE");
+	}
+	else if (err == ECONNRESET)
+	{
+		return std::string("ECONNRESET");
+	}
+	else if (err == EHOSTUNREACH)
+	{
+		return std::string("EHOSTUNREACH");
+	}
+	else if (err == EADDRNOTAVAIL)
+	{
+		return std::string("EADDRNOTAVAIL");
+	}
+	//
+
+	return std::string("UNKNOWN ERROR CODE - ASK RS-DEVS TO ADD IT!");
+}
+
+bool getLocalAddresses_unix(std::list<sockaddr_storage> &addrs) {
+	struct ifaddrs *ifsaddrs, *ifa;
+
+	if(getifaddrs(&ifsaddrs) != 0)
+	{
+	   std::cerr << "FATAL ERROR: getLocalAddresses failed!" << std::endl;
+	   return false ;
+	}
+
+	for ( ifa = ifsaddrs; ifa; ifa = ifa->ifa_next ) {
+		if ( ifa->ifa_addr && (ifa->ifa_flags & IFF_UP) )
+		{
+			sockaddr_storage tmp;
+			sockaddr_storage_clear(tmp);
+			if (sockaddr_storage_copyip(tmp, * reinterpret_cast<sockaddr_storage*>(ifa->ifa_addr)))
+				addrs.push_back(tmp);
+		}
+	}
+
+	freeifaddrs(ifsaddrs);
+	return true;
+}
+
+int unix_close_unix(int fd) {
+	return close(fd);
+}
+
+int unix_connect_unix(int ret) {
+	// emtpy
+	return ret;
+}
+
+int unix_fcntl_nonblock_unix(int fd) {
+	return fcntl(fd, F_SETFL, O_NONBLOCK);
+}
+
+int unix_getsockopt_error_unix(int sockfd, int *err) {
+	socklen_t optlen = 4;
+	return getsockopt(sockfd, SOL_SOCKET, SO_ERROR, err, &optlen);
+}
+
+void unix_socket_unix(int fd)  {
+	// empty
+	(void) fd;
+}
+
+const struct pqinetworkOps netOps = {
+	.getLocalAddresses = getLocalAddresses_unix,
+	.unix_close = unix_close_unix,
+	.unix_connect = unix_connect_unix,
+	.unix_fcntl_nonblock = unix_fcntl_nonblock_unix,
+	.unix_getsockopt_error = unix_getsockopt_error_unix,
+	.unix_socket = unix_socket_unix
+};

--- a/libretroshare/src/pqi/pqinetwork_win.cc
+++ b/libretroshare/src/pqi/pqinetwork_win.cc
@@ -151,7 +151,7 @@ int	WinToUnixError(int error)
 	return ECONNREFUSED; /* sensible default? */
 }
 
-bool getLocalAddresses_win(std::list<sockaddr_storage> &addrs) {
+bool _getLocalAddresses(std::list<sockaddr_storage> &addrs) {
 	// Seems strange to me but M$ documentation suggests to allocate this way...
 	DWORD bf_size = 16000;
 	IP_ADAPTER_ADDRESSES* adapter_addresses = (IP_ADAPTER_ADDRESSES*) rs_malloc(bf_size);
@@ -189,11 +189,11 @@ bool getLocalAddresses_win(std::list<sockaddr_storage> &addrs) {
 	return true;
 }
 
-int unix_close_win(int fd) {
+int _unix_close(int fd) {
 	return ret = closesocket(fd);
 }
 
-int unix_connect_win(int ret) {
+int _unix_connect(int ret) {
 	if (ret != 0)
 	{
 		errno = WinToUnixError(WSAGetLastError());
@@ -202,7 +202,7 @@ int unix_connect_win(int ret) {
 	return ret;
 }
 
-int unix_fcntl_nonblock_win(int fd) {
+int _unix_fcntl_nonblock(int fd) {
 	int ret;
 	unsigned long int on = 1;
 	ret = ioctlsocket(fd, FIONBIO, &on);
@@ -221,7 +221,7 @@ int unix_fcntl_nonblock_win(int fd) {
 	return ret;
 }
 
-int unix_getsockopt_error_win(int sockfd, int *err) {
+int _unix_getsockopt_error(int sockfd, int *err) {
 	int ret;
 	int optlen = 4;
 
@@ -238,7 +238,7 @@ int unix_getsockopt_error_win(int sockfd, int *err) {
 	return ret;
 }
 
-void unix_socket_win(int osock) {
+void _unix_socket(int osock) {
 	if ((unsigned) osock == INVALID_SOCKET)
 	{
 		// Invalidate socket Unix style.
@@ -246,12 +246,3 @@ void unix_socket_win(int osock) {
 		errno = WinToUnixError(WSAGetLastError());
 	}
 }
-
-const struct pqinetworkOps netOps = {
-	.getLocalAddresses = getLocalAddresses_win,
-	.unix_close = unix_close_win,
-	.unix_connect = unix_connect_win,
-	.unix_fcntl_nonblock = unix_fcntl_nonblock_win,
-	.unix_getsockops_error = unix_getsockopt_error_win,
-	.unix_socket = unix_socket_win
-};

--- a/libretroshare/src/pqi/pqinetwork_win.cc
+++ b/libretroshare/src/pqi/pqinetwork_win.cc
@@ -1,0 +1,257 @@
+int errno;
+
+#include <winsock2.h>
+#include <iphlpapi.h>
+#pragma comment(lib, "IPHLPAPI.lib")
+
+void showSocketError(std::string &out)
+{
+	int err = WSAGetLastError();
+	rs_sprintf_append(out, "\tSocket Error(%d) : %s\n", err, socket_errorType(err).c_str());
+}
+
+std::string socket_errorType(int err)
+{
+	if (err == WSAEBADF)
+	{
+		return std::string("WSABADF");
+	}
+
+
+	else if (err == WSAEINTR)
+	{
+		return std::string("WSAEINTR");
+	}
+	else if (err == WSAEACCES)
+	{
+		return std::string("WSAEACCES");
+	}
+	else if (err == WSAEFAULT)
+	{
+		return std::string("WSAEFAULT");
+	}
+	else if (err == WSAEINVAL)
+	{
+		return std::string("WSAEINVAL");
+	}
+	else if (err == WSAEMFILE)
+	{
+		return std::string("WSAEMFILE");
+	}
+	else if (err == WSAEWOULDBLOCK)
+	{
+		return std::string("WSAEWOULDBLOCK");
+	}
+	else if (err == WSAEINPROGRESS)
+	{
+		return std::string("WSAEINPROGRESS");
+	}
+	else if (err == WSAEALREADY)
+	{
+		return std::string("WSAEALREADY");
+	}
+	else if (err == WSAENOTSOCK)
+	{
+		return std::string("WSAENOTSOCK");
+	}
+	else if (err == WSAEDESTADDRREQ)
+	{
+		return std::string("WSAEDESTADDRREQ");
+	}
+	else if (err == WSAEMSGSIZE)
+	{
+		return std::string("WSAEMSGSIZE");
+	}
+	else if (err == WSAEPROTOTYPE)
+	{
+		return std::string("WSAEPROTOTYPE");
+	}
+	else if (err == WSAENOPROTOOPT)
+	{
+		return std::string("WSAENOPROTOOPT");
+	}
+	else if (err == WSAENOTSOCK)
+	{
+		return std::string("WSAENOTSOCK");
+	}
+	else if (err == WSAEISCONN)
+	{
+		return std::string("WSAISCONN");
+	}
+	else if (err == WSAECONNREFUSED)
+	{
+		return std::string("WSACONNREFUSED");
+	}
+	else if (err == WSAECONNRESET)
+	{
+		return std::string("WSACONNRESET");
+	}
+	else if (err == WSAETIMEDOUT)
+	{
+		return std::string("WSATIMEDOUT");
+	}
+	else if (err == WSAENETUNREACH)
+	{
+		return std::string("WSANETUNREACH");
+	}
+	else if (err == WSAEADDRINUSE)
+	{
+		return std::string("WSAADDRINUSE");
+	}
+	else if (err == WSAEAFNOSUPPORT)
+	{
+		return std::string("WSAEAFNOSUPPORT (normally UDP related!)");
+	}
+
+	return std::string("----WINDOWS OPERATING SYSTEM FAILURE----");
+}
+
+// implement the improved unix inet address fn.
+// using old one.
+int inet_aton(const char *name, struct in_addr *addr)
+{
+	return (((*addr).s_addr = inet_addr(name)) != INADDR_NONE);
+}
+
+int	WinToUnixError(int error)
+{
+#ifdef NET_DEBUG
+	std::cerr << "WinToUnixError(" << error << ")" << std::endl;
+#endif
+	switch(error)
+	{
+	    case WSAEINPROGRESS:
+		    return EINPROGRESS;
+		    break;
+	    case WSAEWOULDBLOCK:
+		    return EINPROGRESS;
+		    break;
+	    case WSAENETUNREACH:
+		    return ENETUNREACH;
+		    break;
+	    case WSAETIMEDOUT:
+		    return ETIMEDOUT;
+		    break;
+	    case WSAEHOSTDOWN:
+		    return EHOSTDOWN;
+		    break;
+	    case WSAECONNREFUSED:
+		    return ECONNREFUSED;
+		    break;
+	    case WSAECONNRESET:
+		    return ECONNRESET;
+		    break;
+	    default:
+#ifdef NET_DEBUG
+		    std::cerr << "WinToUnixError(" << error << ") Code Unknown!";
+			std::cerr << std::endl;
+#endif
+		    break;
+	}
+	return ECONNREFUSED; /* sensible default? */
+}
+
+bool getLocalAddresses_win(std::list<sockaddr_storage> &addrs) {
+	// Seems strange to me but M$ documentation suggests to allocate this way...
+	DWORD bf_size = 16000;
+	IP_ADAPTER_ADDRESSES* adapter_addresses = (IP_ADAPTER_ADDRESSES*) rs_malloc(bf_size);
+
+	if(adapter_addresses == NULL)
+		return false ;
+
+	DWORD error = GetAdaptersAddresses(AF_UNSPEC,
+	                                   GAA_FLAG_SKIP_MULTICAST |
+	                                   GAA_FLAG_SKIP_DNS_SERVER |
+	                                   GAA_FLAG_SKIP_FRIENDLY_NAME,
+	                                   NULL,
+	                                   adapter_addresses,
+	                                   &bf_size);
+	if (error != ERROR_SUCCESS)
+	{
+	   std::cerr << "FATAL ERROR: getLocalAddresses failed!" << std::endl;
+	   return false ;
+	}
+
+	IP_ADAPTER_ADDRESSES* adapter(NULL);
+	for(adapter = adapter_addresses; NULL != adapter; adapter = adapter->Next)
+	{
+		IP_ADAPTER_UNICAST_ADDRESS* address;
+		for ( address = adapter->FirstUnicastAddress; address; address = address->Next)
+		{
+			sockaddr_storage tmp;
+			sockaddr_storage_clear(tmp);
+			if (sockaddr_storage_copyip(tmp, * reinterpret_cast<sockaddr_storage*>(address->Address.lpSockaddr)))
+				addrs.push_back(tmp);
+		}
+	}
+
+	free(adapter_addresses);
+	return true;
+}
+
+int unix_close_win(int fd) {
+	return ret = closesocket(fd);
+}
+
+int unix_connect_win(int ret) {
+	if (ret != 0)
+	{
+		errno = WinToUnixError(WSAGetLastError());
+		ret = -1;
+	}
+	return ret;
+}
+
+int unix_fcntl_nonblock_win(int fd) {
+	int ret;
+	unsigned long int on = 1;
+	ret = ioctlsocket(fd, FIONBIO, &on);
+
+#ifdef NET_DEBUG
+	std::cerr << "unix_fcntl_nonblock()" << std::endl;
+#endif
+
+	if (ret != 0)
+	{
+		/* store unix-style error */
+		ret = -1;
+		errno = WinToUnixError(WSAGetLastError());
+	}
+
+	return ret;
+}
+
+int unix_getsockopt_error_win(int sockfd, int *err) {
+	int ret;
+	int optlen = 4;
+
+	ret = getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char *) err, &optlen);
+
+	/* translate */
+#ifdef NET_DEBUG
+	std::cerr << "unix_getsockopt_error() returned: " << (int) err << std::endl;
+#endif
+
+	if (*err != 0)
+		*err = WinToUnixError(*err);
+
+	return ret;
+}
+
+void unix_socket_win(int osock) {
+	if ((unsigned) osock == INVALID_SOCKET)
+	{
+		// Invalidate socket Unix style.
+		osock = -1;
+		errno = WinToUnixError(WSAGetLastError());
+	}
+}
+
+const struct pqinetworkOps netOps = {
+	.getLocalAddresses = getLocalAddresses_win,
+	.unix_close = unix_close_win,
+	.unix_connect = unix_connect_win,
+	.unix_fcntl_nonblock = unix_fcntl_nonblock_win,
+	.unix_getsockops_error = unix_getsockopt_error_win,
+	.unix_socket = unix_socket_win
+};


### PR DESCRIPTION
After the discussion yesterday i decided to make this small clean up patch. 
I'm not sure if it is worth merging. I just want to show how the unix/windows code can be handled without any \#ifdefs (expect one for including the right file 😉 ). 

The idea is to have a ops struct that contains function pointers for every function that is OS specific. These functions pointers get set to the corresponding OS specific function once and the rest of the code just calls the function pointer. This results in a much cleaner code.
Since the new code doesn't use any run time ifs the execution speed should be similar to the old version (+ the extra function call).

(tested on Linux)