### PR TITLE
moved memory ownership of RsGxsGrpMetaData down into RsGxsDataAccess.…

### DIFF
--- a/libretroshare/src/gxs/rsdataservice.h
+++ b/libretroshare/src/gxs/rsdataservice.h
@@ -71,7 +71,7 @@ public:
      * @param cache whether to store retrieval in mem for faster later retrieval
      * @return error code
      */
-    int retrieveGxsGrpMetaData(std::map<RsGxsGroupId, RsGxsGrpMetaData*>& grp);
+    int retrieveGxsGrpMetaData(RsGxsGrpMetaTemporaryMap& grp);
 
     /*!
      * Retrieves meta data of all groups stored (most current versions only)
@@ -208,7 +208,7 @@ private:
      * extracts a grp meta item from a cursor at its
      * current position
      */
-    RsGxsGrpMetaData* locked_getGrpMeta(RetroCursor& c, int colOffset);
+    RsGxsGrpMetaData* locked_getNewGrpMeta(RetroCursor& c, int colOffset);
 
     /*!
      * extracts a msg item from a cursor at its
@@ -347,7 +347,7 @@ private:
     
     void locked_clearGrpMetaCache(const RsGxsGroupId& gid);
 
-    std::map<RsGxsGroupId,RsGxsGrpMetaData> mGrpMetaDataCache ;
+    std::map<RsGxsGroupId,const RsGxsGrpMetaData*> mGrpMetaDataCache ;
     bool mGrpMetaDataCache_ContainsAllDatabase ;
 };
 

--- a/libretroshare/src/gxs/rsgds.h
+++ b/libretroshare/src/gxs/rsgds.h
@@ -36,8 +36,8 @@
 #include "rsitems/rsnxsitems.h"
 #include "gxs/rsgxsdata.h"
 #include "rsgxs.h"
+#include "rsgxsutil.h"
 #include "util/contentvalue.h"
-
 
 class RsGxsSearchModule  {
 
@@ -60,6 +60,8 @@ public:
     RsGxsGrpMsgIdPair msgId;
     ContentValue val;
 };
+
+typedef std::map<RsGxsGroupId,const RsGxsGrpMetaData*> RsGxsGrpMetaTemporaryMap;
 
 /*!
  * This allows modification of local
@@ -168,7 +170,7 @@ public:
      *            , if grpId is failed to be retrieved it will be erased from map
      * @return error code
      */
-    virtual int retrieveGxsGrpMetaData(std::map<RsGxsGroupId, RsGxsGrpMetaData*>& grp) = 0;
+    virtual int retrieveGxsGrpMetaData(RsGxsGrpMetaTemporaryMap& grp) = 0;
 
     /*!
      * Retrieves meta data of all groups stored (most current versions only)

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -3220,7 +3220,6 @@ void RsGenExchange::performUpdateValidation()
 			gu.newGrp = NULL ;
 		}
 
-		delete gu.oldGrpMeta;
 		gu.oldGrpMeta = NULL ;
 	}
 	// notify the client

--- a/libretroshare/src/gxs/rsgenexchange.h
+++ b/libretroshare/src/gxs/rsgenexchange.h
@@ -223,7 +223,7 @@ public:
      * @param groupInfo
      * @return false if could not redeem token
      */
-    bool getGroupMeta(const uint32_t &token, std::list<RsGroupMetaData> &groupInfo);
+    bool getGroupMeta(const uint32_t &token, std::list<RsGroupMetaData>& groupInfo);
 
     /*!
      * retrieves message meta data associated to a request token
@@ -765,7 +765,7 @@ private:
      * 		   SIGN_FAIL_TRY_LATER for Id sign key not avail (but requested), try later
      */
     int createMsgSignatures(RsTlvKeySignatureSet& signSet, RsTlvBinaryData& msgData,
-                             const RsGxsMsgMetaData& msgMeta, RsGxsGrpMetaData& grpMeta);
+                             const RsGxsMsgMetaData& msgMeta, const RsGxsGrpMetaData& grpMeta);
 
     /*!
      * convenience function to create sign for groups
@@ -835,7 +835,7 @@ private:
      * @param newGrp the new group that updates the old group (must have meta data member initialised)
      * @return
      */
-    bool updateValid(RsGxsGrpMetaData& oldGrp, RsNxsGrp& newGrp) const;
+    bool updateValid(const RsGxsGrpMetaData& oldGrp, RsNxsGrp& newGrp) const;
 
     /*!
      * convenience function for checking private publish and admin keys are present

--- a/libretroshare/src/gxs/rsgxsdata.cc
+++ b/libretroshare/src/gxs/rsgxsdata.cc
@@ -33,7 +33,7 @@ RsGxsGrpMetaData::RsGxsGrpMetaData()
     clear();
 }
 
-uint32_t RsGxsGrpMetaData::serial_size(uint32_t api_version)
+uint32_t RsGxsGrpMetaData::serial_size(uint32_t api_version) const
 {
     uint32_t s = 8; // header size
 

--- a/libretroshare/src/gxs/rsgxsdata.h
+++ b/libretroshare/src/gxs/rsgxsdata.h
@@ -51,7 +51,7 @@ public:
     RsGxsGrpMetaData();
     bool deserialise(void *data, uint32_t &pktsize);
     bool serialise(void* data, uint32_t &pktsize, uint32_t api_version);
-    uint32_t serial_size(uint32_t api_version);
+    uint32_t serial_size(uint32_t api_version) const;
     void clear();
     void operator =(const RsGroupMetaData& rMeta);
 

--- a/libretroshare/src/gxs/rsgxsdataaccess.cc
+++ b/libretroshare/src/gxs/rsgxsdataaccess.cc
@@ -25,6 +25,7 @@
 
 #include <time.h>
 
+#include "rsgxsutil.h"
 #include "rsgxsdataaccess.h"
 #include "retroshare/rsgxsflags.h"
 
@@ -377,7 +378,7 @@ bool RsGxsDataAccess::clearRequest(const uint32_t& token)
 	return true;
 }
 
-bool RsGxsDataAccess::getGroupSummary(const uint32_t& token, std::list<RsGxsGrpMetaData*>& groupInfo)
+bool RsGxsDataAccess::getGroupSummary(const uint32_t& token, std::list<const RsGxsGrpMetaData*>& groupInfo)
 {
 
 	RS_STACK_MUTEX(mDataMutex);
@@ -1000,23 +1001,22 @@ bool RsGxsDataAccess::getGroupData(GroupDataReq* req)
 bool RsGxsDataAccess::getGroupSummary(GroupMetaReq* req)
 {
 
-	std::map<RsGxsGroupId, RsGxsGrpMetaData*> grpMeta;
+	RsGxsGrpMetaTemporaryMap grpMeta;
+	std::list<RsGxsGroupId> grpIdsOut;
 
-        std::list<RsGxsGroupId> grpIdsOut;
+	getGroupList(req->mGroupIds, req->Options, grpIdsOut);
 
-        getGroupList(req->mGroupIds, req->Options, grpIdsOut);
+	if(grpIdsOut.empty())
+		return true;
 
-        if(grpIdsOut.empty())
-            return true;
+	std::list<RsGxsGroupId>::const_iterator lit = grpIdsOut.begin();
 
-        std::list<RsGxsGroupId>::const_iterator lit = grpIdsOut.begin();
-
-        for(; lit != grpIdsOut.end(); ++lit)
+	for(; lit != grpIdsOut.end(); ++lit)
 		grpMeta[*lit] = NULL;
 
 	mDataStore->retrieveGxsGrpMetaData(grpMeta);
 
-	std::map<RsGxsGroupId, RsGxsGrpMetaData*>::iterator mit = grpMeta.begin();
+	std::map<RsGxsGroupId, const RsGxsGrpMetaData*>::iterator mit = grpMeta.begin();
 
 	for(; mit != grpMeta.end(); ++mit)
 		req->mGroupMetaData.push_back(mit->second);
@@ -1033,28 +1033,17 @@ bool RsGxsDataAccess::getGroupList(GroupIdReq* req)
 
 bool RsGxsDataAccess::getGroupList(const std::list<RsGxsGroupId>& grpIdsIn, const RsTokReqOptions& opts, std::list<RsGxsGroupId>& grpIdsOut)
 {
-    std::map<RsGxsGroupId, RsGxsGrpMetaData*> grpMeta;
+	RsGxsGrpMetaTemporaryMap grpMeta;
 
-    std::list<RsGxsGroupId>::const_iterator lit = grpIdsIn.begin();
-
-    for(; lit != grpIdsIn.end(); ++lit)
-            grpMeta[*lit] = NULL;
+    for(auto lit = grpIdsIn.begin(); lit != grpIdsIn.end(); ++lit)
+		grpMeta[*lit] = NULL;
 
     mDataStore->retrieveGxsGrpMetaData(grpMeta);
 
-    std::map<RsGxsGroupId, RsGxsGrpMetaData*>::iterator mit = grpMeta.begin();
-
-    for(; mit != grpMeta.end(); ++mit)
-    {
-            grpIdsOut.push_back(mit->first);
-    }
+    for(auto mit = grpMeta.begin() ; mit != grpMeta.end(); ++mit)
+		grpIdsOut.push_back(mit->first);
 
     filterGrpList(grpIdsOut, opts, grpMeta);
-
-    for(mit = grpMeta.begin(); mit != grpMeta.end(); ++mit)
-    {
-            delete mit->second; // so wasteful!!
-    }
 
     return true;
 }
@@ -1622,11 +1611,9 @@ bool RsGxsDataAccess::getGroupStatistic(GroupStatisticRequest *req)
 // potentially very expensive!
 bool RsGxsDataAccess::getServiceStatistic(ServiceStatisticRequest *req)
 {
-    std::map<RsGxsGroupId, RsGxsGrpMetaData*> grpMeta;
+	RsGxsGrpMetaTemporaryMap grpMeta ;
 
     mDataStore->retrieveGxsGrpMetaData(grpMeta);
-
-    std::map<RsGxsGroupId, RsGxsGrpMetaData*>::iterator mit = grpMeta.begin();
 
     req->mServiceStatistic.mNumGrps = grpMeta.size();
     req->mServiceStatistic.mNumMsgs = 0;
@@ -1638,9 +1625,9 @@ bool RsGxsDataAccess::getServiceStatistic(ServiceStatisticRequest *req)
     req->mServiceStatistic.mNumChildMsgsNew = 0;
     req->mServiceStatistic.mNumChildMsgsUnread = 0;
 
-    for(; mit != grpMeta.end(); ++mit)
+    for(auto mit = grpMeta.begin(); mit != grpMeta.end(); ++mit)
     {
-        RsGxsGrpMetaData* m = mit->second;
+        const RsGxsGrpMetaData* m = mit->second;
         req->mServiceStatistic.mSizeOfGrps += m->mGrpSize + m->serial_size(RS_GXS_GRP_META_DATA_CURRENT_API_VERSION);
 
         if (IS_GROUP_SUBSCRIBED(m->mSubscribeFlags))
@@ -1658,8 +1645,6 @@ bool RsGxsDataAccess::getServiceStatistic(ServiceStatisticRequest *req)
             req->mServiceStatistic.mNumChildMsgsNew += gr.mGroupStatistic.mNumChildMsgsNew;
             req->mServiceStatistic.mNumChildMsgsUnread += gr.mGroupStatistic.mNumChildMsgsUnread;
         }
-
-        delete m;
     }
 
     req->mServiceStatistic.mSizeStore = req->mServiceStatistic.mSizeOfGrps + req->mServiceStatistic.mSizeOfMsgs;

--- a/libretroshare/src/gxs/rsgxsdataaccess.h
+++ b/libretroshare/src/gxs/rsgxsdataaccess.h
@@ -32,7 +32,7 @@
 
 
 typedef std::map< RsGxsGroupId, std::map<RsGxsMessageId, RsGxsMsgMetaData*> > MsgMetaFilter;
-typedef std::map< RsGxsGroupId, RsGxsGrpMetaData* > GrpMetaFilter;
+typedef std::map< RsGxsGroupId, const RsGxsGrpMetaData* > GrpMetaFilter;
 
 class RsGxsDataAccess : public RsTokenService
 {
@@ -209,7 +209,7 @@ public:
      * @param token request token to be redeemed
      * @param groupInfo
      */
-    bool getGroupSummary(const uint32_t &token, std::list<RsGxsGrpMetaData*> &groupInfo);
+    bool getGroupSummary(const uint32_t &token, std::list<const RsGxsGrpMetaData*>& groupInfo);
 
     /*!
      *

--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -559,7 +559,7 @@ void RsGxsNetService::syncWithPeers()
 
     for(RsGxsGrpMetaTemporaryMap::iterator mit = grpMeta.begin(); mit != grpMeta.end(); ++mit)
     {
-	    RsGxsGrpMetaData* meta = mit->second;
+	    const RsGxsGrpMetaData* meta = mit->second;
 
 	    // This was commented out because we want to know how many messages are available for unsubscribed groups.
 
@@ -689,7 +689,7 @@ void RsGxsNetService::syncGrpStatistics()
 
     time_t now = time(NULL) ;
 
-    for(std::map<RsGxsGroupId,RsGxsGrpMetaData*>::const_iterator it(grpMeta.begin());it!=grpMeta.end();++it)
+    for(auto it(grpMeta.begin());it!=grpMeta.end();++it)
     {
 	    const RsGxsGrpConfig& rec = locked_getGrpConfig(it->first) ;
 
@@ -755,7 +755,7 @@ void RsGxsNetService::handleRecvSyncGrpStatistics(RsNxsSyncGrpStatsItem *grs)
 
 	    mDataStore->retrieveGxsGrpMetaData(grpMetas);
 
-	    RsGxsGrpMetaData* grpMeta = grpMetas[grs->grpId];
+	    const RsGxsGrpMetaData* grpMeta = grpMetas[grs->grpId];
 
 	if(grpMeta == NULL)
             {
@@ -1951,7 +1951,7 @@ void RsGxsNetService::updateServerSyncTS()
     	// finally, update timestamps.
 	bool change = false;
 
-	for(std::map<RsGxsGroupId, RsGxsGrpMetaData*>::const_iterator mit = gxsMap.begin();mit != gxsMap.end(); ++mit)
+	for(auto mit = gxsMap.begin();mit != gxsMap.end(); ++mit)
 	{
         	// Check if the group is subscribed and restricted to a circle. If the circle has changed, update the
         	// global TS to reflect that change to clients who may be able to see/subscribe to that particular group.
@@ -2722,7 +2722,7 @@ void RsGxsNetService::locked_genReqMsgTransaction(NxsTransaction* tr)
     grpMetaMap[grpId] = NULL;
 
     mDataStore->retrieveGxsGrpMetaData(grpMetaMap);
-    RsGxsGrpMetaData* grpMeta = grpMetaMap[grpId];
+    const RsGxsGrpMetaData* grpMeta = grpMetaMap[grpId];
 
     if(grpMeta == NULL) // this should not happen, but just in case...
     {
@@ -3028,7 +3028,7 @@ void RsGxsNetService::locked_genReqGrpTransaction(NxsTransaction* tr)
         RsNxsSyncGrpItem*& grpSyncItem = *llit;
         const RsGxsGroupId& grpId = grpSyncItem->grpId;
 
-	std::map<RsGxsGroupId, RsGxsGrpMetaData*>::const_iterator metaIter = grpMetaMap.find(grpId);
+	std::map<RsGxsGroupId, const RsGxsGrpMetaData*>::const_iterator metaIter = grpMetaMap.find(grpId);
         bool haveItem = false;
         bool latestVersion = false;
 
@@ -3825,9 +3825,9 @@ void RsGxsNetService::handleRecvSyncGroup(RsNxsSyncGrpReqItem *item)
     GXSNETDEBUG_P_(peer) << "  Group list beings being sent: " << std::endl;
 #endif
 
-    for(std::map<RsGxsGroupId, RsGxsGrpMetaData*>::iterator mit = grp.begin(); mit != grp.end(); ++mit)
+    for(auto mit = grp.begin(); mit != grp.end(); ++mit)
     {
-	    RsGxsGrpMetaData* grpMeta = mit->second;
+	    const RsGxsGrpMetaData* grpMeta = mit->second;
 
 	    // Only send info about subscribed groups.
 
@@ -3899,7 +3899,7 @@ void RsGxsNetService::handleRecvSyncGroup(RsNxsSyncGrpReqItem *item)
 
 
 
-bool RsGxsNetService::canSendGrpId(const RsPeerId& sslId, RsGxsGrpMetaData& grpMeta, std::vector<GrpIdCircleVet>& /* toVet */, bool& should_encrypt)
+bool RsGxsNetService::canSendGrpId(const RsPeerId& sslId, const RsGxsGrpMetaData& grpMeta, std::vector<GrpIdCircleVet>& /* toVet */, bool& should_encrypt)
 {
 #ifdef NXS_NET_DEBUG_4
 	GXSNETDEBUG_PG(sslId,grpMeta.mGroupId) << "RsGxsNetService::canSendGrpId()"<< std::endl;
@@ -4092,7 +4092,7 @@ void RsGxsNetService::handleRecvSyncMessage(RsNxsSyncMsgReqItem *item,bool item_
     grpMetas[item->grpId] = NULL;
 
     mDataStore->retrieveGxsGrpMetaData(grpMetas);
-    RsGxsGrpMetaData* grpMeta = grpMetas[item->grpId];
+    const RsGxsGrpMetaData* grpMeta = grpMetas[item->grpId];
 
     if(grpMeta == NULL)
     {
@@ -4633,7 +4633,7 @@ void RsGxsNetService::sharePublishKeysPending()
 
         // Find the publish keys in the retrieved info
 
-        RsGxsGrpMetaData *grpMeta = grpMetaMap[mit->first] ;
+        const RsGxsGrpMetaData *grpMeta = grpMetaMap[mit->first] ;
 
         if(grpMeta == NULL)
         {
@@ -4718,7 +4718,7 @@ void RsGxsNetService::handleRecvPublishKeys(RsNxsGroupPublishKeyItem *item)
 
 	// update the publish keys in this group meta info
 
-	RsGxsGrpMetaData *grpMeta = grpMetaMap[item->grpId] ;
+	const RsGxsGrpMetaData *grpMeta = grpMetaMap[item->grpId] ;
 	if (!grpMeta) {
 		std::cerr << "(EE) RsGxsNetService::handleRecvPublishKeys() grpMeta not found." << std::endl;
 		return ;
@@ -4760,9 +4760,10 @@ void RsGxsNetService::handleRecvPublishKeys(RsNxsGroupPublishKeyItem *item)
 
 	// Store/update the info.
 
-	grpMeta->keys.private_keys[item->private_key.keyId] = item->private_key ;
+	RsTlvSecurityKeySet keys = grpMeta->keys ;
+	keys.private_keys[item->private_key.keyId] = item->private_key ;
 
-	bool ret = mDataStore->updateGroupKeys(item->grpId,grpMeta->keys, grpMeta->mSubscribeFlags | GXS_SERV::GROUP_SUBSCRIBE_PUBLISH) ;
+	bool ret = mDataStore->updateGroupKeys(item->grpId,keys, grpMeta->mSubscribeFlags | GXS_SERV::GROUP_SUBSCRIBE_PUBLISH) ;
 
 	if(ret)
 	{

--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -370,7 +370,7 @@ private:
      * @param toVet groupid/peer to vet are stored here if their circle id is not cached
      * @return false, if you cannot send to this peer, true otherwise
      */
-    bool canSendGrpId(const RsPeerId& sslId, RsGxsGrpMetaData& grpMeta, std::vector<GrpIdCircleVet>& toVet, bool &should_encrypt);
+    bool canSendGrpId(const RsPeerId& sslId, const RsGxsGrpMetaData& grpMeta, std::vector<GrpIdCircleVet>& toVet, bool &should_encrypt);
     bool canSendMsgIds(std::vector<RsGxsMsgMetaData*>& msgMetas, const RsGxsGrpMetaData&, const RsPeerId& sslId, RsGxsCircleId &should_encrypt_id);
 
     /*!

--- a/libretroshare/src/gxs/rsgxsrequesttypes.h
+++ b/libretroshare/src/gxs/rsgxsrequesttypes.h
@@ -52,7 +52,7 @@ public:
 
 public:
 	std::list<RsGxsGroupId> mGroupIds;
-	std::list<RsGxsGrpMetaData*> mGroupMetaData;
+	std::list<const RsGxsGrpMetaData*> mGroupMetaData;
 };
 
 class GroupIdReq : public GxsRequest

--- a/libretroshare/src/gxs/rsgxsutil.cc
+++ b/libretroshare/src/gxs/rsgxsutil.cc
@@ -42,13 +42,10 @@ static const uint32_t MAX_GXS_IDS_REQUESTS_NET   =  10 ; // max number of reques
 RsGxsMessageCleanUp::RsGxsMessageCleanUp(RsGeneralDataService* const dataService, RsGenExchange *genex, uint32_t chunkSize)
 : mDs(dataService), mGenExchangeClient(genex), CHUNK_SIZE(chunkSize)
 {
-
-	std::map<RsGxsGroupId, RsGxsGrpMetaData*> grpMeta;
+	RsGxsGrpMetaTemporaryMap grpMeta;
 	mDs->retrieveGxsGrpMetaData(grpMeta);
 
-	std::map<RsGxsGroupId, RsGxsGrpMetaData*>::iterator cit = grpMeta.begin();
-
-	for(;cit != grpMeta.end(); ++cit)
+	for(auto cit=grpMeta.begin();cit != grpMeta.end(); ++cit)
 		mGrpMeta.push_back(cit->second);
 }
 
@@ -64,7 +61,7 @@ bool RsGxsMessageCleanUp::clean()
 #endif
 	while(!mGrpMeta.empty())
 	{
-		RsGxsGrpMetaData* grpMeta = mGrpMeta.back();
+		const RsGxsGrpMetaData* grpMeta = mGrpMeta.back();
 		const RsGxsGroupId& grpId = grpMeta->mGroupId;
 		mGrpMeta.pop_back();
 		GxsMsgReq req;
@@ -136,8 +133,6 @@ bool RsGxsMessageCleanUp::clean()
 		}
 
 		mDs->removeMsgs(req);
-
-		delete grpMeta;
 
 		i++;
 		if(i > CHUNK_SIZE) break;

--- a/libretroshare/src/gxs/rsgxsutil.h
+++ b/libretroshare/src/gxs/rsgxsutil.h
@@ -32,6 +32,7 @@
 
 class RsGixs ;
 class RsGenExchange ;
+class RsGeneralDataService ;
 
 // temporary holds a map of pointers to class T, and destroys all pointers on delete.
 
@@ -104,7 +105,7 @@ public:
     }
 };
 
-typedef t_RsGxsGenericDataTemporaryMap<RsGxsGroupId,RsGxsGrpMetaData> RsGxsGrpMetaTemporaryMap;
+typedef std::map<RsGxsGroupId,const RsGxsGrpMetaData*>                RsGxsGrpMetaTemporaryMap;
 typedef t_RsGxsGenericDataTemporaryMap<RsGxsGroupId,RsNxsGrp>         RsNxsGrpDataTemporaryMap;
 
 typedef t_RsGxsGenericDataTemporaryMapVector<RsGxsMsgMetaData>        RsGxsMsgMetaTemporaryMap ;
@@ -178,7 +179,7 @@ private:
 	RsGeneralDataService* const mDs;
     RsGenExchange *mGenExchangeClient;
 	uint32_t CHUNK_SIZE;
-	std::vector<RsGxsGrpMetaData*> mGrpMeta;
+	std::vector<const RsGxsGrpMetaData*> mGrpMeta;
 };
 
 /*!
@@ -226,7 +227,7 @@ class GroupUpdate
 public:
 	GroupUpdate() : oldGrpMeta(NULL), newGrp(NULL), validUpdate(false)
 	{}
-	RsGxsGrpMetaData* oldGrpMeta;
+	const RsGxsGrpMetaData* oldGrpMeta;
 	RsNxsGrp* newGrp;
 	bool validUpdate;
 };

--- a/tests/unittests/libretroshare/gxs/data_service/rsdataservice_test.cc
+++ b/tests/unittests/libretroshare/gxs/data_service/rsdataservice_test.cc
@@ -98,7 +98,7 @@ void test_groupStoreAndRetrieve(){
         }
 
         RsGxsGrpMetaData *l_Meta = (*mit)->metaData,
-        *r_Meta = grpMetaR[grpId];
+        *r_Meta = const_cast<RsGxsGrpMetaData*>(grpMetaR[grpId]);
 
         // assign signSet and mGrpSize
         // to right as these values are not stored in db

--- a/tests/unittests/libretroshare/gxs/gen_exchange/genexchangetester.cc
+++ b/tests/unittests/libretroshare/gxs/gen_exchange/genexchangetester.cc
@@ -334,8 +334,8 @@ void GenExchangeTest::init(RsGroupMetaData& grpMetaData) const
     randString(SHORT_STR, grpMetaData.mServiceString);
 
 
-    grpMetaData.mGroupFlags = randNum() & (0x00000007);//See GXS_SERV::FLAG_PRIVACY_XXX values /libretroshare/src/retroshare/rsgxsflags.h:21
-    if (grpMetaData.mGroupFlags == 0) grpMetaData.mGroupFlags = GXS_SERV::FLAG_PRIVACY_PRIVATE;
+    grpMetaData.mGroupFlags = GXS_SERV::FLAG_PRIVACY_PUBLIC; //randNum() & (0x00000007);//See GXS_SERV::FLAG_PRIVACY_XXX values /libretroshare/src/retroshare/rsgxsflags.h:21
+
     grpMetaData.mLastPost = randNum();
     grpMetaData.mGroupStatus = randNum();
     grpMetaData.mVisibleMsgCount = randNum();


### PR DESCRIPTION
… Avoids many copy-constructors of RsTlvSecurityKey. Will probably spare a lot of CPU on windows