### PR TITLE
Add support for libsecret (including KDE keyring) and fix retroshare-nogui autologin

### DIFF
--- a/retroshare-nogui/src/retroshare-nogui.pro
+++ b/retroshare-nogui/src/retroshare-nogui.pro
@@ -23,14 +23,11 @@ INCLUDEPATH += ../../rapidjson-1.1.0
 
 ################################# Linux ##########################################
 linux-* {
+        CONFIG += link_pkgconfig
 	#CONFIG += version_detail_bash_script
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
 	LIBS *= -rdynamic
-
-	rs_autologin {
-		LIBS *= -lgnome-keyring
-	}
 }
 
 unix {

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -340,11 +340,17 @@ linux-* {
     QMAKE_LIBDIR *= "$$RS_LIB_DIR"
 
     rs_autologin {
-        #DEFINES *= HAS_GNOME_KEYRING
-        #PKGCONFIG *= gnome-keyring-1
-
-        DEFINES *= HAS_LIBSECRET
-        PKGCONFIG *= libsecret-1
+        # try libsecret first since it is not limited to gnome keyring and libgnome-keyring is deprecated
+        LIBSECRET_AVAILABLE = $$system(pkg-config --exists libsecret-1 && echo yes)
+        isEmpty(LIBSECRET_AVAILABLE) {
+            message("using libgnome-keyring for auto login")
+            DEFINES *= HAS_GNOME_KEYRING
+            PKGCONFIG *= gnome-keyring-1
+        } else {
+            message("using libsecret for auto login")
+            DEFINES *= HAS_LIBSECRET
+            PKGCONFIG *= libsecret-1
+        }
     }
 }
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -340,8 +340,11 @@ linux-* {
     QMAKE_LIBDIR *= "$$RS_LIB_DIR"
 
     rs_autologin {
-        DEFINES *= HAS_GNOME_KEYRING
-        PKGCONFIG *= gnome-keyring-1
+        #DEFINES *= HAS_GNOME_KEYRING
+        #PKGCONFIG *= gnome-keyring-1
+
+        DEFINES *= HAS_LIBSECRET
+        PKGCONFIG *= libsecret-1
     }
 }
 


### PR DESCRIPTION
As @PhenomRetroShare  pointed out in 5f12b6076dd29e0353c7c6b9788ea73767f56afb libgnome-keyring is deprecated by the gnome project and its successor is libsecret.

While libgnome-keyring was only designed to interact with gnome keyring, libsecret can use any back-end that implements the "Secret Service" using D-Bus. (These are gnome-keyring and ksecretservice). So this PR effectively adds support for KDEs keyring, too.

The first commit fixes 5f12b6076dd29e0353c7c6b9788ea73767f56afb. retroshare.pri takes care of everything so nothing needs to be set manually in retroshare-nogui.pro except that Qts library system must be enabled.

The second commit adds support for libsecret which is very similar to libgnome-keyring.

The third commit adds an automatic switch that will select libsecret when available and fall back to libgnome-keyring otherwise when rs_autologin is set.

This was tested on Arch Linux. 