### PR TITLE
Fix CppCheck in ftcontroller.cc

### DIFF
--- a/libretroshare/src/ft/ftcontroller.cc
+++ b/libretroshare/src/ft/ftcontroller.cc
@@ -88,16 +88,13 @@ ftFileControl::ftFileControl()
 	return;
 }
 
-ftFileControl::ftFileControl(std::string fname,
-		std::string tmppath, std::string dest,
-        uint64_t size, const RsFileHash &hash, TransferRequestFlags flags,
-		ftFileCreator *fc, ftTransferModule *tm)
-	:mName(fname), mCurrentPath(tmppath), mDestination(dest),
-	 mTransfer(tm), mCreator(fc), mState(DOWNLOADING), mHash(hash),
-	 mSize(size), mFlags(flags), mCreateTime(0), mQueuePriority(0), mQueuePosition(0)
-{
-    return;
-}
+ftFileControl::ftFileControl(const std::string& fname, const std::string& tmppath, const std::string& dest
+                           , uint64_t size, const RsFileHash &hash, TransferRequestFlags flags
+                           , ftFileCreator *fc, ftTransferModule *tm)
+  : mName(fname), mCurrentPath(tmppath), mDestination(dest)
+  , mTransfer(tm), mCreator(fc), mState(DOWNLOADING), mHash(hash)
+  , mSize(size), mFlags(flags), mCreateTime(0), mQueuePriority(0), mQueuePosition(0)
+{}
 
 ftController::ftController(ftDataMultiplex *dm, p3ServiceControl *sc, uint32_t ftServiceId)
   : p3Config(),
@@ -1479,7 +1476,7 @@ bool 	ftController::setPartialsDirectory(std::string path)
 
         path = RsDirUtil::convertPathToUnix(path);
 
-        if (!path.find(mDownloadPath)) {
+        if (path.find(mDownloadPath) == std::string::npos) {
             return false;
         }
 
@@ -1488,7 +1485,7 @@ bool 	ftController::setPartialsDirectory(std::string path)
             std::list<SharedDirInfo> dirs;
             rsFiles->getSharedDirectories(dirs);
             for (it = dirs.begin(); it != dirs.end(); ++it) {
-                if (!path.find((*it).filename)) {
+                if (path.find((*it).filename) == std::string::npos) {
                     return false;
                 }
             }

--- a/libretroshare/src/ft/ftcontroller.h
+++ b/libretroshare/src/ft/ftcontroller.h
@@ -73,9 +73,9 @@ class ftFileControl
 		};
 
 		ftFileControl();
-		ftFileControl(std::string fname, std::string tmppath, std::string dest,
-                            uint64_t size, const RsFileHash& hash, TransferRequestFlags flags,
-							ftFileCreator *fc, ftTransferModule *tm);
+		ftFileControl( const std::string& fname, const std::string& tmppath, const std::string& dest
+		             , uint64_t size, const RsFileHash& hash, TransferRequestFlags flags
+		             , ftFileCreator *fc, ftTransferModule *tm);
 
 		std::string	   mName;
 		std::string	   mCurrentPath; /* current full path (including name) */


### PR DESCRIPTION
/libretroshare/src/ft/ftcontroller.cc:91: warning:
Cppcheck(passedByValue): Function parameter 'fname' should be passed by
reference.
/libretroshare/src/ft/ftcontroller.cc:92: warning:
Cppcheck(passedByValue): Function parameter 'tmppath' should be passed
by reference.
/libretroshare/src/ft/ftcontroller.cc:92: warning:
Cppcheck(passedByValue): Function parameter 'dest' should be passed by
reference.
/libretroshare/src/ft/ftcontroller.cc:1482: warning:
Cppcheck(stlIfStrFind): Inefficient usage of string::find() in
condition; string::compare() would be faster.
/libretroshare/src/ft/ftcontroller.cc:1491: warning:
Cppcheck(stlIfStrFind): Inefficient usage of string::find() in
condition; string::compare() would be faster.