### PR TITLE
Fix CppCheck duplInheritedMember warning in RsItem

### DIFF
--- a/libretroshare/src/pqi/p3historymgr.cc
+++ b/libretroshare/src/pqi/p3historymgr.cc
@@ -67,7 +67,7 @@ p3HistoryMgr::~p3HistoryMgr()
 
 /***** p3HistoryMgr *****/
 
-//void p3HistoryMgr::addMessage(bool incoming, const RsPeerId &chatPeerId, const RsPeerId &peerId, const RsChatMsgItem *chatItem)
+//void p3HistoryMgr::addMessage(bool incoming, const RsPeerId &chatPeerId, const RsPeerId &msgPeerId, const RsChatMsgItem *chatItem)
 void p3HistoryMgr::addMessage(const ChatMessage& cm)
 {
 	uint32_t addMsgId = 0;
@@ -84,48 +84,48 @@ void p3HistoryMgr::addMessage(const ChatMessage& cm)
 		RsStackMutex stack(mHistoryMtx); /********** STACK LOCKED MTX ******/
 
 
-        RsPeerId peerId; // id of sending peer
-        RsPeerId chatPeerId; // id of chat endpoint
-        std::string peerName; //name of sending peer
+		RsPeerId msgPeerId; // id of sending peer
+		RsPeerId chatPeerId; // id of chat endpoint
+		std::string peerName; //name of sending peer
 
-        bool enabled = false;
-        if (cm.chat_id.isBroadcast() && mPublicEnable == true) {
-            peerName = rsPeers->getPeerName(cm.broadcast_peer_id);
-            enabled = true;
+		bool enabled = false;
+		if (cm.chat_id.isBroadcast() && mPublicEnable == true) {
+			peerName = rsPeers->getPeerName(cm.broadcast_peer_id);
+			enabled = true;
 		}
-        if (cm.chat_id.isPeerId() && mPrivateEnable == true) {
-            peerId = cm.incoming ? cm.chat_id.toPeerId() : rsPeers->getOwnId();
-            peerName = rsPeers->getPeerName(peerId);
-            enabled = true;
-        }
-        if (cm.chat_id.isLobbyId() && mLobbyEnable == true) {
-            peerName = cm.lobby_peer_gxs_id.toStdString();
-            enabled = true;
-        }
+		if (cm.chat_id.isPeerId() && mPrivateEnable == true) {
+			msgPeerId = cm.incoming ? cm.chat_id.toPeerId() : rsPeers->getOwnId();
+			peerName = rsPeers->getPeerName(msgPeerId);
+			enabled = true;
+		}
+		if (cm.chat_id.isLobbyId() && mLobbyEnable == true) {
+			peerName = cm.lobby_peer_gxs_id.toStdString();
+			enabled = true;
+		}
 
-        if(cm.chat_id.isDistantChatId())
-	{
-		DistantChatPeerInfo dcpinfo;
-		if (rsMsgs->getDistantChatStatus(cm.chat_id.toDistantChatId(), dcpinfo))
-			peerName = cm.chat_id.toPeerId().toStdString();
-		enabled = true;
-	}
+		if(cm.chat_id.isDistantChatId())
+		{
+			DistantChatPeerInfo dcpinfo;
+			if (rsMsgs->getDistantChatStatus(cm.chat_id.toDistantChatId(), dcpinfo))
+				peerName = cm.chat_id.toPeerId().toStdString();
+			enabled = true;
+		}
 
-        if(enabled == false)
-            return;
+		if(enabled == false)
+			return;
 
-        if(!chatIdToVirtualPeerId(cm.chat_id, chatPeerId))
-            return;
+		if(!chatIdToVirtualPeerId(cm.chat_id, chatPeerId))
+			return;
 
 		RsHistoryMsgItem* item = new RsHistoryMsgItem;
 		item->chatPeerId = chatPeerId;
-        item->incoming = cm.incoming;
-		item->peerId = peerId;
-        item->peerName = peerName;
-        item->sendTime = cm.sendTime;
-        item->recvTime = cm.recvTime;
+		item->incoming = cm.incoming;
+		item->msgPeerId = msgPeerId;
+		item->peerName = peerName;
+		item->sendTime = cm.sendTime;
+		item->recvTime = cm.recvTime;
 
-        item->message = cm.msg ;
+		item->message = cm.msg ;
 		//librs::util::ConvertUtf16ToUtf8(chatItem->message, item->message);
 
 		std::map<RsPeerId, std::map<uint32_t, RsHistoryMsgItem*> >::iterator mit = mMessages.find(item->chatPeerId);
@@ -138,7 +138,7 @@ void p3HistoryMgr::addMessage(const ChatMessage& cm)
 			uint32_t limit;
 			if (chatPeerId.isNull()) 
 				limit = mPublicSaveCount;
-            else if (cm.chat_id.isLobbyId())
+			else if (cm.chat_id.isLobbyId())
 				limit = mLobbySaveCount;
 			else 
 				limit = mPrivateSaveCount;
@@ -424,7 +424,7 @@ static void convertMsg(const RsHistoryMsgItem* item, HistoryMsg &msg)
 	msg.msgId = item->msgId;
 	msg.chatPeerId = item->chatPeerId;
 	msg.incoming = item->incoming;
-	msg.peerId = item->peerId;
+	msg.peerId = item->msgPeerId;
 	msg.peerName = item->peerName;
 	msg.sendTime = item->sendTime;
 	msg.recvTime = item->recvTime;

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -2014,7 +2014,7 @@ bool p3PeerMgrIMPL::saveList(bool &cleanup, std::list<RsItem *>& saveData)
 	RsPeerNetItem *item = new RsPeerNetItem();
 	item->clear();
 
-	item->peerId = getOwnId();
+	item->nodePeerId = getOwnId();
 	item->pgpId = mOwnState.gpg_id;
 	item->location = mOwnState.location;
 
@@ -2065,7 +2065,7 @@ bool p3PeerMgrIMPL::saveList(bool &cleanup, std::list<RsItem *>& saveData)
 		item = new RsPeerNetItem();
 		item->clear();
 
-		item->peerId = it->first;
+		item->nodePeerId = it->first;
 		item->pgpId = (it->second).gpg_id;
 		item->location = (it->second).location;
 		item->netMode = (it->second).netMode;
@@ -2265,7 +2265,7 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
 	    RsPeerNetItem *pitem = dynamic_cast<RsPeerNetItem *>(*it);
 	    if (pitem)
 	    {
-		    RsPeerId peer_id = pitem->peerId ;
+		    RsPeerId peer_id = pitem->nodePeerId ;
 		    RsPgpId peer_pgp_id = pitem->pgpId ;
 
 		    if (peer_id == ownId)
@@ -2292,7 +2292,7 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
 			    /* ************* */
 			    // permission flags is used as a mask for the existing perms, so we set it to 0xffff
 			    addFriend(peer_id, peer_pgp_id, pitem->netMode, pitem->vs_disc, pitem->vs_dht, pitem->lastContact, RS_NODE_PERM_ALL);
-			    setLocation(pitem->peerId, pitem->location);
+			    setLocation(pitem->nodePeerId, pitem->location);
 		    }
 
 		    if (pitem->netMode == RS_NET_MODE_HIDDEN)

--- a/libretroshare/src/rsitems/rsbanlistitems.cc
+++ b/libretroshare/src/rsitems/rsbanlistitems.cc
@@ -48,8 +48,8 @@ void RsBanListItem::serial_process(RsGenericSerializer::SerializeJob j,RsGeneric
 
 void RsBanListConfigItem::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
 {
-    RsTypeSerializer::serial_process<uint32_t>(j,ctx,type,"type") ;
-    RsTypeSerializer::serial_process          (j,ctx,peerId,"peerId") ;
+    RsTypeSerializer::serial_process<uint32_t>(j,ctx,banListType,"type") ;
+    RsTypeSerializer::serial_process          (j,ctx,banListPeerId,"peerId") ;
     RsTypeSerializer::serial_process<time_t>  (j,ctx,update_time,"update_time") ;
     RsTypeSerializer::serial_process          (j,ctx,banned_peers,"banned_peers") ;
 }

--- a/libretroshare/src/rsitems/rsbanlistitems.h
+++ b/libretroshare/src/rsitems/rsbanlistitems.h
@@ -60,18 +60,20 @@ class RsBanListItem: public RsItem
 class RsBanListConfigItem: public RsItem
 {
 public:
-    RsBanListConfigItem()
-            :RsItem(RS_PKT_VERSION_SERVICE, RS_SERVICE_TYPE_BANLIST, RS_PKT_SUBTYPE_BANLIST_CONFIG_ITEM) {}
+	RsBanListConfigItem()
+	  : RsItem(RS_PKT_VERSION_SERVICE, RS_SERVICE_TYPE_BANLIST, RS_PKT_SUBTYPE_BANLIST_CONFIG_ITEM)
+	  , banListType(0), update_time(0)
+	{}
 
-    virtual ~RsBanListConfigItem(){}
-    virtual void clear() { banned_peers.TlvClear() ; }
+	virtual ~RsBanListConfigItem(){}
+	virtual void clear() { banned_peers.TlvClear() ; }
 
 	void serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx);
 
-    uint32_t		type ;
-    RsPeerId  		peerId ;
-    time_t			update_time ;
-    RsTlvBanList	banned_peers;
+	uint32_t      banListType ;
+	RsPeerId      banListPeerId ;
+	time_t        update_time ;
+	RsTlvBanList  banned_peers;
 };
 
 class RsBanListSerialiser: public RsServiceSerializer

--- a/libretroshare/src/rsitems/rsconfigitems.cc
+++ b/libretroshare/src/rsitems/rsconfigitems.cc
@@ -137,9 +137,9 @@ RsItem *RsPeerConfigSerialiser::create_item(uint8_t item_type,uint8_t item_subty
 
 void RsPeerNetItem::clear()
 {
-	peerId.clear();
-        pgpId.clear();
-        location.clear();
+	nodePeerId.clear();
+	pgpId.clear();
+	location.clear();
 	netMode = 0;
 	vs_disc = 0;
 	vs_dht = 0;
@@ -160,7 +160,7 @@ void RsPeerNetItem::clear()
 }
 void RsPeerNetItem::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
 {
-	RsTypeSerializer::serial_process(j,ctx,peerId,"peerId") ;
+	RsTypeSerializer::serial_process(j,ctx,nodePeerId,"peerId") ;
 	RsTypeSerializer::serial_process(j,ctx,pgpId,"pgpId") ;
 	RsTypeSerializer::serial_process(j,ctx,TLV_TYPE_STR_LOCATION,location,"location") ;
 

--- a/libretroshare/src/rsitems/rsconfigitems.h
+++ b/libretroshare/src/rsitems/rsconfigitems.h
@@ -84,7 +84,7 @@ public:
 	virtual void serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx);
 
 	/* networking information */
-	RsPeerId    peerId;                       /* Mandatory */
+	RsPeerId    nodePeerId;                   /* Mandatory */
 	RsPgpId     pgpId;                        /* Mandatory */
 	std::string location;                     /* Mandatory */
 	uint32_t    netMode;                      /* Mandatory */

--- a/libretroshare/src/rsitems/rshistoryitems.cc
+++ b/libretroshare/src/rsitems/rshistoryitems.cc
@@ -44,7 +44,7 @@ void RsHistoryMsgItem::serial_process(RsGenericSerializer::SerializeJob j,RsGene
     RsTypeSerializer::serial_process<uint16_t>(j,ctx,version,"version") ;
     RsTypeSerializer::serial_process          (j,ctx,chatPeerId,"chatPeerId") ;
     RsTypeSerializer::serial_process<bool>    (j,ctx,incoming,"incoming") ;
-    RsTypeSerializer::serial_process          (j,ctx,peerId,"peerId") ;
+    RsTypeSerializer::serial_process          (j,ctx,msgPeerId,"peerId") ;
     RsTypeSerializer::serial_process          (j,ctx,TLV_TYPE_STR_NAME,peerName,"peerName") ;
     RsTypeSerializer::serial_process<uint32_t>(j,ctx,sendTime,"sendTime") ;
     RsTypeSerializer::serial_process<uint32_t>(j,ctx,recvTime,"recvTime") ;

--- a/libretroshare/src/rsitems/rshistoryitems.h
+++ b/libretroshare/src/rsitems/rshistoryitems.h
@@ -46,7 +46,7 @@ public:
 
 	RsPeerId    chatPeerId; // empty for global chat
 	bool        incoming;
-	RsPeerId    peerId;
+	RsPeerId    msgPeerId;
 	std::string peerName;
 	uint32_t    sendTime;
 	uint32_t    recvTime;

--- a/libretroshare/src/services/p3banlist.cc
+++ b/libretroshare/src/services/p3banlist.cc
@@ -735,9 +735,9 @@ bool p3BanList::saveList(bool &cleanup, std::list<RsItem*>& itemlist)
     {
         RsBanListConfigItem *item = new RsBanListConfigItem ;
 
-        item->type         = RSBANLIST_TYPE_PEERLIST ;
-        item->peerId       = it->second.mPeerId ;
-        item->update_time  = it->second.mLastUpdate ;
+        item->banListType   = RSBANLIST_TYPE_PEERLIST ;
+        item->banListPeerId = it->second.mPeerId ;
+        item->update_time   = it->second.mLastUpdate ;
         item->banned_peers.TlvClear() ;
 
         for(std::map<sockaddr_storage,BanListPeer>::const_iterator it2 = it->second.mBanPeers.begin();it2!=it->second.mBanPeers.end();++it2)
@@ -754,8 +754,8 @@ bool p3BanList::saveList(bool &cleanup, std::list<RsItem*>& itemlist)
     // Add  whitelist
     RsBanListConfigItem *item = new RsBanListConfigItem ;
 
-    item->type         = RSBANLIST_TYPE_WHITELIST ;
-    item->peerId.clear() ;
+    item->banListType = RSBANLIST_TYPE_WHITELIST ;
+    item->banListPeerId.clear() ;
     item->update_time  = 0 ;
     item->banned_peers.TlvClear() ;
 
@@ -773,8 +773,8 @@ bool p3BanList::saveList(bool &cleanup, std::list<RsItem*>& itemlist)
 
     item = new RsBanListConfigItem ;
 
-    item->type         = RSBANLIST_TYPE_BLACKLIST ;
-    item->peerId.clear();
+    item->banListType = RSBANLIST_TYPE_BLACKLIST ;
+    item->banListPeerId.clear();
     item->update_time  = 0 ;
     item->banned_peers.TlvClear() ;
 
@@ -850,11 +850,11 @@ bool p3BanList::loadList(std::list<RsItem*>& load)
 
         if(citem != NULL)
         {
-            if(citem->type == RSBANLIST_TYPE_PEERLIST)
+            if(citem->banListType == RSBANLIST_TYPE_PEERLIST)
             {
-                BanList& bl(mBanSources[citem->peerId]) ;
+                BanList& bl(mBanSources[citem->banListPeerId]) ;
 
-                bl.mPeerId = citem->peerId ;
+                bl.mPeerId = citem->banListPeerId ;
                 bl.mLastUpdate = citem->update_time ;
 
                 bl.mBanPeers.clear() ;
@@ -870,7 +870,7 @@ bool p3BanList::loadList(std::list<RsItem*>& load)
                         std::cerr << "(WW) removed wrong address " << sockaddr_storage_iptostring(blp.addr) << std::endl;
                 }
             }
-            else if(citem->type == RSBANLIST_TYPE_BLACKLIST)
+            else if(citem->banListType == RSBANLIST_TYPE_BLACKLIST)
             {
                 mBanRanges.clear() ;
 
@@ -885,7 +885,7 @@ bool p3BanList::loadList(std::list<RsItem*>& load)
                         std::cerr << "(WW) removed wrong address " << sockaddr_storage_iptostring(blp.addr) << std::endl;
                 }
             }
-            else if(citem->type == RSBANLIST_TYPE_WHITELIST)
+            else if(citem->banListType == RSBANLIST_TYPE_WHITELIST)
             {
                 mWhiteListedRanges.clear() ;
 
@@ -903,7 +903,7 @@ bool p3BanList::loadList(std::list<RsItem*>& load)
                 }
             }
             else
-                std::cerr << "(EE) BanList item unknown type " << citem->type << ". This is a bug." << std::endl;
+                std::cerr << "(EE) BanList item unknown type " << citem->banListType << ". This is a bug." << std::endl;
         }
 
         delete *it ;

--- a/tests/unittests/libretroshare/serialiser/rsconfigitem_test.cc
+++ b/tests/unittests/libretroshare/serialiser/rsconfigitem_test.cc
@@ -29,7 +29,7 @@
 RsSerialType* init_item(RsPeerNetItem& rpn)
 {
 	randString(SHORT_STR, rpn.dyndns);
-	rpn.peerId.random();
+	rpn.nodePeerId.random();
 	rpn.pgpId.random();
 	randString(SHORT_STR, rpn.location);
 
@@ -165,7 +165,7 @@ bool operator==(const RsPeerNetItem& left, const RsPeerNetItem& right)
 	if(left.dyndns != right.dyndns) return false;
 	if(left.pgpId != right.pgpId) return false;
 	if(left.location != right.location) return false;
-	if(left.peerId != right.peerId) return false;
+	if(left.nodePeerId != right.nodePeerId) return false;
 	if(left.lastContact != right.lastContact) return false;
 	if(left.netMode != right.netMode) return false;
 	if(left.visState != right.visState) return false;


### PR DESCRIPTION
/libretroshare/src/rsitems/rsitem.h:92: warning:
Cppcheck(duplInheritedMember): The class 'RsPeerNetItem' defines member
variable with name 'peerId' also defined in its parent struct 'RsItem'.
/libretroshare/src/rsitems/rsitem.h:92: warning:
Cppcheck(duplInheritedMember): The class 'RsHistoryMsgItem' defines
member variable with name 'peerId' also defined in its parent struct
'RsItem'.
/libretroshare/src/rsitems/rsitem.h:91: warning:
Cppcheck(duplInheritedMember): The class 'RsBanListConfigItem' defines
member variable with name 'type' also defined in its parent struct
'RsItem'.
/libretroshare/src/rsitems/rsitem.h:92: warning:
Cppcheck(duplInheritedMember): The class 'RsBanListConfigItem' defines
member variable with name 'peerId' also defined in its parent struct
'RsItem'.