### PR TITLE
fix gcc8

### DIFF
--- a/libretroshare/src/grouter/p3grouter.cc
+++ b/libretroshare/src/grouter/p3grouter.cc
@@ -540,7 +540,7 @@ if(itm == NULL)
 
 void GRouterTunnelInfo::removeVirtualPeer(const TurtleVirtualPeerId& vpid)
 {
-    std::set<TurtleVirtualPeerId,RsGRouterTransactionChunkItem*>::iterator it = virtual_peers.find(vpid) ;
+    std::set<TurtleVirtualPeerId>::iterator it = virtual_peers.find(vpid) ;
 
     if(it == virtual_peers.end())
     {


### PR DESCRIPTION
As far as i can tell `std::set<TurtleVirtualPeerId, RsGRouterTransactionChunkItem*>` doesn't make any sense.
Compile and (quickly) run tested on Arch with gcc-Version 8.1.0 (GCC) 