### PR TITLE
Fix Partial Dir Check

### DIFF
--- a/libretroshare/src/ft/ftcontroller.cc
+++ b/libretroshare/src/ft/ftcontroller.cc
@@ -1472,24 +1472,24 @@ bool 	ftController::setPartialsDirectory(std::string path)
 
 	/* check it is not a subdir of download / shared directories (BAD) - TODO */
 	{
-        RsStackMutex stack(ctrlMutex);
+		RsStackMutex stack(ctrlMutex);
 
-        path = RsDirUtil::convertPathToUnix(path);
+		path = RsDirUtil::convertPathToUnix(path);
 
-        if (path.find(mDownloadPath) == std::string::npos) {
-            return false;
-        }
+		if (path.find(mDownloadPath) != std::string::npos) {
+			return false;
+		}
 
-        if (rsFiles) {
-            std::list<SharedDirInfo>::iterator it;
-            std::list<SharedDirInfo> dirs;
-            rsFiles->getSharedDirectories(dirs);
-            for (it = dirs.begin(); it != dirs.end(); ++it) {
-                if (path.find((*it).filename) == std::string::npos) {
-                    return false;
-                }
-            }
-        }
+		if (rsFiles) {
+			std::list<SharedDirInfo>::iterator it;
+			std::list<SharedDirInfo> dirs;
+			rsFiles->getSharedDirectories(dirs);
+			for (it = dirs.begin(); it != dirs.end(); ++it) {
+				if (path.find((*it).filename) != std::string::npos) {
+					return false;
+				}
+			}
+		}
 	}
 
 	/* check if it exists */

--- a/libretroshare/src/ft/ftcontroller.h
+++ b/libretroshare/src/ft/ftcontroller.h
@@ -175,8 +175,8 @@ class ftController: public RsTickingThread, public pqiServiceMonitor, public p3C
         void FileDownloads(std::list<RsFileHash> &hashs);
 
 		/* Directory Handling */
-        bool 	setDownloadDirectory(std::string path);
-		bool 	setPartialsDirectory(std::string path);
+		bool setDownloadDirectory(std::string path);
+		bool setPartialsDirectory(std::string path);
 		std::string getDownloadDirectory();
 		std::string getPartialsDirectory();
         bool 	FileDetails(const RsFileHash &hash, FileInfo &info);

--- a/libretroshare/src/ft/ftserver.cc
+++ b/libretroshare/src/ft/ftserver.cc
@@ -23,34 +23,39 @@
  *
  */
 
-#include <iostream>
-#include <time.h>
-#include "util/rsdebug.h"
-#include "util/rsdir.h"
-#include "util/rsprint.h"
 #include "crypto/chacha20.h"
-#include "retroshare/rstypes.h"
-#include "retroshare/rspeers.h"
 //const int ftserverzone = 29539;
 
 #include "file_sharing/p3filelists.h"
-#include "ft/ftturtlefiletransferitem.h"
-#include "ft/ftserver.h"
-#include "ft/ftextralist.h"
-#include "ft/ftfilesearch.h"
 #include "ft/ftcontroller.h"
-#include "ft/ftfileprovider.h"
 #include "ft/ftdatamultiplex.h"
 //#include "ft/ftdwlqueue.h"
-#include "turtle/p3turtle.h"
-#include "pqi/p3notify.h"
-#include "rsserver/p3face.h"
+#include "ft/ftextralist.h"
+#include "ft/ftfileprovider.h"
+#include "ft/ftfilesearch.h"
+#include "ft/ftserver.h"
+#include "ft/ftturtlefiletransferitem.h"
 
-#include "pqi/pqi.h"
 #include "pqi/p3linkmgr.h"
+#include "pqi/p3notify.h"
+#include "pqi/pqi.h"
+
+#include "retroshare/rstypes.h"
+#include "retroshare/rspeers.h"
 
 #include "rsitems/rsfiletransferitems.h"
 #include "rsitems/rsserviceids.h"
+
+#include "rsserver/p3face.h"
+#include "rsserver/rsaccounts.h"
+#include "turtle/p3turtle.h"
+
+#include "util/rsdebug.h"
+#include "util/rsdir.h"
+#include "util/rsprint.h"
+
+#include <iostream>
+#include <time.h>
 
 /***
  * #define SERVER_DEBUG       1
@@ -145,9 +150,19 @@ void ftServer::SetupFtServer()
 	/* make Controller */
 	mFtController = new ftController(mFtDataplex, mServiceCtrl, getServiceInfo().mServiceType);
 	mFtController -> setFtSearchNExtra(mFtSearch, mFtExtra);
-	std::string tmppath = ".";
-	mFtController->setPartialsDirectory(tmppath);
-	mFtController->setDownloadDirectory(tmppath);
+
+	std::string emergencySaveDir = rsAccounts->PathAccountDirectory();
+	std::string emergencyPartialsDir = rsAccounts->PathAccountDirectory();
+	if (emergencySaveDir != "")
+	{
+		emergencySaveDir += "/";
+		emergencyPartialsDir += "/";
+	}
+	emergencySaveDir += "Downloads";
+	emergencyPartialsDir += "Partials";
+
+	mFtController->setDownloadDirectory(emergencySaveDir);
+	mFtController->setPartialsDirectory(emergencyPartialsDir);
 
 	/* complete search setup */
 	mFtSearch->addSearchMode(mFtExtra, RS_FILE_HINTS_EXTRA);
@@ -412,9 +427,9 @@ void ftServer::requestDirUpdate(void *ref)
 }
 
 /* Directory Handling */
-void ftServer::setDownloadDirectory(std::string path)
+bool ftServer::setDownloadDirectory(std::string path)
 {
-	mFtController->setDownloadDirectory(path);
+	return mFtController->setDownloadDirectory(path);
 }
 
 std::string ftServer::getDownloadDirectory()
@@ -422,9 +437,9 @@ std::string ftServer::getDownloadDirectory()
 	return mFtController->getDownloadDirectory();
 }
 
-void ftServer::setPartialsDirectory(std::string path)
+bool ftServer::setPartialsDirectory(std::string path)
 {
-	mFtController->setPartialsDirectory(path);
+	return mFtController->setPartialsDirectory(path);
 }
 
 std::string ftServer::getPartialsDirectory()

--- a/libretroshare/src/ft/ftserver.h
+++ b/libretroshare/src/ft/ftserver.h
@@ -202,8 +202,8 @@ public:
          * Directory Handling
          ***/
     virtual void requestDirUpdate(void *ref) ;			// triggers the update of the given reference. Used when browsing.
-    virtual void	setDownloadDirectory(std::string path);
-    virtual void	setPartialsDirectory(std::string path);
+    virtual bool setDownloadDirectory(std::string path);
+    virtual bool setPartialsDirectory(std::string path);
     virtual std::string getDownloadDirectory();
     virtual std::string getPartialsDirectory();
 

--- a/libretroshare/src/retroshare/rsfiles.h
+++ b/libretroshare/src/retroshare/rsfiles.h
@@ -278,8 +278,8 @@ class RsFiles
 		 ***/
         virtual void requestDirUpdate(void *ref) =0 ;			// triggers the update of the given reference. Used when browsing.
 
-		virtual void    setDownloadDirectory(std::string path) = 0;
-		virtual void    setPartialsDirectory(std::string path) = 0;
+		virtual bool setDownloadDirectory(std::string path) = 0;
+		virtual bool setPartialsDirectory(std::string path) = 0;
 		virtual std::string getDownloadDirectory() = 0;
 		virtual std::string getPartialsDirectory() = 0;
 

--- a/retroshare-gui/src/gui/qss/stylesheet/qss.default
+++ b/retroshare-gui/src/gui/qss/stylesheet/qss.default
@@ -244,9 +244,15 @@ OpModeStatus[opMode="Minimal"] {
 	background: #FFCCCC;
 }
 
+/*Property Values at end to overwrite other settings*/
+
 [new=false] {
 	background: #F8F8F8;
 }
 [new=true] {
 	background: #DCECFD;
+}
+
+[WrongValue="true"] {
+	background-color: #FF8080;
 }

--- a/retroshare-gui/src/qss/blacknight.qss
+++ b/retroshare-gui/src/qss/blacknight.qss
@@ -293,9 +293,16 @@ OpModeStatus[opMode="Minimal"] {
 	background: #700000;
 }
 
+/*Property Values at end to overwrite other settings*/
+
 [new=false] {
 	background: #202020;
 }
 [new=true] {
 	background: #005000;
 }
+
+[WrongValue=true] {
+	background-color: #702020;
+}
+

--- a/retroshare-gui/src/qss/qdarkstyle.qss
+++ b/retroshare-gui/src/qss/qdarkstyle.qss
@@ -1126,9 +1126,15 @@ OpModeStatus[opMode="Minimal"] {
 	background: #700000;
 }
 
+/*Property Values at end to overwrite other settings*/
+
 [new=false] {
 	background: #202020;
 }
 [new=true] {
 	background: #005000;
+}
+
+[WrongValue="true"] {
+	background-color: #702020;
 }


### PR DESCRIPTION
Add WrongValue StyleSheet property, when bad directory selected.
Update QLineEdit with current setting so it's possible to see if
something is modified. No need to restart.