### PR TITLE
handle backspace when entering password

### DIFF
--- a/retroshare-nogui/src/TerminalApiClient.cpp
+++ b/retroshare-nogui/src/TerminalApiClient.cpp
@@ -103,6 +103,15 @@ static std::string readStringFromKeyboard(bool passwd_mode)
 
 	while((c=getchar()) != '\n')
 	{
+		// handle backspace
+		if (c == 127) {
+			if(s.length()!=0) {
+				std::cout << "\b \b";
+				s.resize(s.length()-1);
+			}
+			continue;
+		}
+
 		if(passwd_mode)
 			putchar('*') ;
 		else


### PR DESCRIPTION
When entering the password on a nogui instance the backspace is not honored (instead it is added to the password). Fix this by handling it. 

Note 1: This will obviously break when someone is using the backspace key as part of his password. I assume though that this might be a rare corner case.

Note 2: There is also a second code pass that is used when building without web UI (in notifytxt.cc). This code pass is not touched by this patch.