### PR TITLE
WIP: auto detect and use system's cmark

### DIFF
--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -58,7 +58,21 @@ MOC_DIR = temp/moc
 ################################# Linux ##########################################
 # Put lib dir in QMAKE_LFLAGS so it appears before -L/usr/lib
 linux-* {
-    CONFIG += link_pkgconfig
+        CONFIG += link_pkgconfig
+
+        # auto detect installed version of cmark
+        cmark {
+                CMARK_AVAILABLE = $$system(pkg-config --exists libcmark && echo yes)
+                isEmpty(CMARK_AVAILABLE) {
+                        message("using built-in cmark")
+                        CONFIG += cmark_builtin
+                } else {
+                        message("using systems cmark")
+                        DEFINES += HAS_CMARK
+                        PKGCONFIG += libcmark
+                }
+        }
+
 
 	#CONFIG += version_detail_bash_script
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
@@ -95,7 +109,6 @@ unix {
 	pixmap_files.path = "$${PREFIX}/share/pixmaps"
 	pixmap_files.files = ../../data/retroshare.xpm
 	INSTALLS += pixmap_files
-
 }
 
 linux-g++ {
@@ -1373,6 +1386,7 @@ gxsgui {
 cmark {
   DEFINES *= USE_CMARK
 
+    cmark_builtin {
   HEADERS += \
     ../../supportlibs/cmark/src/buffer.h								 \
     ../../supportlibs/cmark/src/chunk.h									 \
@@ -1408,5 +1422,5 @@ cmark {
     ../../supportlibs/cmark/src/scanners.c								 \
     ../../supportlibs/cmark/src/utf8.c										 \
     ../../supportlibs/cmark/src/xml.c											 \
-
+    }
 }

--- a/retroshare-gui/src/util/HandleRichText.cpp
+++ b/retroshare-gui/src/util/HandleRichText.cpp
@@ -39,11 +39,14 @@
 #include "util/rstime.h"
 
 #ifdef USE_CMARK
-//Include for CMark
-// This needs to be fixed: use system library if available, etc.
-#include <gui/../../../supportlibs/cmark/src/cmark.h>
-#include <gui/../../../supportlibs/cmark/src/node.h>
-#endif
+  //Include for CMark
+  #ifdef HAS_CMARK
+    #include <cmark.h>
+  #else
+    #include <gui/../../../supportlibs/cmark/src/cmark.h>
+    #include <gui/../../../supportlibs/cmark/src/node.h>
+  #endif // HAS_CMARK
+#endif // USE_CMARK
 
 #include <iostream>
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -32,6 +32,8 @@ CONFIG *= gxsdistsync
 
 # disabled by the time we fix compilation
 CONFIG *= no_cmark
+# still allow overwriting
+cmark:CONFIG -= no_cmark
 
 # To disable RetroShare-nogui append the following
 # assignation to qmake command line "CONFIG+=no_retroshare_nogui"


### PR DESCRIPTION
won't compile right now (see #999 )
Whith this patch it compiles and works (i have no idea whether it leaks memory now or not)
https://gist.github.com/sehraf/e8f753844427d7a7551c14a84a84fa7e