### PR TITLE
fixed webui files generation under MSYS2

### DIFF
--- a/libresapi/src/libresapi.pro
+++ b/libresapi/src/libresapi.pro
@@ -110,7 +110,7 @@ libresapihttpserver {
         QMAKE_EXTRA_COMPILERS += create_webfiles_html create_webfiles_js create_webfiles_css
     }
 
-    win32 {
+    win32-x {
 	DEFINES *= WINDOWS_SYS
 	INCLUDEPATH += . $$INC_DIR
 
@@ -124,6 +124,19 @@ libresapihttpserver {
 
 	# create dummy files
 	system($$MAKE_SRC\\init.bat .)
+    }
+
+    win32 {
+	DEFINES *= WINDOWS_SYS
+	INCLUDEPATH += . $$INC_DIR
+
+    PRO_PATH=$$shell_path($$_PRO_FILE_PWD_)
+    MAKE_SRC=$$shell_path($$PRO_PATH/webui-src/make-src)
+
+    QMAKE_POST_LINK=$$MAKE_SRC/build.sh $$PRO_PATH
+
+	# create dummy files
+	system($$MAKE_SRC/init.sh .)
     }
 
 	linux {

--- a/libresapi/src/libresapi.pro
+++ b/libresapi/src/libresapi.pro
@@ -110,7 +110,7 @@ libresapihttpserver {
         QMAKE_EXTRA_COMPILERS += create_webfiles_html create_webfiles_js create_webfiles_css
     }
 
-    win32-x {
+    appveyor {
 	DEFINES *= WINDOWS_SYS
 	INCLUDEPATH += . $$INC_DIR
 


### PR DESCRIPTION
The reason it failed is because MSYS2 uses unix tools and unix pathnames so I just made it use the  build.sh instead of build.bat.

I changed the previous target from "win32" to "win32-x" so it should keep running on appveyor which does use windows cmd.exe I think. Can someone using appveyor confirm the fix is fine?
