### PR TITLE
Added switch to enable native dialogs at compile time

### DIFF
--- a/build_scripts/Windows-msys2/build/build.bat
+++ b/build_scripts/Windows-msys2/build/build.bat
@@ -48,7 +48,7 @@ echo.
 
 title Build - %SourceName%-%RsBuildConfig% [qmake]
 
-set RS_QMAKE_CONFIG="CONFIG+=%RsBuildConfig%"
+set RS_QMAKE_CONFIG=%RS_QMAKE_CONFIG% "CONFIG+=%RsBuildConfig%"
 if "%ParamAutologin%"=="1" set RS_QMAKE_CONFIG=%RS_QMAKE_CONFIG% "CONFIG+=rs_autologin"
 if "%ParamPlugins%"=="1" set RS_QMAKE_CONFIG=%RS_QMAKE_CONFIG% "CONFIG+=retroshare_plugins"
 
@@ -63,7 +63,7 @@ echo.
 
 title Build - %SourceName%-%RsBuildConfig% [make]
 
-%EnvMSYS2Cmd% "make -j 4"
+%EnvMSYS2Cmd% "make -j %NUMBER_OF_PROCESSORS%"
 
 :error
 popd

--- a/build_scripts/Windows-msys2/build/env-base.bat
+++ b/build_scripts/Windows-msys2/build/env-base.bat
@@ -6,6 +6,7 @@ set ParamDebug=0
 set ParamAutologin=0
 set ParamPlugins=0
 set ParamTor=0
+set RS_QMAKE_CONFIG=
 
 :parameter_loop
 if "%~1" NEQ "" (
@@ -24,6 +25,8 @@ if "%~1" NEQ "" (
 			set ParamPlugins=1
 		) else if "%%~a"=="tor" (
 			set ParamTor=1
+		) else if "%%~a"=="CONFIG+" (
+			set RS_QMAKE_CONFIG=%RS_QMAKE_CONFIG% %1
 		) else (
 			echo.
 			echo Unknown parameter %1

--- a/retroshare-gui/src/gui/ShareManager.cpp
+++ b/retroshare-gui/src/gui/ShareManager.cpp
@@ -123,7 +123,11 @@ void ShareManager::doubleClickedCell(int row,int column)
 {
     if(column == COLUMN_PATH)
     {
+#ifdef NATIVEDIALOGS
+        QString dirname = QFileDialog::getExistingDirectory(NULL,tr("Choose directory"),QString(),                                   QFileDialog::ShowDirsOnly);
+#else
         QString dirname = QFileDialog::getExistingDirectory(NULL,tr("Choose directory"),QString(),QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
+#endif
 
         if(!dirname.isNull())
         {
@@ -357,7 +361,11 @@ void ShareManager::showEvent(QShowEvent *event)
 
 void ShareManager::addShare()
 {
+#ifdef NATIVEDIALOGS
+	QString fname = QFileDialog::getExistingDirectory(NULL,tr("Choose a directory to share"),QString(),                                   QFileDialog::ShowDirsOnly);
+#else
     QString fname = QFileDialog::getExistingDirectory(NULL,tr("Choose a directory to share"),QString(),QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
+#endif
 
     if(fname.isNull())
         return;

--- a/retroshare-gui/src/gui/ShareManager.cpp
+++ b/retroshare-gui/src/gui/ShareManager.cpp
@@ -37,6 +37,7 @@
 #include "gui/common/GroupDefs.h"
 #include "gui/notifyqt.h"
 #include "util/QtVersion.h"
+#include "util/misc.h"
 
 /* Images for context menu icons */
 #define IMAGE_CANCEL               ":/images/delete.png"
@@ -123,11 +124,7 @@ void ShareManager::doubleClickedCell(int row,int column)
 {
     if(column == COLUMN_PATH)
     {
-#ifdef NATIVEDIALOGS
-        QString dirname = QFileDialog::getExistingDirectory(NULL,tr("Choose directory"),QString(),                                   QFileDialog::ShowDirsOnly);
-#else
-        QString dirname = QFileDialog::getExistingDirectory(NULL,tr("Choose directory"),QString(),QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
-#endif
+		QString dirname = misc::getExistingDirectory(nullptr,tr("Choose directory"),QString());
 
         if(!dirname.isNull())
         {
@@ -361,11 +358,7 @@ void ShareManager::showEvent(QShowEvent *event)
 
 void ShareManager::addShare()
 {
-#ifdef NATIVEDIALOGS
-	QString fname = QFileDialog::getExistingDirectory(NULL,tr("Choose a directory to share"),QString(),                                   QFileDialog::ShowDirsOnly);
-#else
-    QString fname = QFileDialog::getExistingDirectory(NULL,tr("Choose a directory to share"),QString(),QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
-#endif
+	QString fname = misc::getExistingDirectory(nullptr,tr("Choose a directory to share"),QString());
 
     if(fname.isNull())
         return;

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -22,7 +22,6 @@
 #include <QApplication>
 #include <QBuffer>
 #include <QColorDialog>
-#include <QFontDialog>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QMessageBox>
@@ -1487,11 +1486,8 @@ void ChatWidget::chooseFont()
 {
 	bool ok;
 	//Use NULL as parent as with this QFontDialog don't take care of title nether options.
-#ifdef NATIVEDIALOGS
-	QFont font = QFontDialog::getFont(&ok, currentFont, NULL, tr("Choose your font.")                                 );
-#else
-	QFont font = QFontDialog::getFont(&ok, currentFont, NULL, tr("Choose your font."),QFontDialog::DontUseNativeDialog);
-#endif
+	QFont font = misc::getFont(&ok, currentFont, nullptr, tr("Choose your font."));
+
 	if (ok) {
 		currentFont = font;
 		setFont();

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -1487,7 +1487,11 @@ void ChatWidget::chooseFont()
 {
 	bool ok;
 	//Use NULL as parent as with this QFontDialog don't take care of title nether options.
+#ifdef NATIVEDIALOGS
+	QFont font = QFontDialog::getFont(&ok, currentFont, NULL, tr("Choose your font.")                                 );
+#else
 	QFont font = QFontDialog::getFont(&ok, currentFont, NULL, tr("Choose your font."),QFontDialog::DontUseNativeDialog);
+#endif
 	if (ok) {
 		currentFont = font;
 		setFont();

--- a/retroshare-gui/src/gui/settings/ChatPage.cpp
+++ b/retroshare-gui/src/gui/settings/ChatPage.cpp
@@ -19,7 +19,6 @@
  *******************************************************************************/
 
 #include <QColorDialog>
-#include <QFontDialog>
 #include <QMenu>
 #include <QMessageBox>
 #include <time.h>
@@ -415,11 +414,8 @@ ChatPage::load()
 void ChatPage::on_pushButtonChangeChatFont_clicked()
 {
 	bool ok;
-#ifdef NATIVEDIALOGS
-	QFont font = QFontDialog::getFont(&ok, fontTempChat, this, tr("Choose your default font for Chat.")                                 );
-#else
-	QFont font = QFontDialog::getFont(&ok, fontTempChat, this, tr("Choose your default font for Chat."),QFontDialog::DontUseNativeDialog);
-#endif
+	QFont font = misc::getFont(&ok, fontTempChat, this, tr("Choose your default font for Chat."));
+
 	if (ok) {
 		fontTempChat = font;
 		// using fontTempChat.rawname() does not always work!

--- a/retroshare-gui/src/gui/settings/ChatPage.cpp
+++ b/retroshare-gui/src/gui/settings/ChatPage.cpp
@@ -415,7 +415,11 @@ ChatPage::load()
 void ChatPage::on_pushButtonChangeChatFont_clicked()
 {
 	bool ok;
+#ifdef NATIVEDIALOGS
+	QFont font = QFontDialog::getFont(&ok, fontTempChat, this, tr("Choose your default font for Chat.")                                 );
+#else
 	QFont font = QFontDialog::getFont(&ok, fontTempChat, this, tr("Choose your default font for Chat."),QFontDialog::DontUseNativeDialog);
+#endif
 	if (ok) {
 		fontTempChat = font;
 		// using fontTempChat.rawname() does not always work!

--- a/retroshare-gui/src/util/misc.cpp
+++ b/retroshare-gui/src/util/misc.cpp
@@ -25,6 +25,7 @@
 #include <QByteArray>
 #include <QBuffer>
 #include <time.h>
+#include <QFontDialog>
 
 #include "misc.h"
 
@@ -315,7 +316,7 @@ bool misc::getOpenFileName(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type);
 
-#ifdef NATIVEDIALOGS
+#ifdef RS_NATIVEDIALOGS
     file = QFileDialog::getOpenFileName(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks |                                    options);
 #else
     file = QFileDialog::getOpenFileName(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog | options);
@@ -342,7 +343,7 @@ bool misc::getOpenFileNames(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type);
 
-#ifdef NATIVEDIALOGS
+#ifdef RS_NATIVEDIALOGS
     files = QFileDialog::getOpenFileNames(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks |                                    options);
 #else
     files = QFileDialog::getOpenFileNames(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog | options);
@@ -372,7 +373,7 @@ bool misc::getSaveFileName(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type) + "/" + file;
 
-#ifdef NATIVEDIALOGS
+#ifdef RS_NATIVEDIALOGS
     file = QFileDialog::getSaveFileName(parent, caption, lastDir, filter, selectedFilter,                                    options);
 #else
     file = QFileDialog::getSaveFileName(parent, caption, lastDir, filter, selectedFilter, QFileDialog::DontUseNativeDialog | options);
@@ -384,5 +385,23 @@ bool misc::getSaveFileName(QWidget *parent, RshareSettings::enumLastDir type
     lastDir = QFileInfo(file).absoluteDir().absolutePath();
     Settings->setLastDir(type, lastDir);
 
-    return true;
+	return true;
+}
+
+QFont misc::getFont(bool *ok, const QFont &initial, QWidget *parent, const QString &title)
+{
+#ifdef RS_NATIVEDIALOGS
+		return QFontDialog::getFont(ok, initial, parent, title);
+#else
+		return QFontDialog::getFont(ok, initial, parent, title, QFontDialog::DontUseNativeDialog);
+#endif
+}
+
+QString misc::getExistingDirectory(QWidget *parent, const QString &caption, const QString &dir)
+{
+#ifdef RS_NATIVEDIALOGS
+		return QFileDialog::getExistingDirectory(parent, caption, dir, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+#else
+		return QFileDialog::getExistingDirectory(parent, caption, dir, QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+#endif
 }

--- a/retroshare-gui/src/util/misc.cpp
+++ b/retroshare-gui/src/util/misc.cpp
@@ -315,7 +315,11 @@ bool misc::getOpenFileName(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type);
 
+#ifdef NATIVEDIALOGS
+    file = QFileDialog::getOpenFileName(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks |                                    options);
+#else
     file = QFileDialog::getOpenFileName(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog | options);
+#endif
 
     if (file.isEmpty())
         return false;
@@ -338,7 +342,11 @@ bool misc::getOpenFileNames(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type);
 
+#ifdef NATIVEDIALOGS
+    files = QFileDialog::getOpenFileNames(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks |                                    options);
+#else
     files = QFileDialog::getOpenFileNames(parent, caption, lastDir, filter, NULL, QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog | options);
+#endif
 
     if (files.isEmpty())
         return false;
@@ -364,7 +372,11 @@ bool misc::getSaveFileName(QWidget *parent, RshareSettings::enumLastDir type
 {
     QString lastDir = Settings->getLastDir(type) + "/" + file;
 
+#ifdef NATIVEDIALOGS
+    file = QFileDialog::getSaveFileName(parent, caption, lastDir, filter, selectedFilter,                                    options);
+#else
     file = QFileDialog::getSaveFileName(parent, caption, lastDir, filter, selectedFilter, QFileDialog::DontUseNativeDialog | options);
+#endif
 
     if (file.isEmpty())
         return false;

--- a/retroshare-gui/src/util/misc.h
+++ b/retroshare-gui/src/util/misc.h
@@ -171,8 +171,17 @@ class misc : public QObject
 
     static bool getSaveFileName(QWidget *parent, RshareSettings::enumLastDir type
                                 , const QString &caption , const QString &filter
-                                , QString &file, QString *selectedFilter = NULL
+								, QString &file, QString *selectedFilter = NULL
                                 , QFileDialog::Options options = 0);
+
+	static QFont getFont(bool *ok
+						 , const QFont &initial
+						 , QWidget *parent = nullptr
+						 , const QString &title = QString());
+
+	static QString getExistingDirectory(QWidget *parent = nullptr
+										, const QString &caption = QString()
+										, const QString &dir = QString());
 };
 
 //  Trick to get a portable sleep() function

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -187,6 +187,10 @@ rs_deep_search:CONFIG -= no_rs_deep_search
 #RS_EXTRA_VERSION=git
 
 
+# To enable native dialogs append the following assignation to qmake command line
+# "CONFIG+=use_native_dialogs"
+use_native_dialogs:DEFINES *= NATIVEDIALOGS
+
 ###########################################################################################################################################################
 #
 #  V07_NON_BACKWARD_COMPATIBLE_CHANGE_001:

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -186,10 +186,9 @@ rs_deep_search:CONFIG -= no_rs_deep_search
 # assignation to qmake command line 'RS_EXTRA_VERSION=""'
 #RS_EXTRA_VERSION=git
 
-
 # To enable native dialogs append the following assignation to qmake command line
-# "CONFIG+=use_native_dialogs"
-use_native_dialogs:DEFINES *= NATIVEDIALOGS
+# "CONFIG+=rs_use_native_dialogs"
+rs_use_native_dialogs:DEFINES *= RS_NATIVEDIALOGS
 
 ###########################################################################################################################################################
 #


### PR DESCRIPTION
Native file dialogs were disabled because they caused errors on some platforms.
This commits adds a compile time switch to enable them again.

CONFIG+=use_native_dialogs