### PR TITLE
Add support for displaying TLSv1.3

### DIFF
--- a/libretroshare/src/pqi/pqissl.cc
+++ b/libretroshare/src/pqi/pqissl.cc
@@ -313,7 +313,12 @@ void pqissl::getCryptoParams(RsPeerCryptoParams& params)
 		params.cipher_bits_2 = al2 ;
 
 		char *desc = SSL_CIPHER_description(SSL_get_current_cipher(ssl_connection), NULL, 0);
-		params.cipher_version = std::string(desc).find("TLSv1.2") != std::string::npos ? std::string("TLSv1.2") : std::string("TLSv1");
+		params.cipher_version =
+		        std::string(desc).find("TLSv1.3") != std::string::npos ?
+		            std::string("TLSv1.3") :
+		            std::string(desc).find("TLSv1.2") != std::string::npos ?
+		                std::string("TLSv1.2") :
+		                std::string("TLSv1");
 		OPENSSL_free(desc);
 	}
 	else

--- a/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
+++ b/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
@@ -170,7 +170,7 @@ void ConfCertDialog::load()
 			  ct += QString::fromStdString(cdet.cipher_version) + ": ";
 			 ct += QString::fromStdString(cdet.cipher_name);
 
-			 if(cdet.cipher_version != "TLSv1.2")
+			 if(cdet.cipher_version != "TLSv1.2" && cdet.cipher_version != "TLSv1.3")
 				ct += QString::number(cdet.cipher_bits_1);
 
 			 ui.crypto_info->setText(ct) ;


### PR DESCRIPTION
OpenSSL already uses TLSv1.3 when available, only displaying the version needs to be fixed.