### PR TITLE
WIP: V0.6 gxs fix

### DIFF
--- a/libretroshare/src/gxs/rsgds.h
+++ b/libretroshare/src/gxs/rsgds.h
@@ -82,13 +82,13 @@ struct RsGroupNetworkStats
 {
 	RsGroupNetworkStats() :
 	    mSuppliers(0), mMaxVisibleCount(0), mGrpAutoSync(false),
-	    mAllowMsgSync(false), mLastGroupModificationTS(0) {}
+	    mAllowMsgSync(false), mLastGroupMessageTS(0) {}
 
 	uint32_t mSuppliers;
 	uint32_t mMaxVisibleCount;
 	bool     mGrpAutoSync;
 	bool     mAllowMsgSync;
-	time_t   mLastGroupModificationTS;
+	time_t   mLastGroupMessageTS;
 };
 
 typedef std::map<RsGxsGroupId,      std::vector<RsNxsMsg*> > NxsMsgDataResult;

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -1210,7 +1210,7 @@ bool RsGenExchange::getGroupMeta(const uint32_t &token, std::list<RsGroupMetaDat
 			m.mVisibleMsgCount = sts.mMaxVisibleCount ;
 
 			if((!(IS_GROUP_SUBSCRIBED(gMeta.mSubscribeFlags))) || gMeta.mLastPost == 0)
-				m.mLastPost = sts.mLastGroupModificationTS ;
+				m.mLastPost = sts.mLastGroupMessageTS ;
 		}
 		else
 		{
@@ -1391,7 +1391,7 @@ bool RsGenExchange::getGroupData(const uint32_t &token, std::vector<RsGxsGrpItem
 						// uninitialised, so we will it too.
 
 						if((!(IS_GROUP_SUBSCRIBED(gItem->meta.mSubscribeFlags))) || gItem->meta.mLastPost == 0)
-							gItem->meta.mLastPost = sts.mLastGroupModificationTS ;
+							gItem->meta.mLastPost = sts.mLastGroupMessageTS ;
 					}
 					else
 					{

--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -997,7 +997,7 @@ void RsGxsNetService::handleRecvSyncGrpStatistics(RsNxsSyncGrpStatsItem *grs)
 	   rec.suppliers.ids.insert(grs->PeerId()) ;
 	   rec.max_visible_count = std::max(rec.max_visible_count,grs->number_of_posts) ;
 	   rec.statistics_update_TS = time(NULL) ;
-	   rec.last_group_modification_TS = grs->last_post_TS;
+	   rec.last_group_post_TS = std::max(rec.last_group_post_TS,grs->last_post_TS);		// friends may not agree on last modification TS, so we keep the most recent one.
 
 	   if (old_count != rec.max_visible_count || old_suppliers_count != rec.suppliers.ids.size())
 		  mNewStatsToNotify.insert(grs->grpId) ;
@@ -2511,7 +2511,7 @@ bool RsGxsNetService::getGroupNetworkStats(const RsGxsGroupId& gid,RsGroupNetwor
     stats.mMaxVisibleCount = it->second.max_visible_count ;
     stats.mAllowMsgSync = mAllowMsgSync ;
     stats.mGrpAutoSync = mGrpAutoSync ;
-    stats.mLastGroupModificationTS = it->second.last_group_modification_TS ;
+    stats.mLastGroupMessageTS = it->second.last_group_modification_TS ;
 
     return true ;
 }
@@ -4731,7 +4731,7 @@ RsGxsGrpConfig& RsGxsNetService::locked_getGrpConfig(const RsGxsGroupId& grp_id)
 
 		conf.max_visible_count = 0 ;
 		conf.statistics_update_TS = 0 ;
-		conf.last_group_modification_TS = 0 ;
+		conf.last_group_post_TS = 0 ;
 
 		return conf ;
 	}
@@ -5344,7 +5344,7 @@ bool RsGxsNetService::search( const std::string& substring,
 			s.mPublishTs         = it->second->mPublishTs;
 			s.mAuthorId          = it->second->mAuthorId;
 			s.mNumberOfMessages  = stats.mMaxVisibleCount;
-			s.mLastMessageTs     = stats.mLastGroupModificationTS;
+			s.mLastMessageTs     = stats.mLastGroupMessageTS;
 			s.mPopularity        = it->second->mPop;
 
 			group_infos.push_back(s);

--- a/libretroshare/src/rsitems/rsgxsupdateitems.h
+++ b/libretroshare/src/rsitems/rsgxsupdateitems.h
@@ -58,7 +58,7 @@ public:
 
 		max_visible_count = 0 ;
 		statistics_update_TS = 0 ;
-		last_group_modification_TS = 0 ;
+		last_group_post_TS = 0 ;
 	}
 
 	uint32_t     msg_keep_delay ;	// delay after which we discard the posts
@@ -68,7 +68,7 @@ public:
 	RsTlvPeerIdSet suppliers;		// list of friends who feed this group
 	uint32_t max_visible_count ;	// max visible count reported by contributing friends
 	time_t statistics_update_TS ;	// last time the max visible count was updated.
-	time_t last_group_modification_TS ;	// last time the group was modified, either in meta data or in the list of messages posted in it.
+	time_t last_group_post_TS ;	// last time the group was modified, either in meta data or in the list of messages posted in it.
 };
 
 class RsGxsGrpConfigItem : public RsGxsNetServiceItem, public RsGxsGrpConfig


### PR DESCRIPTION
This PR makes RS sync according to last post time instead of current time. The effect is that when syncing for 1 month, it always syncs a time window of 1 months of posts instead of sync-ing the last month of posts. 

Should this be extending to also storing 1 months of posts instead of posts for the last month? Not sure because some users may also use the storage time to auto-clean dead forums.

It might also be possible to offer the two ways of sync as an option (although that may make the  UI more complicated): sync for the last month (or last 3 months etc) or sync for a slidign wndow of 1 month (resp. 3 months etc)
 
This is to be tested (not to be merged yet)