### PR TITLE
fixed compilation on Windows/MSYS2

### DIFF
--- a/retroshare-gui/src/gui/common/FriendSelectionWidget.cpp
+++ b/retroshare-gui/src/gui/common/FriendSelectionWidget.cpp
@@ -689,7 +689,7 @@ void FriendSelectionWidget::requestGXSIdList()
 	mIdQueue->requestGroupInfo(token, RS_TOKREQ_ANSTYPE_DATA, opts, IDDIALOG_IDLIST);
 }
 
-template<> void FriendSelectionWidget::setSelectedIds<RsGxsId,FriendSelectionWidget::IDTYPE_GXS>(const std::set<RsGxsId>& ids, bool add)
+template<> inline void FriendSelectionWidget::setSelectedIds<RsGxsId,FriendSelectionWidget::IDTYPE_GXS>(const std::set<RsGxsId>& ids, bool add)
 {
     mPreSelectedGxsIds = ids ;
     requestGXSIdList();

--- a/retroshare-gui/src/gui/common/FriendSelectionWidget.cpp
+++ b/retroshare-gui/src/gui/common/FriendSelectionWidget.cpp
@@ -689,6 +689,7 @@ void FriendSelectionWidget::requestGXSIdList()
 	mIdQueue->requestGroupInfo(token, RS_TOKREQ_ANSTYPE_DATA, opts, IDDIALOG_IDLIST);
 }
 
+// This call is inlined so that there's no linking conflict with MinGW on Windows
 template<> inline void FriendSelectionWidget::setSelectedIds<RsGxsId,FriendSelectionWidget::IDTYPE_GXS>(const std::set<RsGxsId>& ids, bool add)
 {
     mPreSelectedGxsIds = ids ;


### PR DESCRIPTION
This  prevents the following error:

C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/7.3.0/../../../../i686-w64-mingw32/bin/ld.exe: ./temp/obj/GxsGroupDialog.o: in function `ZN21FriendSelectionWidget14setSelectedIdsI17t_RsGenericIdTypeILj16ELb0ELj6EELNS_6IdTypeE4EEEvRKSt3setIT_St4lessIS5_ESaIS5_EEb':
C:\msys64\home\zapek\RetroShare\retroshare-gui\src/./gui/common/FriendSelectionWidget.h:98: multiple definition of `void FriendSelectionWidget::setSelectedIds<t_RsGenericIdType<16u, false, 6u>, (FriendSelectionWidget::IdType)4>(std::set<t_RsGenericIdType<16u, false, 6u>, std::less<t_RsGenericIdType<16u, false, 6u> >, std::allocator<t_RsGenericIdType<16u, false, 6u> > > const&, bool)'; ./temp/obj/FriendSelectionWidget.o:C:\msys64\home\zapek\RetroShare\retroshare-gui\src/gui/common/FriendSelectionWidget.cpp:693: first defined here

