### PR TITLE
fixed JSONAPI build for Windows

### DIFF
--- a/WindowsMSys2_InstallGuide.md
+++ b/WindowsMSys2_InstallGuide.md
@@ -32,7 +32,7 @@ Run MSYS2 MSYS again and finish updating with:
 
 Install the default programs needed to build:
 
-	pacman -S base-devel git wget p7zip gcc perl ruby python2
+	pacman -S base-devel git wget p7zip gcc perl ruby python2 doxygen cmake
 
 Install the 32-bit toolchain:
 

--- a/jsonapi-generator/src/jsonapi-generator.cpp
+++ b/jsonapi-generator/src/jsonapi-generator.cpp
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QCoreApplication>
-#include <QDebug>
-#include <QtXml>
-#include <QDirIterator>
-#include <QFileInfo>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDebug>
+#include <QtXml/QtXml>
+#include <QtCore/QDirIterator>
+#include <QtCore/QFileInfo>
 #include <iterator>
 
 struct MethodParam

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -860,16 +860,25 @@ rs_gxs_trans {
 }
 
 rs_jsonapi {
-    JSONAPI_GENERATOR_SRC=$$system_path($$clean_path($${RS_SRC_PATH}/jsonapi-generator/src/))
-    JSONAPI_GENERATOR_OUT=$$system_path($$clean_path($${RS_BUILD_PATH}/jsonapi-generator/src/))
-    JSONAPI_GENERATOR_EXE=$$system_path($$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-generator))
-    DOXIGEN_INPUT_DIRECTORY=$$system_path($$clean_path($${PWD}))
-    DOXIGEN_CONFIG_SRC=$$system_path($$clean_path($${RS_SRC_PATH}/jsonapi-generator/src/jsonapi-generator-doxygen.conf))
-    DOXIGEN_CONFIG_OUT=$$system_path($$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-generator-doxygen.conf))
-    WRAPPERS_INCL_FILE=$$system_path($$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-includes.inl))
-    WRAPPERS_REG_FILE=$$system_path($$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-wrappers.inl))
+    JSONAPI_GENERATOR_SRC=$$clean_path($${RS_SRC_PATH}/jsonapi-generator/src/)
+    JSONAPI_GENERATOR_OUT=$$clean_path($${RS_BUILD_PATH}/jsonapi-generator/src/)
+    win32 {
+        CONFIG(release, debug|release) {
+            JSONAPI_GENERATOR_EXE=$$clean_path($${JSONAPI_GENERATOR_OUT}/release/jsonapi-generator.exe)
+        }
+	CONFIG(debug, debug|release) {
+            JSONAPI_GENERATOR_EXE=$$clean_path($${JSONAPI_GENERATOR_OUT}/debug/jsonapi-generator.exe)
+        }
+    } else {
+        JSONAPI_GENERATOR_EXE=$$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-generator)
+    }
+    DOXIGEN_INPUT_DIRECTORY=$$clean_path($${PWD})
+    DOXIGEN_CONFIG_SRC=$$clean_path($${RS_SRC_PATH}/jsonapi-generator/src/jsonapi-generator-doxygen.conf)
+    DOXIGEN_CONFIG_OUT=$$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-generator-doxygen-final.conf)
+    WRAPPERS_INCL_FILE=$$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-includes.inl)
+    WRAPPERS_REG_FILE=$$clean_path($${JSONAPI_GENERATOR_OUT}/jsonapi-wrappers.inl)
 
-    restbed.target = $$system_path($$clean_path($${RESTBED_BUILD_PATH}/library/librestbed.a))
+    restbed.target = $$clean_path($${RESTBED_BUILD_PATH}/library/librestbed.a)
     restbed.commands = \
         cd $${RS_SRC_PATH};\
         git submodule update --init --recommend-shallow supportlibs/restbed;\
@@ -878,7 +887,7 @@ rs_jsonapi {
         git submodule update --init --recommend-shallow dependency/catch;\
         git submodule update --init --recommend-shallow dependency/kashmir;\
         mkdir -p $${RESTBED_BUILD_PATH}; cd $${RESTBED_BUILD_PATH};\
-        cmake -DBUILD_SSL=OFF -DCMAKE_INSTALL_PREFIX=. -B. -H$${RESTBED_SRC_PATH};\
+        cmake -DBUILD_SSL=OFF -DCMAKE_INSTALL_PREFIX=. -B. -H$$shell_path($${RESTBED_SRC_PATH});\
         make; make install
     QMAKE_EXTRA_TARGETS += restbed
     libretroshare.depends += restbed
@@ -891,8 +900,8 @@ rs_jsonapi {
     jsonwrappersincl.target = $${WRAPPERS_INCL_FILE}
     jsonwrappersincl.commands = \
         cp $${DOXIGEN_CONFIG_SRC} $${DOXIGEN_CONFIG_OUT}; \
-        echo OUTPUT_DIRECTORY=$${JSONAPI_GENERATOR_OUT} >> $${DOXIGEN_CONFIG_OUT};\
-        echo INPUT=$${DOXIGEN_INPUT_DIRECTORY} >> $${DOXIGEN_CONFIG_OUT}; \
+        echo OUTPUT_DIRECTORY=$$shell_path($${JSONAPI_GENERATOR_OUT}) >> $${DOXIGEN_CONFIG_OUT};\
+        echo INPUT=$$shell_path($${DOXIGEN_INPUT_DIRECTORY}) >> $${DOXIGEN_CONFIG_OUT}; \
         doxygen $${DOXIGEN_CONFIG_OUT}; \
         $${JSONAPI_GENERATOR_EXE} $${JSONAPI_GENERATOR_SRC} $${JSONAPI_GENERATOR_OUT};
     QMAKE_EXTRA_TARGETS += jsonwrappersincl

--- a/libretroshare/src/use_libretroshare.pri
+++ b/libretroshare/src/use_libretroshare.pri
@@ -57,6 +57,9 @@ rs_jsonapi {
     QMAKE_LIBDIR *= $$clean_path($${RESTBED_BUILD_PATH}/library/)
     # Using sLibs would fail as librestbed.a is generated at compile-time
     LIBS *= -L$$clean_path($${RESTBED_BUILD_PATH}/library/) -lrestbed
+    win32-g++ {
+	LIBS += -lwsock32
+    }
 }
 
 linux-* {

--- a/libretroshare/src/use_libretroshare.pri
+++ b/libretroshare/src/use_libretroshare.pri
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU Lesser General Public License     #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.       #
 ################################################################################
-DEPENDPATH *= $$system_path($$clean_path($${PWD}/../../libretroshare/src/))
-INCLUDEPATH  *= $$system_path($$clean_path($${PWD}/../../libretroshare/src))
-LIBS *= -L$$system_path($$clean_path($${OUT_PWD}/../../libretroshare/src/lib/)) -lretroshare
+DEPENDPATH *= $$clean_path($${PWD}/../../libretroshare/src/)
+INCLUDEPATH  *= $$clean_path($${PWD}/../../libretroshare/src)
+LIBS *= -L$$clean_path($${OUT_PWD}/../../libretroshare/src/lib/) -lretroshare
 
 equals(TARGET, retroshare):equals(TEMPLATE, lib){
 } else {
-    PRE_TARGETDEPS *= $$system_path($$clean_path($$OUT_PWD/../../libretroshare/src/lib/libretroshare.a))
+    PRE_TARGETDEPS *= $$clean_path($$OUT_PWD/../../libretroshare/src/lib/libretroshare.a)
 }
 
 !include("../../openpgpsdk/src/use_openpgpsdk.pri"):error("Including")
@@ -36,7 +36,7 @@ bitdht {
 RAPIDJSON_AVAILABLE = $$system(pkg-config --atleast-version 1.1 RapidJSON && echo yes)
 isEmpty(RAPIDJSON_AVAILABLE) {
     message("using built-in rapidjson")
-    INCLUDEPATH *= $$system_path($$clean_path($${PWD}/../../rapidjson-1.1.0))
+    INCLUDEPATH *= $$clean_path($${PWD}/../../rapidjson-1.1.0)
 } else {
     message("using systems rapidjson")
     DEFINES *= HAS_RAPIDJSON
@@ -48,15 +48,15 @@ mLibs = $$RS_SQL_LIB ssl crypto $$RS_THREAD_LIB $$RS_UPNP_LIB
 dLibs =
 
 rs_jsonapi {
-    RS_SRC_PATH=$$system_path($$clean_path($${PWD}/../../))
-    RS_BUILD_PATH=$$system_path($$clean_path($${OUT_PWD}/../../))
-    RESTBED_SRC_PATH=$$system_path($$clean_path($${RS_SRC_PATH}/supportlibs/restbed))
-    RESTBED_BUILD_PATH=$$system_path($$clean_path($${RS_BUILD_PATH}/supportlibs/restbed))
+    RS_SRC_PATH=$$clean_path($${PWD}/../../)
+    RS_BUILD_PATH=$$clean_path($${OUT_PWD}/../../)
+    RESTBED_SRC_PATH=$$clean_path($${RS_SRC_PATH}/supportlibs/restbed)
+    RESTBED_BUILD_PATH=$$clean_path($${RS_BUILD_PATH}/supportlibs/restbed)
 
-    INCLUDEPATH *= $$system_path($$clean_path($${RESTBED_BUILD_PATH}/include/))
-    QMAKE_LIBDIR *= $$system_path($$clean_path($${RESTBED_BUILD_PATH}/library/))
+    INCLUDEPATH *= $$clean_path($${RESTBED_BUILD_PATH}/include/)
+    QMAKE_LIBDIR *= $$clean_path($${RESTBED_BUILD_PATH}/library/)
     # Using sLibs would fail as librestbed.a is generated at compile-time
-    LIBS *= -L$$system_path($$clean_path($${RESTBED_BUILD_PATH}/library/)) -lrestbed
+    LIBS *= -L$$clean_path($${RESTBED_BUILD_PATH}/library/) -lrestbed
 }
 
 linux-* {

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -170,7 +170,7 @@ win32-g++ {
 
 	OBJECTS_DIR = temp/obj
 
-    dLib = ws2_32 wsock32 gdi32 uuid ole32 iphlpapi crypt32 winmm
+    dLib = ws2_32 gdi32 uuid ole32 iphlpapi crypt32 winmm
     LIBS *= $$linkDynamicLibs(dLib)
 
 	RC_FILE = gui/images/retroshare_win.rc

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -170,7 +170,7 @@ win32-g++ {
 
 	OBJECTS_DIR = temp/obj
 
-    dLib = ws2_32 gdi32 uuid ole32 iphlpapi crypt32 winmm
+    dLib = ws2_32 wsock32 gdi32 uuid ole32 iphlpapi crypt32 winmm
     LIBS *= $$linkDynamicLibs(dLib)
 
 	RC_FILE = gui/images/retroshare_win.rc


### PR DESCRIPTION
JSONAPI now builds on Windows, some notes:
- I added doxygen and cmake as tool requirements in the docs
- $$system_path() shouldn't be needed anymore as MSYS2 uses unix path
- doxygen generation didn't work when not using shadow builds, now it does
- wsock32 is needed because ASIO generates 2 old winsock functions
- I didn't find a more elegant way to have a "jsonapi-generator" executable name work for both shadow/non-shadow and windows/linux, suggestions or fixes welcome
- I didn't test a linux build because I have to setup a machine/VM for it but I tried to not break anything