### PR TITLE
[jsonapi] add most remaining functions of rsMsg

### DIFF
--- a/libretroshare/src/retroshare/rsmsgs.h
+++ b/libretroshare/src/retroshare/rsmsgs.h
@@ -503,11 +503,11 @@ public:
 	/**
 	 * @brief getMessage
 	 * @jsonapi{development}
-	 * @param[in] mId message ID to lookup
+	 * @param[in] msgId message ID to lookup
 	 * @param[out] msg
 	 * @return true on success
 	 */
-	virtual bool getMessage(const std::string &mId, Rs::Msgs::MessageInfo &msg)  = 0;
+	virtual bool getMessage(const std::string &msgId, Rs::Msgs::MessageInfo &msg)  = 0;
 	/**
 	 * @brief getMessageCount
 	 * @jsonapi{development}
@@ -550,11 +550,11 @@ public:
 	/**
 	 * @brief MessageToTrash
 	 * @jsonapi{development}
-	 * @param[in] mid
+	 * @param[in] msgId
 	 * @param[in] bTrash
 	 * @return true on success
 	 */
-	virtual bool MessageToTrash(const std::string &mid, bool bTrash)   = 0;
+	virtual bool MessageToTrash(const std::string &msgId, bool bTrash)   = 0;
 
 	/**
 	 * @brief getMsgParentId
@@ -568,55 +568,55 @@ public:
 	/**
 	 * @brief MessageDelete
 	 * @jsonapi{development}
-	 * @param[in] mid
+	 * @param[in] msgId
 	 * @return true on success
 	 */
-	virtual bool MessageDelete(const std::string &mid)                 = 0;
+	virtual bool MessageDelete(const std::string &msgId)                 = 0;
 
 	/**
 	 * @brief MessageRead
 	 * @jsonapi{development}
-	 * @param[in] mid
+	 * @param[in] msgId
 	 * @param[in] unreadByUser
 	 * @return true on success
 	 */
-	virtual bool MessageRead(const std::string &mid, bool unreadByUser) = 0;
+	virtual bool MessageRead(const std::string &msgId, bool unreadByUser) = 0;
 
 	/**
 	 * @brief MessageReplied
 	 * @jsonapi{development}
-	 * @param[in] mid
+	 * @param[in] msgId
 	 * @param[in] replied
 	 * @return true on success
 	 */
-	virtual bool MessageReplied(const std::string &mid, bool replied) = 0;
+	virtual bool MessageReplied(const std::string &msgId, bool replied) = 0;
 
 	/**
 	 * @brief MessageForwarded
 	 * @jsonapi{development}
-	 * @param[in] mid
+	 * @param[in] msgId
 	 * @param[in] forwarded
 	 * @return true on success
 	 */
-	virtual bool MessageForwarded(const std::string &mid, bool forwarded) = 0;
+	virtual bool MessageForwarded(const std::string &msgId, bool forwarded) = 0;
 
 	/**
 	 * @brief MessageStar
 	 * @jsonapi{development}
-	 * @param[in] mid
+	 * @param[in] msgId
 	 * @param[in] mark
 	 * @return true on success
 	 */
-	virtual bool MessageStar(const std::string &mid, bool mark) = 0;
+	virtual bool MessageStar(const std::string &msgId, bool mark) = 0;
 
 	/**
 	 * @brief MessageLoadEmbeddedImages
 	 * @jsonapi{development}
-	 * @param[in] mid
+	 * @param[in] msgId
 	 * @param[in] load
 	 * @return true on success
 	 */
-	virtual bool MessageLoadEmbeddedImages(const std::string &mid, bool load) = 0;
+	virtual bool MessageLoadEmbeddedImages(const std::string &msgId, bool load) = 0;
 
 	/* message tagging */
 	/**

--- a/libretroshare/src/retroshare/rsmsgs.h
+++ b/libretroshare/src/retroshare/rsmsgs.h
@@ -165,9 +165,8 @@ class MessageInfo_v2
 		int count; /* file count     */
 };
 
-class MessageInfo
+struct MessageInfo : RsSerializable
 {
-public:
     MessageInfo(): msgflags(0), size(0), count(0), ts(0) {}
     std::string msgId;
 
@@ -199,13 +198,42 @@ public:
     int count; /* file count     */
 
     int ts;
+
+	// RsSerializable interface
+	void serial_process(RsGenericSerializer::SerializeJob j, RsGenericSerializer::SerializeContext &ctx) {
+		RS_SERIAL_PROCESS(msgId);
+
+		RS_SERIAL_PROCESS(rspeerid_srcId);
+		RS_SERIAL_PROCESS(rsgxsid_srcId);
+
+		RS_SERIAL_PROCESS(msgflags);
+
+		RS_SERIAL_PROCESS(rspeerid_msgto);
+		RS_SERIAL_PROCESS(rspeerid_msgcc);
+		RS_SERIAL_PROCESS(rspeerid_msgbcc);
+
+		RS_SERIAL_PROCESS(rsgxsid_msgto);
+		RS_SERIAL_PROCESS(rsgxsid_msgcc);
+		RS_SERIAL_PROCESS(rsgxsid_msgcc);
+
+		RS_SERIAL_PROCESS(title);
+		RS_SERIAL_PROCESS(msg);
+
+		RS_SERIAL_PROCESS(attach_title);
+		RS_SERIAL_PROCESS(attach_comment);
+		RS_SERIAL_PROCESS(files);
+
+		RS_SERIAL_PROCESS(size);
+		RS_SERIAL_PROCESS(count);
+
+		RS_SERIAL_PROCESS(ts);
+	}
 };
 
 
-class MsgInfoSummary 
+struct MsgInfoSummary : RsSerializable
 {
-	public:
-    MsgInfoSummary(): msgflags(0), count(0), ts(0) {}
+	MsgInfoSummary() : msgflags(0), count(0), ts(0) {}
 
 	std::string msgId;
 	RsPeerId srcId;
@@ -216,6 +244,18 @@ class MsgInfoSummary
 	int count; /* file count     */
 	time_t ts;
 
+
+	// RsSerializable interface
+	void serial_process(RsGenericSerializer::SerializeJob j, RsGenericSerializer::SerializeContext &ctx) {
+		RS_SERIAL_PROCESS(msgId);
+		RS_SERIAL_PROCESS(srcId);
+
+		RS_SERIAL_PROCESS(msgflags);
+
+		RS_SERIAL_PROCESS(title);
+		RS_SERIAL_PROCESS(count);
+		RS_SERIAL_PROCESS(ts);
+	}
 };
 
 class MsgTagInfo
@@ -444,52 +484,66 @@ public:
 	RsMsgs() {}
 	virtual ~RsMsgs() {}
 
-/****************************************/
-/*             Message Items            */
-/****************************************/
+	/****************************************/
+	/*             Message Items            */
+	/****************************************/
 
-virtual bool getMessageSummaries(std::list<Rs::Msgs::MsgInfoSummary> &msgList) = 0;
-virtual bool getMessage(const std::string &mId, Rs::Msgs::MessageInfo &msg)  = 0;
-virtual void getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxNew, unsigned int *pnOutbox, unsigned int *pnDraftbox, unsigned int *pnSentbox, unsigned int *pnTrashbox) = 0;
+	/**
+	 * @brief getMessageSummaries
+	 * @jsonapi{de22velopment}
+	 * @param[out] msgList
+	 * @return always true
+	 */
+	virtual bool getMessageSummaries(std::list<Rs::Msgs::MsgInfoSummary> &msgList) = 0;
 
-virtual bool MessageSend(Rs::Msgs::MessageInfo &info) = 0;
-virtual bool SystemMessage(const std::string &title, const std::string &message, uint32_t systemFlag) = 0;
-virtual bool MessageToDraft(Rs::Msgs::MessageInfo &info, const std::string &msgParentId) = 0;
-virtual bool MessageToTrash(const std::string &mid, bool bTrash)   = 0;
-virtual bool getMsgParentId(const std::string &msgId, std::string &msgParentId) = 0;
+	/**
+	 * @brief getMessage
+	 * @jsonapi{dev22elopment}
+	 * @param[in] mId message ID to lookup
+	 * @param[out] msg
+	 * @return true on success
+	 */
+	virtual bool getMessage(const std::string &mId, Rs::Msgs::MessageInfo &msg)  = 0;
+	virtual void getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxNew, unsigned int *pnOutbox, unsigned int *pnDraftbox, unsigned int *pnSentbox, unsigned int *pnTrashbox) = 0;
 
-virtual bool MessageDelete(const std::string &mid)                 = 0;
-virtual bool MessageRead(const std::string &mid, bool unreadByUser) = 0;
-virtual bool MessageReplied(const std::string &mid, bool replied) = 0;
-virtual bool MessageForwarded(const std::string &mid, bool forwarded) = 0;
-virtual bool MessageStar(const std::string &mid, bool mark) = 0;
-virtual bool MessageLoadEmbeddedImages(const std::string &mid, bool load) = 0;
+	virtual bool MessageSend(Rs::Msgs::MessageInfo &info) = 0;
+	virtual bool SystemMessage(const std::string &title, const std::string &message, uint32_t systemFlag) = 0;
+	virtual bool MessageToDraft(Rs::Msgs::MessageInfo &info, const std::string &msgParentId) = 0;
+	virtual bool MessageToTrash(const std::string &mid, bool bTrash)   = 0;
+	virtual bool getMsgParentId(const std::string &msgId, std::string &msgParentId) = 0;
 
-/* message tagging */
+	virtual bool MessageDelete(const std::string &mid)                 = 0;
+	virtual bool MessageRead(const std::string &mid, bool unreadByUser) = 0;
+	virtual bool MessageReplied(const std::string &mid, bool replied) = 0;
+	virtual bool MessageForwarded(const std::string &mid, bool forwarded) = 0;
+	virtual bool MessageStar(const std::string &mid, bool mark) = 0;
+	virtual bool MessageLoadEmbeddedImages(const std::string &mid, bool load) = 0;
 
-virtual bool getMessageTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
-/* set == false && tagId == 0 --> remove all */
-virtual bool setMessageTagType(uint32_t tagId, std::string& text, uint32_t rgb_color) = 0;
-virtual bool removeMessageTagType(uint32_t tagId) = 0;
+	/* message tagging */
 
-virtual bool getMessageTag(const std::string &msgId, Rs::Msgs::MsgTagInfo& info) = 0;
-virtual bool setMessageTag(const std::string &msgId, uint32_t tagId, bool set) = 0;
+	virtual bool getMessageTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
+	/* set == false && tagId == 0 --> remove all */
+	virtual bool setMessageTagType(uint32_t tagId, std::string& text, uint32_t rgb_color) = 0;
+	virtual bool removeMessageTagType(uint32_t tagId) = 0;
 
-virtual bool resetMessageStandardTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
+	virtual bool getMessageTag(const std::string &msgId, Rs::Msgs::MsgTagInfo& info) = 0;
+	virtual bool setMessageTag(const std::string &msgId, uint32_t tagId, bool set) = 0;
 
-/****************************************/
-/*        Private distant messages      */
-/****************************************/
+	virtual bool resetMessageStandardTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
+
+	/****************************************/
+	/*        Private distant messages      */
+	/****************************************/
 
     virtual uint32_t getDistantMessagingPermissionFlags()=0 ;
     virtual void setDistantMessagingPermissionFlags(uint32_t flags)=0 ;
     
-/****************************************/
-/*                 Chat                 */
-/****************************************/
-// sendChat for broadcast, private, lobby and private distant chat
-// note: for lobby chat, you first have to subscribe to a lobby
-//       for private distant chat, it is reqired to have an active distant chat session
+	/****************************************/
+	/*                 Chat                 */
+	/****************************************/
+	// sendChat for broadcast, private, lobby and private distant chat
+	// note: for lobby chat, you first have to subscribe to a lobby
+	//       for private distant chat, it is reqired to have an active distant chat session
 
 	/**
 	 * @brief sendChat send a chat message to a given id

--- a/libretroshare/src/retroshare/rsmsgs.h
+++ b/libretroshare/src/retroshare/rsmsgs.h
@@ -626,13 +626,51 @@ public:
 	 * @return always true
 	 */
 	virtual bool getMessageTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
-	/* set == false && tagId == 0 --> remove all */
+
+	/**
+	 * @brief setMessageTagType
+	 * @jsonapi{development}
+	 * @param[in] tagId
+	 * @param[in] text
+	 * @param[in] rgb_color
+	 * @return true on success
+	 */
 	virtual bool setMessageTagType(uint32_t tagId, std::string& text, uint32_t rgb_color) = 0;
+
+	/**
+	 * @brief removeMessageTagType
+	 * @jsonapi{development}
+	 * @param[in] tagId
+	 * @return true on success
+	 */
 	virtual bool removeMessageTagType(uint32_t tagId) = 0;
 
+	/**
+	 * @brief getMessageTag
+	 * @jsonapi{development}
+	 * @param[in] msgId
+	 * @param[out] info
+	 * @return true on success
+	 */
 	virtual bool getMessageTag(const std::string &msgId, Rs::Msgs::MsgTagInfo& info) = 0;
+
+	/**
+	 * @brief setMessageTag
+	 * set == false && tagId == 0 --> remove all
+	 * @jsonapi{development}
+	 * @param[in] msgId
+	 * @param[in] tagId
+	 * @param[in] set
+	 * @return true on success
+	 */
 	virtual bool setMessageTag(const std::string &msgId, uint32_t tagId, bool set) = 0;
 
+	/**
+	 * @brief resetMessageStandardTagTypes
+	 * @jsonapi{development}
+	 * @param[out] tags
+	 * @return always true
+	 */
 	virtual bool resetMessageStandardTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
 
 	/****************************************/

--- a/libretroshare/src/retroshare/rsmsgs.h
+++ b/libretroshare/src/retroshare/rsmsgs.h
@@ -258,23 +258,27 @@ struct MsgInfoSummary : RsSerializable
 	}
 };
 
-class MsgTagInfo
+struct MsgTagInfo : RsSerializable
 {
-public:
-	MsgTagInfo() {}
-
 	std::string msgId;
 	std::list<uint32_t> tagIds;
+
+	// RsSerializable interface
+	void serial_process(RsGenericSerializer::SerializeJob j, RsGenericSerializer::SerializeContext &ctx) {
+		RS_SERIAL_PROCESS(msgId);
+		RS_SERIAL_PROCESS(tagIds);
+	}
 };
 
-class MsgTagType
+struct MsgTagType : RsSerializable
 {
-public:
-	MsgTagType() {}
-
 	/* map containing tagId -> pair (text, rgb color) */
 	std::map<uint32_t, std::pair<std::string, uint32_t> > types;
 
+	// RsSerializable interface
+	void serial_process(RsGenericSerializer::SerializeJob j, RsGenericSerializer::SerializeContext &ctx) {
+		RS_SERIAL_PROCESS(types);
+	}
 };
 
 } //namespace Rs
@@ -516,21 +520,111 @@ public:
 	 */
 	virtual void getMessageCount(uint32_t &nInbox, uint32_t &nInboxNew, uint32_t &nOutbox, uint32_t &nDraftbox, uint32_t &nSentbox, uint32_t &nTrashbox) = 0;
 
+	/**
+	 * @brief MessageSend
+	 * @jsonapi{development}
+	 * @param[in] info
+	 * @return always true
+	 */
 	virtual bool MessageSend(Rs::Msgs::MessageInfo &info) = 0;
+
+	/**
+	 * @brief SystemMessage
+	 * @jsonapi{development}
+	 * @param[in] title
+	 * @param[in] message
+	 * @param[in] systemFlag
+	 * @return true on success
+	 */
 	virtual bool SystemMessage(const std::string &title, const std::string &message, uint32_t systemFlag) = 0;
+
+	/**
+	 * @brief MessageToDraft
+	 * @jsonapi{development}
+	 * @param[in] info
+	 * @param[in] msgParentId
+	 * @return true on success
+	 */
 	virtual bool MessageToDraft(Rs::Msgs::MessageInfo &info, const std::string &msgParentId) = 0;
+
+	/**
+	 * @brief MessageToTrash
+	 * @jsonapi{development}
+	 * @param[in] mid
+	 * @param[in] bTrash
+	 * @return true on success
+	 */
 	virtual bool MessageToTrash(const std::string &mid, bool bTrash)   = 0;
+
+	/**
+	 * @brief getMsgParentId
+	 * @jsonapi{development}
+	 * @param[in] msgId
+	 * @param[out] msgParentId
+	 * @return true on success
+	 */
 	virtual bool getMsgParentId(const std::string &msgId, std::string &msgParentId) = 0;
 
+	/**
+	 * @brief MessageDelete
+	 * @jsonapi{development}
+	 * @param[in] mid
+	 * @return true on success
+	 */
 	virtual bool MessageDelete(const std::string &mid)                 = 0;
+
+	/**
+	 * @brief MessageRead
+	 * @jsonapi{development}
+	 * @param[in] mid
+	 * @param[in] unreadByUser
+	 * @return true on success
+	 */
 	virtual bool MessageRead(const std::string &mid, bool unreadByUser) = 0;
+
+	/**
+	 * @brief MessageReplied
+	 * @jsonapi{development}
+	 * @param[in] mid
+	 * @param[in] replied
+	 * @return true on success
+	 */
 	virtual bool MessageReplied(const std::string &mid, bool replied) = 0;
+
+	/**
+	 * @brief MessageForwarded
+	 * @jsonapi{development}
+	 * @param[in] mid
+	 * @param[in] forwarded
+	 * @return true on success
+	 */
 	virtual bool MessageForwarded(const std::string &mid, bool forwarded) = 0;
+
+	/**
+	 * @brief MessageStar
+	 * @jsonapi{development}
+	 * @param[in] mid
+	 * @param[in] mark
+	 * @return true on success
+	 */
 	virtual bool MessageStar(const std::string &mid, bool mark) = 0;
+
+	/**
+	 * @brief MessageLoadEmbeddedImages
+	 * @jsonapi{development}
+	 * @param[in] mid
+	 * @param[in] load
+	 * @return true on success
+	 */
 	virtual bool MessageLoadEmbeddedImages(const std::string &mid, bool load) = 0;
 
 	/* message tagging */
-
+	/**
+	 * @brief getMessageTagTypes
+	 * @jsonapi{development}
+	 * @param[out] tags
+	 * @return always true
+	 */
 	virtual bool getMessageTagTypes(Rs::Msgs::MsgTagType& tags) = 0;
 	/* set == false && tagId == 0 --> remove all */
 	virtual bool setMessageTagType(uint32_t tagId, std::string& text, uint32_t rgb_color) = 0;

--- a/libretroshare/src/retroshare/rsmsgs.h
+++ b/libretroshare/src/retroshare/rsmsgs.h
@@ -490,7 +490,7 @@ public:
 
 	/**
 	 * @brief getMessageSummaries
-	 * @jsonapi{de22velopment}
+	 * @jsonapi{development}
 	 * @param[out] msgList
 	 * @return always true
 	 */
@@ -498,13 +498,23 @@ public:
 
 	/**
 	 * @brief getMessage
-	 * @jsonapi{dev22elopment}
+	 * @jsonapi{development}
 	 * @param[in] mId message ID to lookup
 	 * @param[out] msg
 	 * @return true on success
 	 */
 	virtual bool getMessage(const std::string &mId, Rs::Msgs::MessageInfo &msg)  = 0;
-	virtual void getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxNew, unsigned int *pnOutbox, unsigned int *pnDraftbox, unsigned int *pnSentbox, unsigned int *pnTrashbox) = 0;
+	/**
+	 * @brief getMessageCount
+	 * @jsonapi{development}
+	 * @param[out] nInbox
+	 * @param[out] nInboxNew
+	 * @param[out] nOutbox
+	 * @param[out] nDraftbox
+	 * @param[out] nSentbox
+	 * @param[out] nTrashbox
+	 */
+	virtual void getMessageCount(uint32_t &nInbox, uint32_t &nInboxNew, uint32_t &nOutbox, uint32_t &nDraftbox, uint32_t &nSentbox, uint32_t &nTrashbox) = 0;
 
 	virtual bool MessageSend(Rs::Msgs::MessageInfo &info) = 0;
 	virtual bool SystemMessage(const std::string &title, const std::string &message, uint32_t systemFlag) = 0;

--- a/libretroshare/src/rsserver/p3msgs.cc
+++ b/libretroshare/src/rsserver/p3msgs.cc
@@ -287,9 +287,9 @@ bool p3Msgs::getMessage(const std::string &mid, MessageInfo &msg)
 	return mMsgSrv->getMessage(mid, msg);
 }
 
-void p3Msgs::getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxNew, unsigned int *pnOutbox, unsigned int *pnDraftbox, unsigned int *pnSentbox, unsigned int *pnTrashbox)
+void p3Msgs::getMessageCount(uint32_t &nInbox, uint32_t &nInboxNew, uint32_t &nOutbox, uint32_t &nDraftbox, uint32_t &nSentbox, uint32_t &nTrashbox)
 {
-	mMsgSrv->getMessageCount(pnInbox, pnInboxNew, pnOutbox, pnDraftbox, pnSentbox, pnTrashbox);
+	mMsgSrv->getMessageCount(nInbox, nInboxNew, nOutbox, nDraftbox, nSentbox, nTrashbox);
 }
 
 /****************************************/

--- a/libretroshare/src/rsserver/p3msgs.h
+++ b/libretroshare/src/rsserver/p3msgs.h
@@ -52,7 +52,7 @@ class p3Msgs: public RsMsgs
 	   */
 	  virtual bool getMessageSummaries(std::list<Rs::Msgs::MsgInfoSummary> &msgList);
 	  virtual bool getMessage(const std::string &mId, Rs::Msgs::MessageInfo &msg);
-	  virtual void getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxNew, unsigned int *pnOutbox, unsigned int *pnDraftbox, unsigned int *pnSentbox, unsigned int *pnTrashbox);
+	  virtual void getMessageCount(uint32_t &nInbox, uint32_t &nInboxNew, uint32_t &nOutbox, uint32_t &nDraftbox, uint32_t &nSentbox, uint32_t &nTrashbox);
 
 	  virtual bool MessageSend(Rs::Msgs::MessageInfo &info);
 	  virtual bool SystemMessage(const std::string &title, const std::string &message, uint32_t systemFlag);

--- a/libretroshare/src/serialiser/rstypeserializer.h
+++ b/libretroshare/src/serialiser/rstypeserializer.h
@@ -532,7 +532,7 @@ struct RsTypeSerializer
 			for(uint32_t i=0; i<n; ++i)
 			{
 				T tmp;
-				serial_process<T>(j,ctx,tmp,memberName);
+				serial_process(j,ctx,tmp,memberName);
 				v.insert(tmp);
 			}
 			break;
@@ -590,7 +590,7 @@ struct RsTypeSerializer
 			for(uint32_t i=0;i<n;++i)
 			{
 				T tmp;
-				serial_process<T>(j,ctx,tmp,memberName);
+				serial_process(j,ctx,tmp,memberName);
 				v.push_back(tmp);
 			}
 			break;

--- a/libretroshare/src/serialiser/rstypeserializer.h
+++ b/libretroshare/src/serialiser/rstypeserializer.h
@@ -394,8 +394,8 @@ struct RsTypeSerializer
 			RsGenericSerializer::SerializeContext lCtx(
 			            nullptr, 0, ctx.mFlags, &allocator );
 
-			serial_process(j, ctx, p.first, "first");
-			serial_process(j, ctx, p.second, "second");
+			serial_process(j, lCtx, p.first, "first");
+			serial_process(j, lCtx, p.second, "second");
 
 			rapidjson::Value key;
 			key.SetString(memberName.c_str(), memberName.length(), allocator);
@@ -434,8 +434,8 @@ struct RsTypeSerializer
 			RsGenericSerializer::SerializeContext lCtx(nullptr, 0, ctx.mFlags);
 			lCtx.mJson.SetObject() = v; // Beware of move semantic!!
 
-			serial_process(j, ctx, p.first, "first");
-			serial_process(j, ctx, p.second, "second");
+			serial_process(j, lCtx, p.first, "first");
+			serial_process(j, lCtx, p.second, "second");
 			ctx.mOk &= lCtx.mOk;
 
 			break;

--- a/libretroshare/src/serialiser/rstypeserializer.h
+++ b/libretroshare/src/serialiser/rstypeserializer.h
@@ -290,11 +290,11 @@ struct RsTypeSerializer
 				// Use same allocator to avoid deep copy
 				RsGenericSerializer::SerializeContext kCtx(
 				            nullptr, 0, ctx.mFlags, &allocator );
-				serial_process<T>(j, kCtx, const_cast<T&>(kv.first), "key");
+				serial_process(j, kCtx, const_cast<T&>(kv.first), "key");
 
 				RsGenericSerializer::SerializeContext vCtx(
 				            nullptr, 0, ctx.mFlags, &allocator );
-				serial_process<U>(j, vCtx, const_cast<U&>(kv.second), "value");
+				serial_process(j, vCtx, const_cast<U&>(kv.second), "value");
 
 				if(kCtx.mOk && vCtx.mOk)
 				{

--- a/libretroshare/src/services/p3msgservice.cc
+++ b/libretroshare/src/services/p3msgservice.cc
@@ -857,16 +857,16 @@ bool p3MsgService::getMessage(const std::string &mId, MessageInfo &msg)
 	return true;
 }
 
-void p3MsgService::getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxNew, unsigned int *pnOutbox, unsigned int *pnDraftbox, unsigned int *pnSentbox, unsigned int *pnTrashbox)
+void p3MsgService::getMessageCount(uint32_t &nInbox, uint32_t &nInboxNew, uint32_t &nOutbox, uint32_t &nDraftbox, uint32_t &nSentbox, uint32_t &nTrashbox)
 {
     RsStackMutex stack(mMsgMtx); /********** STACK LOCKED MTX ******/
 
-    if (pnInbox) *pnInbox = 0;
-    if (pnInboxNew) *pnInboxNew = 0;
-    if (pnOutbox) *pnOutbox = 0;
-    if (pnDraftbox) *pnDraftbox = 0;
-    if (pnSentbox) *pnSentbox = 0;
-    if (pnTrashbox) *pnTrashbox = 0;
+	nInbox = 0;
+	nInboxNew = 0;
+	nOutbox = 0;
+	nDraftbox = 0;
+	nSentbox = 0;
+	nTrashbox = 0;
 
     std::map<uint32_t, RsMsgItem *>::iterator mit;
     std::map<uint32_t, RsMsgItem *> *apMsg [2] = { &imsg, &msgOutgoing };
@@ -877,24 +877,23 @@ void p3MsgService::getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxN
             initRsMIS(mit->second, mis);
 
             if (mis.msgflags & RS_MSG_TRASH) {
-                if (pnTrashbox) ++(*pnTrashbox);
+				++nTrashbox;
                 continue;
             }
             switch (mis.msgflags & RS_MSG_BOXMASK) {
             case RS_MSG_INBOX:
-                    if (pnInbox) ++(*pnInbox);
-                    if ((mis.msgflags & RS_MSG_NEW) == RS_MSG_NEW) {
-                        if (pnInboxNew) ++(*pnInboxNew);
-                    }
+				    ++nInbox;
+				    if ((mis.msgflags & RS_MSG_NEW) == RS_MSG_NEW)
+						++nInboxNew;
                     break;
             case RS_MSG_OUTBOX:
-                    if (pnOutbox) ++(*pnOutbox);
+				    ++nOutbox;
                     break;
             case RS_MSG_DRAFTBOX:
-                    if (pnDraftbox) ++(*pnDraftbox);
+				   ++nDraftbox;
                     break;
             case RS_MSG_SENTBOX:
-                    if (pnSentbox) ++(*pnSentbox);
+				    ++nSentbox;
                     break;
             }
         }

--- a/libretroshare/src/services/p3msgservice.h
+++ b/libretroshare/src/services/p3msgservice.h
@@ -62,7 +62,7 @@ public:
     /* External Interface */
     bool 	getMessageSummaries(std::list<Rs::Msgs::MsgInfoSummary> &msgList);
     bool 	getMessage(const std::string &mid, Rs::Msgs::MessageInfo &msg);
-    void    getMessageCount(unsigned int *pnInbox, unsigned int *pnInboxNew, unsigned int *pnOutbox, unsigned int *pnDraftbox, unsigned int *pnSentbox, unsigned int *pnTrashbox);
+	void	getMessageCount(uint32_t &nInbox, uint32_t &nInboxNew, uint32_t &nOutbox, uint32_t &nDraftbox, uint32_t &nSentbox, uint32_t &nTrashbox);
 
     bool decryptMessage(const std::string& mid) ;
     bool    removeMsgId(const std::string &mid); 

--- a/retroshare-gui/src/gui/msgs/MessageUserNotify.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageUserNotify.cpp
@@ -51,8 +51,9 @@ QIcon MessageUserNotify::getMainIcon(bool hasNew)
 
 unsigned int MessageUserNotify::getNewCount()
 {
-	unsigned int newInboxCount = 0;
-	rsMail->getMessageCount(NULL, &newInboxCount, NULL, NULL, NULL, NULL);
+	uint32_t newInboxCount = 0;
+	uint32_t a, b, c, d, e; // dummies
+	rsMail->getMessageCount(a, newInboxCount, b, c, d, e);
 
 	return newInboxCount;
 }


### PR DESCRIPTION
I have only tested message retrieval and tagging, as usually nothing can go wrong by adding a few doxygen comments. Nevertheless there was a bug that is fixed now (see rstypeserializer.h).
New even the nested type `std::map<uint32_t, std::pair<std::string, uint32_t> > types;` serializes to something nice:
```json
"types": [
            {
                "key": 1,
                "value": {
                    "first": "Important",
                    "second": 16711680
                }
            },
            {
                "key": 2,
                "value": {
                    "first": "Work",
                    "second": 16750848
                }
            },
            {
                "key": 3,
                "value": {
                    "first": "Personal",
                    "second": 39168
                }
            },
            {
                "key": 4,
                "value": {
                    "first": "Todo",
                    "second": 3355647
                }
            },
            {
                "key": 5,
                "value": {
                    "first": "Later",
                    "second": 10040217
                }
            },
            {
                "key": 101,
                "value": {
                    "first": "jsonapi",
                    "second": 14540253
                }
            }
        ]

```