### PR TITLE
GXS deep search notify results also of already known groups

### DIFF
--- a/libretroshare/src/gxs/rsdataservice.cc
+++ b/libretroshare/src/gxs/rsdataservice.cc
@@ -1373,7 +1373,7 @@ int RsDataService::retrieveGxsGrpMetaData(RsGxsGrpMetaTemporaryMap& grp)
     std::cerr << std::endl;
 #endif
 
-    RsStackMutex stack(mDbMutex);
+	RS_STACK_MUTEX(mDbMutex);
 
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
     rstime::RsScopeTimer timer("");

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -1639,12 +1639,13 @@ void RsGenExchange::receiveNewMessages(std::vector<RsNxsMsg *>& messages)
 
 void RsGenExchange::receiveDistantSearchResults(TurtleRequestId id,const RsGxsGroupId &grpId)
 {
+	std::cerr << __PRETTY_FUNCTION__ << " received result for request "
+	          << std::hex << id << std::dec << std::endl;
+
 	RS_STACK_MUTEX(mGenMtx);
 
 	RsGxsDistantSearchResultChange* gc = new RsGxsDistantSearchResultChange(id,grpId);
 	mNotifications.push_back(gc);
-
-    std::cerr << "RsGenExchange::receiveDistantSearchResults(): received result for request " << std::hex << id << std::dec << std::endl;
 }
 
 void RsGenExchange::notifyReceivePublishKey(const RsGxsGroupId &grpId)

--- a/libretroshare/src/services/p3gxschannels.h
+++ b/libretroshare/src/services/p3gxschannels.h
@@ -114,10 +114,11 @@ virtual bool getChannelDownloadDirectory(const RsGxsGroupId &groupId, std::strin
 
 	/**
 	 * Receive results from turtle search @see RsGenExchange @see RsNxsObserver
+	 * @see RsGxsNetService::receiveTurtleSearchResults
 	 * @see p3turtle::handleSearchResult
 	 */
 	void receiveDistantSearchResults( TurtleRequestId id,
-	                                  const RsGxsGroupId& grpId );
+	                                  const RsGxsGroupId& grpId ) override;
 
 	/* Comment service - Provide RsGxsCommentService - redirect to p3GxsCommentService */
 	virtual bool getCommentData(uint32_t token, std::vector<RsGxsComment> &msgs)


### PR DESCRIPTION
When deep search is enabled search results may contain also search snippets from indexed posts, in this case it may be more attractive to the user to subscribe more then the channel name itself, so notify the result also if channel is already known