### PR TITLE
WIP: Attempt to fix crash in pqissludp

### DIFF
--- a/libretroshare/src/tcponudp/bss_tou.c
+++ b/libretroshare/src/tcponudp/bss_tou.c
@@ -102,44 +102,41 @@ static void BIO_set_data(BIO *a,void *p) { a->ptr = p; }
 
 #endif
 
+static BIO_METHOD methods_tou_sockp =
+{
+    BIO_TYPE_TOU_SOCKET,
+    "tou_socket",
+    tou_socket_write,
+    tou_socket_read,
+    tou_socket_puts,
+    NULL, /* tou_gets, */
+    tou_socket_ctrl,
+    tou_socket_new,
+    tou_socket_free,
+    NULL,
+};
+
 #else
 
-typedef struct bio_method_st {
-    int type;
-    const char *name;
-    int (*bwrite) (BIO *, const char *, int);
-    int (*bread) (BIO *, char *, int);
-    int (*bputs) (BIO *, const char *);
-    int (*bgets) (BIO *, char *, int);
-    long (*ctrl) (BIO *, int, long, void *);
-    int (*create) (BIO *);
-    int (*destroy) (BIO *);
-    long (*callback_ctrl) (BIO *, int, bio_info_cb *);
-} BIO_METHOD;
+static BIO_METHOD methods_tou_sockp =
+        BIO_meth_new(BIO_TYPE_TOU_SOCKET, "tou_socket");
+
+BIO_meth_set_write(&methods_tou_sockp, tou_socket_write);
+BIO_meth_set_read(&methods_tou_sockp, tou_socket_read);
+BIO_meth_set_puts(&methods_tou_sockp, tou_socket_puts);
+BIO_meth_set_ctrl(&methods_tou_sockp, tou_socket_ctrl);
+BIO_meth_set_create(&methods_tou_sockp,tou_socket_new);
+BIO_meth_set_destroy(&methods_tou_sockp,tou_socket_free);
 
 #endif
 
-static BIO_METHOD methods_tou_sockp=
-	{
-	BIO_TYPE_TOU_SOCKET,
-	"tou_socket",
-	tou_socket_write,
-	tou_socket_read,
-	tou_socket_puts,
-	NULL, /* tou_gets, */
-	tou_socket_ctrl,
-	tou_socket_new,
-	tou_socket_free,
-	NULL,
-	};
-
 BIO_METHOD *BIO_s_tou_socket(void)
-	{
+{
 #ifdef DEBUG_TOU_BIO
 	fprintf(stderr, "BIO_s_tou_socket(void)\n");
 #endif
 	return(&methods_tou_sockp);
-	}
+}
 
 BIO *BIO_new_tou_socket(int fd, int close_flag)
 	{

--- a/libretroshare/src/tcponudp/bss_tou.c
+++ b/libretroshare/src/tcponudp/bss_tou.c
@@ -267,17 +267,16 @@ static long tou_socket_ctrl(BIO *b, int cmd, long num, void *ptr)
 		break;
 	case BIO_C_SET_FD:
 		tou_socket_free(b);
-		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
-
+		ret = BIO_meth_get_ctrl((BIO_METHOD*)BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_C_GET_FD:
-		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
+		ret = BIO_meth_get_ctrl((BIO_METHOD*)BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_GET_CLOSE:
-		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
+		ret = BIO_meth_get_ctrl((BIO_METHOD*)BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_SET_CLOSE:
-		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
+		ret = BIO_meth_get_ctrl((BIO_METHOD*)BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_PENDING:
 		ret = tou_maxread(BIO_get_fd(b,NULL));

--- a/libretroshare/src/tcponudp/bss_tou.c
+++ b/libretroshare/src/tcponudp/bss_tou.c
@@ -99,6 +99,8 @@ static int  BIO_get_init(BIO *a) { return a->init; }
 static int  BIO_get_shutdown(BIO *a) { return a->shutdown; }
 static void BIO_set_init(BIO *a,int i) { a->init=i; }
 static void BIO_set_data(BIO *a,void *p) { a->ptr = p; }
+long (*BIO_meth_get_ctrl(const BIO_METHOD* biom)) (BIO*, int, long, void*)
+{ return biom->ctrl; }
 
 #endif
 
@@ -116,27 +118,35 @@ static BIO_METHOD methods_tou_sockp =
     NULL,
 };
 
-#else
-
-static BIO_METHOD methods_tou_sockp =
-        BIO_meth_new(BIO_TYPE_TOU_SOCKET, "tou_socket");
-
-BIO_meth_set_write(&methods_tou_sockp, tou_socket_write);
-BIO_meth_set_read(&methods_tou_sockp, tou_socket_read);
-BIO_meth_set_puts(&methods_tou_sockp, tou_socket_puts);
-BIO_meth_set_ctrl(&methods_tou_sockp, tou_socket_ctrl);
-BIO_meth_set_create(&methods_tou_sockp,tou_socket_new);
-BIO_meth_set_destroy(&methods_tou_sockp,tou_socket_free);
-
-#endif
-
-BIO_METHOD *BIO_s_tou_socket(void)
+BIO_METHOD* BIO_s_tou_socket(void)
 {
 #ifdef DEBUG_TOU_BIO
 	fprintf(stderr, "BIO_s_tou_socket(void)\n");
 #endif
 	return(&methods_tou_sockp);
 }
+
+#else
+
+BIO_METHOD* BIO_s_tou_socket(void)
+{
+	static BIO_METHOD* methods_tou_sockp_ptr = NULL;
+	if(!methods_tou_sockp_ptr)
+	{
+		 methods_tou_sockp_ptr = BIO_meth_new(BIO_TYPE_TOU_SOCKET, "tou_socket");
+
+		BIO_meth_set_write(   methods_tou_sockp_ptr, tou_socket_write );
+		BIO_meth_set_read(    methods_tou_sockp_ptr, tou_socket_read  );
+		BIO_meth_set_puts(    methods_tou_sockp_ptr, tou_socket_puts  );
+		BIO_meth_set_ctrl(    methods_tou_sockp_ptr, tou_socket_ctrl  );
+		BIO_meth_set_create(  methods_tou_sockp_ptr, tou_socket_new   );
+		BIO_meth_set_destroy( methods_tou_sockp_ptr, tou_socket_free  );
+	}
+
+	return methods_tou_sockp_ptr;
+}
+
+#endif
 
 BIO *BIO_new_tou_socket(int fd, int close_flag)
 	{
@@ -257,17 +267,17 @@ static long tou_socket_ctrl(BIO *b, int cmd, long num, void *ptr)
 		break;
 	case BIO_C_SET_FD:
 		tou_socket_free(b);
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 
 		break;
 	case BIO_C_GET_FD:
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_GET_CLOSE:
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_SET_CLOSE:
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_PENDING:
 		ret = tou_maxread(BIO_get_fd(b,NULL));

--- a/libretroshare/src/tcponudp/tou.h
+++ b/libretroshare/src/tcponudp/tou.h
@@ -103,11 +103,10 @@ int 	tou_connect(int sockfd, const struct sockaddr *serv_addr,
 					socklen_t addrlen, uint32_t conn_period);
 int 	tou_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);		
 
-	/* for relay connections */
-int     tou_connect_via_relay(int sockfd,
-                        const struct sockaddr_in *own_addr,
-                        const struct sockaddr_in *proxy_addr,
-                        const struct sockaddr_in *dest_addr);
+/// for relay connections
+int tou_connect_via_relay( int sockfd, const sockaddr_in& own_addr,
+                           const sockaddr_in& proxy_addr,
+                           const sockaddr_in& dest_addr );
 
 /* non-standard bonuses */
 int	tou_connected(int sockfd);

--- a/libretroshare/src/tcponudp/tou.h
+++ b/libretroshare/src/tcponudp/tou.h
@@ -103,11 +103,6 @@ int 	tou_connect(int sockfd, const struct sockaddr *serv_addr,
 					socklen_t addrlen, uint32_t conn_period);
 int 	tou_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);		
 
-/// for relay connections
-int tou_connect_via_relay( int sockfd, const sockaddr_in& own_addr,
-                           const sockaddr_in& proxy_addr,
-                           const sockaddr_in& dest_addr );
-
 /* non-standard bonuses */
 int	tou_connected(int sockfd);
 int 	tou_listenfor(int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen);
@@ -130,6 +125,14 @@ int	tou_maxwrite(int sockfd);
 
 #ifdef  __cplusplus
 }
+
+typedef struct sockaddr_in sockaddr_in;
+
+/// for relay connections
+int tou_connect_via_relay( int sockfd, const sockaddr_in& own_addr,
+                           const sockaddr_in& proxy_addr,
+                           const sockaddr_in& dest_addr );
+
 #endif
 #endif
 

--- a/libretroshare/src/util/stacktrace.h
+++ b/libretroshare/src/util/stacktrace.h
@@ -20,12 +20,12 @@
  *******************************************************************************/
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 #include <csignal>
+#include <cstdlib>
 
 #if defined(__linux__) && defined(__GLIBC__)
 
-#include <stdlib.h>
 #include <execinfo.h>
 #include <cxxabi.h>
 

--- a/libretroshare/src/util/stacktrace.h
+++ b/libretroshare/src/util/stacktrace.h
@@ -1,9 +1,7 @@
 /*******************************************************************************
- * libretroshare/src/util: smallobject.h                                       *
+ * libretroshare                                                               *
  *                                                                             *
- * libretroshare: retroshare core library                                      *
- *                                                                             *
- * Copyright (C) 2016 Gioacchino Mazzurco <gio@eigenlab.org>                   *
+ * Copyright (C) 2016-2018 Gioacchino Mazzurco <gio@eigenlab.org>              *
  * Copyright (C) 2008 Timo Bingmann http://idlebox.net/                        *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
@@ -20,10 +18,10 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef _STACKTRACE_H_
-#define _STACKTRACE_H_
+#pragma once
 
 #include <stdio.h>
+#include <csignal>
 
 #if defined(__linux__) && defined(__GLIBC__)
 
@@ -31,13 +29,28 @@
 #include <execinfo.h>
 #include <cxxabi.h>
 
-/** Print a demangled stack backtrace of the caller function to FILE* out. */
-static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
+/**
+ * @brief Print a backtrace to FILE* out.
+ * @param[in] demangle true to demangle C++ symbols requires malloc working, in
+ *	some patological cases like a SIGSEGV received during a malloc this would
+ *	cause deadlock so pass false if you may be in such situation (like in a
+ *	SIGSEGV handler )
+ * @param[in] out output file
+ * @param[in] maxFrames maximum number of stack frames you want to bu printed
+ */
+static inline void print_stacktrace(
+        bool demangle = true, FILE *out = stderr, unsigned int maxFrames = 63 )
 {
+	if(!out)
+	{
+		fprintf(stderr, "print_stacktrace invalid output file!\n");
+		return;
+	}
+
 	fprintf(out, "stack trace:\n");
 
 	// storage array for stack trace address data
-	void* addrlist[max_frames+1];
+	void* addrlist[maxFrames+1];
 
 	// retrieve current stack addresses
 	int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
@@ -45,6 +58,19 @@ static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames 
 	if (addrlen == 0)
 	{
 		fprintf(out, "  <empty, possibly corrupt>\n");
+		return;
+	}
+
+	if(!demangle)
+	{
+		int outFd = fileno(out);
+		if(outFd < 0)
+		{
+			fprintf(stderr, "print_stacktrace invalid output file descriptor!\n");
+			return;
+		}
+
+		backtrace_symbols_fd(addrlist, addrlen, outFd);
 		return;
 	}
 
@@ -62,8 +88,8 @@ static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames 
 	{
 		char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
 
-		// find parentheses and +address offset surrounding the mangled name:
-		// ./module(function+0x15c) [0x8048a6d]
+		/* find parentheses and +address offset surrounding the mangled
+		 * name: ./module(function+0x15c) [0x8048a6d] */
 		for (char *p = symbollist[i]; *p; ++p)
 		{
 			if (*p == '(') begin_name = p;
@@ -75,7 +101,8 @@ static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames 
 			}
 		}
 
-		if (begin_name && begin_offset && end_offset && begin_name < begin_offset)
+		if ( begin_name && begin_offset && end_offset
+		     && begin_name < begin_offset )
 		{
 			*begin_name++ = '\0';
 			*begin_offset++ = '\0';
@@ -86,17 +113,20 @@ static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames 
 			// __cxa_demangle():
 
 			int status;
-			char* ret = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
+			char* ret = abi::__cxa_demangle(
+			            begin_name, funcname, &funcnamesize, &status );
 			if (status == 0)
 			{
 				funcname = ret; // use possibly realloc()-ed string
-				fprintf(out, "  %s : %s+%s\n", symbollist[i], funcname, begin_offset);
+				fprintf( out, "  %s : %s+%s\n",
+				         symbollist[i], funcname, begin_offset );
 			}
 			else
 			{
 				// demangling failed. Output function name as a C function with
 				// no arguments.
-				fprintf(out, "  %s : %s()+%s\n", symbollist[i], begin_name, begin_offset);
+				fprintf( out, "  %s : %s()+%s\n",
+				         symbollist[i], begin_name, begin_offset );
 			}
 		}
 		else
@@ -111,12 +141,61 @@ static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames 
 }
 
 #else // defined(__linux__) && defined(__GLIBC__)
-static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
+static inline void print_stacktrace(
+        bool demangle = true, FILE *out = stderr, unsigned int max_frames = 63 )
 {
+	(void) demangle;
 	(void) max_frames;
 
 	fprintf(out, "TODO: 2016/01/01 print_stacktrace not implemented yet for WINDOWS_SYS and ANDROID\n");
 }
 #endif // defined(__linux__) && defined(__GLIBC__)
 
-#endif // _STACKTRACE_H_
+/**
+ * @brief CrashStackTrace catch crash signals and print stack trace
+ * Inspired too https://oroboro.com/stack-trace-on-crash/
+ */
+struct CrashStackTrace
+{
+	CrashStackTrace()
+	{
+		signal(SIGABRT, &CrashStackTrace::abortHandler);
+		signal(SIGSEGV, &CrashStackTrace::abortHandler);
+		signal(SIGILL,  &CrashStackTrace::abortHandler);
+		signal(SIGFPE,  &CrashStackTrace::abortHandler);
+#ifdef SIGBUS
+		signal(SIGBUS,  &CrashStackTrace::abortHandler);
+#endif
+	}
+
+	static void abortHandler(int signum)
+	{
+		// associate each signal with a signal name string.
+		const char* name = nullptr;
+		switch(signum)
+		{
+		case SIGABRT: name = "SIGABRT";  break;
+		case SIGSEGV: name = "SIGSEGV";  break;
+		case SIGILL:  name = "SIGILL";   break;
+		case SIGFPE:  name = "SIGFPE";   break;
+#ifdef SIGBUS
+		case SIGBUS:  name = "SIGBUS";   break;
+#endif
+		}
+
+		/** Notify the user which signal was caught. We use printf, because this
+		 * is the most basic output function. Once you get a crash, it is
+		 * possible that more complex output systems like streams and the like
+		 * may be corrupted. So we make the most basic call possible to the
+		 * lowest level, most standard print function. */
+		if(name)
+			fprintf(stderr, "Caught signal %d (%s)\n", signum, name);
+		else
+			fprintf(stderr, "Caught signal %d\n", signum);
+
+		print_stacktrace(false);
+
+		exit(-signum);
+	}
+};
+

--- a/retroshare-gui/src/main.cpp
+++ b/retroshare-gui/src/main.cpp
@@ -19,6 +19,10 @@
  *  Boston, MA  02110-1301, USA.
  ****************************************************************/
 
+#include "util/stacktrace.h"
+
+CrashStackTrace gCrashStackTrace;
+
 #include <QObject>
 #include <QMessageBox>
 #include <QSplashScreen>

--- a/retroshare-service/src/retroshare-service.cc
+++ b/retroshare-service/src/retroshare-service.cc
@@ -16,6 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "util/stacktrace.h"
+
+CrashStackTrace gCrashStackTrace;
+
 #include <QCoreApplication>
 #include <csignal>
 #include <QObject>


### PR DESCRIPTION
Caused by unneeded pointer usages + not enough careful IPv6 porting

I haven't managed to reproduce the crash nor to test the fix due it
happening only when UDP relayed connection happens (apparently never on
my nodes.

I have managed to discover where the bug comes from thanks to multiple
user reports, specially to Ilario report which documented 3 crashes
happening on 0.6.4 with complete log.