### PR TITLE
Attempt to fix crash in pqissludp

### DIFF
--- a/libretroshare/src/tcponudp/tou.h
+++ b/libretroshare/src/tcponudp/tou.h
@@ -103,11 +103,10 @@ int 	tou_connect(int sockfd, const struct sockaddr *serv_addr,
 					socklen_t addrlen, uint32_t conn_period);
 int 	tou_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);		
 
-	/* for relay connections */
-int     tou_connect_via_relay(int sockfd,
-                        const struct sockaddr_in *own_addr,
-                        const struct sockaddr_in *proxy_addr,
-                        const struct sockaddr_in *dest_addr);
+/// for relay connections
+int tou_connect_via_relay( int sockfd, const sockaddr_in& own_addr,
+                           const sockaddr_in& proxy_addr,
+                           const sockaddr_in& dest_addr );
 
 /* non-standard bonuses */
 int	tou_connected(int sockfd);


### PR DESCRIPTION
Caused by unneeded pointer usages + not enough careful IPv6 porting

I haven't managed to reproduce the crash nor to test the fix due it
happening only when UDP relayed connection happens (apparently never on
my nodes.

I have managed to discover where the bug comes from thanks to multiple
user reports, specially to Ilario report which documented 3 crashes
happening on 0.6.4 with complete log.