### PR TITLE
Add a build-time switch to GXS to distributes all requested data

### DIFF
--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -4382,7 +4382,9 @@ void RsGxsNetService::handleRecvSyncMessage(RsNxsSyncMsgReqItem *item,bool item_
 
     rstime_t now = time(NULL) ;
 
+#ifndef RS_GXS_SEND_ALL
     uint32_t max_send_delay = locked_getGrpConfig(item->grpId).msg_req_delay;	// we should use "sync" but there's only one variable used in the GUI: the req one.
+#endif
 
     if(canSendMsgIds(msgMetas, *grpMeta, peer, should_encrypt_to_this_circle_id))
     {
@@ -4413,8 +4415,11 @@ void RsGxsNetService::handleRecvSyncMessage(RsNxsSyncMsgReqItem *item,bool item_
 				}
 			}
 			// Check publish TS
-
+#ifndef RS_GXS_SEND_ALL
 			if(item->createdSinceTS > (*vit)->mPublishTs || ((max_send_delay > 0) && (*vit)->mPublishTs + max_send_delay < now))
+#else
+			if(item->createdSinceTS > (*vit)->mPublishTs)
+#endif
 			{
 #ifdef NXS_NET_DEBUG_0
 				GXSNETDEBUG_PG(item->PeerId(),item->grpId) << "  not sending item ID " << (*vit)->mMsgId << ", because it is too old (publishTS = " << (time(NULL)-(*vit)->mPublishTs)/86400 << " days ago" << std::endl;

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -111,6 +111,11 @@ rs_onlyhiddennode:CONFIG -= no_rs_onlyhiddennode
 CONFIG *= rs_gxs
 no_rs_gxs:CONFIG -= rs_gxs
 
+# To disable GXS distrubuting all available posts independed of the "sync" settings append the following
+# assignation to qmake command line "CONFIG+=no_rs_gxs_sendAll"
+CONFIG *= rs_gxs_sendAll
+no_rs_gxs_sendAll:CONFIG -= rs_gxs_sendAll
+
 # To enable RS Deprecated Warnings append the following assignation to qmake
 # command line "CONFIG+=rs_deprecatedwarning"
 CONFIG *= no_rs_deprecatedwarning
@@ -372,6 +377,7 @@ trough qmake command line arguments!")
 gxsdistsync:DEFINES *= RS_USE_GXS_DISTANT_SYNC
 wikipoos:DEFINES *= RS_USE_WIKI
 rs_gxs:DEFINES *= RS_ENABLE_GXS
+rs_gxs_sendAll:DEFINES *= RS_GXS_SEND_ALL
 libresapilocalserver:DEFINES *= LIBRESAPI_LOCAL_SERVER
 libresapi_settings:DEFINES *= LIBRESAPI_SETTINGS
 libresapihttpserver:DEFINES *= ENABLE_WEBUI

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -112,9 +112,9 @@ CONFIG *= rs_gxs
 no_rs_gxs:CONFIG -= rs_gxs
 
 # To disable GXS distrubuting all available posts independed of the "sync" settings append the following
-# assignation to qmake command line "CONFIG+=no_rs_gxs_sendAll"
-CONFIG *= rs_gxs_sendAll
-no_rs_gxs_sendAll:CONFIG -= rs_gxs_sendAll
+# assignation to qmake command line "CONFIG+=no_rs_gxs_send_all"
+CONFIG *= rs_gxs_send_all
+no_rs_gxs_send_all:CONFIG -= rs_gxs_send_all
 
 # To enable RS Deprecated Warnings append the following assignation to qmake
 # command line "CONFIG+=rs_deprecatedwarning"
@@ -377,7 +377,7 @@ trough qmake command line arguments!")
 gxsdistsync:DEFINES *= RS_USE_GXS_DISTANT_SYNC
 wikipoos:DEFINES *= RS_USE_WIKI
 rs_gxs:DEFINES *= RS_ENABLE_GXS
-rs_gxs_sendAll:DEFINES *= RS_GXS_SEND_ALL
+rs_gxs_send_all:DEFINES *= RS_GXS_SEND_ALL
 libresapilocalserver:DEFINES *= LIBRESAPI_LOCAL_SERVER
 libresapi_settings:DEFINES *= LIBRESAPI_SETTINGS
 libresapihttpserver:DEFINES *= ENABLE_WEBUI


### PR DESCRIPTION
The problem:
------------------
When everybody subscribes to a channel/forum with a sync period of **one week** and a store period of **one year**, a new user can only retrieve posts within a week ago but not from a year ago even if that information is available.


The fix:
----------
This option lets GXS send all available (requested) data independent from the *sync period* setting. As a compromise the default is to send everything available to fix the actual problem, while the option allows someone who is a afraid of increased traffic to change back to the old behavior.