### PR TITLE
Fix DNS resolution for hostnames that has also AAAA record

### DIFF
--- a/libresapi/src/webui-src/app/downloads.js
+++ b/libresapi/src/webui-src/app/downloads.js
@@ -33,7 +33,7 @@ function cntrlBtn(file, act) {
     return(
         m("div.btn",{
             onclick: function(){
-                rs.request("transfers/control_download",{action: act, id: file.id});
+                rs.request("transfers/control_download",{action: act, hash: file.hash});
             }
         },
         act)

--- a/libresapi/src/webui-src/app/downloads.js
+++ b/libresapi/src/webui-src/app/downloads.js
@@ -68,7 +68,7 @@ module.exports = {
                 ]),
             	paths.map(function (file){
             	    var ctrlBtn = m("div","");
-                    var progress = file.transfered  /  file.size * 100;
+                    var progress = file.transferred  /  file.size * 100;
             	    return m("tr",[
             	        m("td",[
             	            m("a.filelink",

--- a/libresapi/src/webui-src/app/downloads.js
+++ b/libresapi/src/webui-src/app/downloads.js
@@ -23,7 +23,7 @@ function progressBar(file){
 	m("div[style="
 	    + 'background-color:lime;'
 	    + 'height:100%;'
-	    + 'width:' + (file.transfered  /  file.size * 100)+'%'
+	    + 'width:' + (file.transferred  /  file.size * 100)+'%'
 	    + ']'
 	,"")
 	]);


### PR DESCRIPTION
rsGetHostByName doesn't support IPv6 addresses.
Before this commit when
an hostname had both AAAA and A record rsGetHostByName retrurned success
but with 0.0.0.0 invalid address. As rsGetHostByName is not capable of
handling IPv6 (fixing it would require API change and a bunch of
refactors around) just avoid to receive IPv6 addresses on resolition, so
the correct IPv4 address is returned if present, otherwise fail
gracefully (A record not found).