### PR TITLE
WIP: removed Tlv sets from forum Group data to comply with new serialization.

### DIFF
--- a/libretroshare/src/retroshare/rsgxsforums.h
+++ b/libretroshare/src/retroshare/rsgxsforums.h
@@ -42,7 +42,7 @@ static const uint32_t RS_GXS_FORUM_MSG_FLAGS_MODERATED = 0x00000001 ;
 class RsGxsForums;
 extern RsGxsForums *rsGxsForums;
 
-class RsGxsForumGroup
+class RsGxsForumGroup_deprecated
 {
 	public:
 	RsGroupMetaData mMeta;
@@ -52,6 +52,18 @@ class RsGxsForumGroup
 
     RsTlvGxsIdSet mAdminList;
     RsTlvGxsMsgIdSet mPinnedPosts;
+};
+
+class RsGxsForumGroup
+{
+	public:
+	RsGroupMetaData mMeta;
+	std::string mDescription;
+
+    // What's below is optional, and handled by the serialiser
+
+    std::set<RsGxsId> mAdminList;
+    std::set<RsGxsMessageId> mPinnedPosts;
 };
 
 class RsGxsForumMsg

--- a/libretroshare/src/rsitems/rsgxsforumitems.cc
+++ b/libretroshare/src/rsitems/rsgxsforumitems.cc
@@ -35,14 +35,26 @@ RsItem *RsGxsForumSerialiser::create_item(uint16_t service_id,uint8_t item_subty
     switch(item_subtype)
     {
     case RS_PKT_SUBTYPE_GXSFORUM_GROUP_ITEM: return new RsGxsForumGroupItem();
+    case RS_PKT_SUBTYPE_GXSFORUM_GROUP_ITEM_deprecated: return new RsGxsForumGroupItem_deprecated();
     case RS_PKT_SUBTYPE_GXSFORUM_MESSAGE_ITEM: return new RsGxsForumMsgItem();
     default:
         return NULL ;
     }
 }
-void RsGxsForumGroupItem::clear()
+void RsGxsForumGroupItem::clear() { mGroup.mDescription.clear(); }
+void RsGxsForumGroupItem_deprecated::clear() { mGroup.mDescription.clear(); }
+
+void RsGxsForumGroupItem_deprecated::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
 {
-	mGroup.mDescription.clear();
+    RsTypeSerializer::serial_process(j,ctx,TLV_TYPE_STR_DESCR,mGroup.mDescription,"mGroup.Description");
+
+    // This is for backward compatibility: normally all members are serialized, but in the previous version, these members are missing.
+
+    if(j == RsGenericSerializer::DESERIALIZE && ctx.mOffset == ctx.mSize)
+        return ;
+
+    RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mGroup.mAdminList  ,"admin_list"  ) ;
+    RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mGroup.mPinnedPosts,"pinned_posts") ;
 }
 
 void RsGxsForumGroupItem::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
@@ -54,8 +66,8 @@ void RsGxsForumGroupItem::serial_process(RsGenericSerializer::SerializeJob j,RsG
     if(j == RsGenericSerializer::DESERIALIZE && ctx.mOffset == ctx.mSize)
         return ;
 
-    RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mGroup.mAdminList  ,"admin_list"  ) ;
-    RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mGroup.mPinnedPosts,"pinned_posts") ;
+    RsTypeSerializer::serial_process(j,ctx,mGroup.mAdminList  ,"admin_list"  ) ;
+    RsTypeSerializer::serial_process(j,ctx,mGroup.mPinnedPosts,"pinned_posts") ;
 }
 
 void RsGxsForumMsgItem::clear()

--- a/libretroshare/src/rsitems/rsgxsforumitems.h
+++ b/libretroshare/src/rsitems/rsgxsforumitems.h
@@ -31,10 +31,27 @@
 
 #include "retroshare/rsgxsforums.h"
 
-const uint8_t RS_PKT_SUBTYPE_GXSFORUM_GROUP_ITEM   = 0x02;
-const uint8_t RS_PKT_SUBTYPE_GXSFORUM_MESSAGE_ITEM = 0x03;
+const uint8_t RS_PKT_SUBTYPE_GXSFORUM_GROUP_ITEM_deprecated   = 0x02;
+const uint8_t RS_PKT_SUBTYPE_GXSFORUM_MESSAGE_ITEM            = 0x03;
+const uint8_t RS_PKT_SUBTYPE_GXSFORUM_GROUP_ITEM              = 0x04;
 
-class RsGxsForumGroupItem : public RsGxsGrpItem
+// This class was created on 11/2018 in order to get rid of the old group system that uses Tlv Sets for ids, that is not json-friendly.
+
+class RsGxsForumGroupItem_deprecated : public RsGxsGrpItem
+{
+
+public:
+
+	RsGxsForumGroupItem_deprecated():  RsGxsGrpItem(RS_SERVICE_GXS_TYPE_FORUMS, RS_PKT_SUBTYPE_GXSFORUM_GROUP_ITEM_deprecated) {}
+	virtual ~RsGxsForumGroupItem_deprecated() {}
+
+	void clear();
+	virtual void serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx);
+
+	RsGxsForumGroup_deprecated mGroup;
+};
+
+class RsGxsForumGroupItem: public RsGxsGrpItem
 {
 
 public:

--- a/libretroshare/src/services/p3gxsforums.cc
+++ b/libretroshare/src/services/p3gxsforums.cc
@@ -280,18 +280,36 @@ bool p3GxsForums::getGroupData(const uint32_t &token, std::vector<RsGxsForumGrou
 		for(; vit != grpData.end(); ++vit)
 		{
 			RsGxsForumGroupItem* item = dynamic_cast<RsGxsForumGroupItem*>(*vit);
+
 			if (item)
 			{
 				RsGxsForumGroup grp = item->mGroup;
 				grp.mMeta = item->meta;
 				delete item;
 				groups.push_back(grp);
+                continue;
 			}
-			else
+
+ 			RsGxsForumGroupItem_deprecated* item2 = dynamic_cast<RsGxsForumGroupItem_deprecated*>(*vit);
+
+			if (item2)
 			{
-				std::cerr << "Not a GxsForumGrpItem, deleting!" << std::endl;
-				delete *vit;
+                std::cerr << "(II) converting a GxsForumGroupItem for group " << item2->meta.mGroupId << " into new format. When the group is updated (e.g. change forum name or admin list, this warning should disappear" << std::endl;
+
+				RsGxsForumGroup grp ;
+
+                grp.mDescription = item2->mGroup.mDescription;
+				grp.mAdminList   = item2->mGroup.mAdminList.ids;
+				grp.mPinnedPosts = item2->mGroup.mPinnedPosts.ids;
+				grp.mMeta        = item2->meta;
+
+				delete item2;
+				groups.push_back(grp);
+                continue;
 			}
+
+			std::cerr << "Not a GxsForumGrpItem, deleting!" << std::endl;
+			delete *vit;
 		}
 	}
 	return ok;

--- a/retroshare-gui/src/gui/gxsforums/GxsForumGroupDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumGroupDialog.cpp
@@ -105,7 +105,7 @@ bool GxsForumGroupDialog::service_CreateGroup(uint32_t &token, const RsGroupMeta
 	RsGxsForumGroup grp;
 	grp.mMeta = meta;
 	grp.mDescription = getDescription().toUtf8().constData();
-	getSelectedModerators(grp.mAdminList.ids);
+	getSelectedModerators(grp.mAdminList);
 
 	rsGxsForums->createGroup(token, grp);
 	return true;
@@ -120,7 +120,7 @@ bool GxsForumGroupDialog::service_EditGroup(uint32_t &token, RsGroupMetaData &ed
 	grp.mMeta = editedMeta;
 	grp.mDescription = getDescription().toUtf8().constData();
 
-	getSelectedModerators(grp.mAdminList.ids);
+	getSelectedModerators(grp.mAdminList);
 
 	std::cerr << "GxsForumGroupDialog::service_EditGroup() submitting changes";
 	std::cerr << std::endl;
@@ -160,7 +160,7 @@ bool GxsForumGroupDialog::service_loadGroup(uint32_t token, Mode /*mode*/, RsGro
 
     // Local information. Description should be handled here.
 
-    setSelectedModerators(groups[0].mAdminList.ids);
+    setSelectedModerators(groups[0].mAdminList);
 
     mGroupData = groups[0]; // keeps the private information
 

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -517,7 +517,7 @@ void GxsForumThreadWidget::threadListCustomPopupMenu(QPoint /*point*/)
 	QAction *editAct = new QAction(QIcon(IMAGE_MESSAGEEDIT), tr("Edit"), &contextMnu);
 	connect(editAct, SIGNAL(triggered()), this, SLOT(editforummessage()));
 
-	bool is_pinned = mForumGroup.mPinnedPosts.ids.find(mThreadId) != mForumGroup.mPinnedPosts.ids.end();
+	bool is_pinned = mForumGroup.mPinnedPosts.find(mThreadId) != mForumGroup.mPinnedPosts.end();
 	QAction *pinUpPostAct = new QAction(QIcon(IMAGE_MESSAGE), (is_pinned?tr("Un-pin this post"):tr("Pin this post up")), &contextMnu);
 	connect(pinUpPostAct , SIGNAL(triggered()), this, SLOT(togglePinUpPost()));
 
@@ -615,7 +615,7 @@ void GxsForumThreadWidget::threadListCustomPopupMenu(QPoint /*point*/)
 		QTreeWidgetItem *item = *selectedItems.begin();
 		GxsIdRSTreeWidgetItem *gxsIdItem = dynamic_cast<GxsIdRSTreeWidgetItem*>(item);
 
-		bool is_pinned = mForumGroup.mPinnedPosts.ids.find( RsGxsMessageId(item->data(COLUMN_THREAD_MSGID,Qt::DisplayRole).toString().toStdString()) ) != mForumGroup.mPinnedPosts.ids.end();
+		bool is_pinned = mForumGroup.mPinnedPosts.find( RsGxsMessageId(item->data(COLUMN_THREAD_MSGID,Qt::DisplayRole).toString().toStdString()) ) != mForumGroup.mPinnedPosts.end();
 
         if(!is_pinned)
 		{
@@ -631,7 +631,7 @@ void GxsForumThreadWidget::threadListCustomPopupMenu(QPoint /*point*/)
 				rsIdentity->getOwnIds(own_ids) ;
 
 				for(auto it(own_ids.begin());it!=own_ids.end();++it)
-					if(mForumGroup.mAdminList.ids.find(*it) != mForumGroup.mAdminList.ids.end())
+					if(mForumGroup.mAdminList.find(*it) != mForumGroup.mAdminList.end())
 					{
 						contextMnu.addAction(editAct);
 						break ;
@@ -840,7 +840,7 @@ void GxsForumThreadWidget::calculateIconsAndFonts(QTreeWidgetItem *item, bool &h
 		calculateIconsAndFonts(item->child(index), myReadChilddren, myUnreadChilddren);
 	}
 
-    bool is_pinned = mForumGroup.mPinnedPosts.ids.find(msgId) != mForumGroup.mPinnedPosts.ids.end();
+    bool is_pinned = mForumGroup.mPinnedPosts.find(msgId) != mForumGroup.mPinnedPosts.end();
 
 	// set font
 	for (int i = 0; i < COLUMN_THREAD_COUNT; ++i) {
@@ -1066,11 +1066,11 @@ static QString getDurationString(uint32_t days)
     tw->ui->subscribeToolButton->setSubscribed(IS_GROUP_SUBSCRIBED(tw->mSubscribeFlags));
     tw->mStateHelper->setWidgetEnabled(tw->ui->newthreadButton, (IS_GROUP_SUBSCRIBED(tw->mSubscribeFlags)));
 
-    if(!group.mAdminList.ids.empty())
+    if(!group.mAdminList.empty())
     {
         QString admin_list_str ;
 
-        for(auto it(group.mAdminList.ids.begin());it!=group.mAdminList.ids.end();++it)
+        for(auto it(group.mAdminList.begin());it!=group.mAdminList.end();++it)
         {
             RsIdentityDetails det ;
 
@@ -1263,7 +1263,7 @@ QTreeWidgetItem *GxsForumThreadWidget::convertMsgToThreadWidget(const RsGxsForum
 	// Early check for a message that should be hidden because its author
 	// is flagged with a bad reputation
 
-    bool is_pinned = mForumGroup.mPinnedPosts.ids.find(msg.mMeta.mMsgId) != mForumGroup.mPinnedPosts.ids.end();
+    bool is_pinned = mForumGroup.mPinnedPosts.find(msg.mMeta.mMsgId) != mForumGroup.mPinnedPosts.end();
 
     uint32_t idflags =0;
 	RsReputations::ReputationLevel reputation_level = rsReputations->overallReputationLevel(msg.mMeta.mAuthorId,&idflags) ;
@@ -2206,10 +2206,10 @@ void GxsForumThreadWidget::togglePinUpPost()
 
     std::cerr << "Toggling Pin-up state of post " << mThreadId.toStdString() << ": \"" << thread_title.toStdString() << "\"" << std::endl;
 
-    if(mForumGroup.mPinnedPosts.ids.find(mThreadId) == mForumGroup.mPinnedPosts.ids.end())
-		mForumGroup.mPinnedPosts.ids.insert(mThreadId) ;
+    if(mForumGroup.mPinnedPosts.find(mThreadId) == mForumGroup.mPinnedPosts.end())
+		mForumGroup.mPinnedPosts.insert(mThreadId) ;
     else
-		mForumGroup.mPinnedPosts.ids.erase(mThreadId) ;
+		mForumGroup.mPinnedPosts.erase(mThreadId) ;
 
 	uint32_t token;
 	rsGxsForums->updateGroup(token,mForumGroup);
@@ -2370,7 +2370,7 @@ void GxsForumThreadWidget::editForumMessageData(const RsGxsForumMsg& msg)
 	rsIdentity->getOwnIds(own_ids) ;
 
 	for(auto it(own_ids.begin());it!=own_ids.end();++it)
-		if(mForumGroup.mAdminList.ids.find(*it) != mForumGroup.mAdminList.ids.end())
+		if(mForumGroup.mAdminList.find(*it) != mForumGroup.mAdminList.end())
         {
             moderator_id = *it;
             break;

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsFillThread.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsFillThread.cpp
@@ -190,11 +190,11 @@ void GxsForumsFillThread::run()
 //#ifdef DEBUG_FORUMS
     std::cerr << "Retrieved group data: " << std::endl;
     std::cerr << "  Group ID: " << forum_group.mMeta.mGroupId << std::endl;
-    std::cerr << "  Admin lst: " << forum_group.mAdminList.ids.size() << " elements." << std::endl;
-    for(auto it(forum_group.mAdminList.ids.begin());it!=forum_group.mAdminList.ids.end();++it)
+    std::cerr << "  Admin lst: " << forum_group.mAdminList.size() << " elements." << std::endl;
+    for(auto it(forum_group.mAdminList.begin());it!=forum_group.mAdminList.end();++it)
         std::cerr << "    " << *it << std::endl;
-    std::cerr << "  Pinned Post: " << forum_group.mPinnedPosts.ids.size() << " messages." << std::endl;
-    for(auto it(forum_group.mPinnedPosts.ids.begin());it!=forum_group.mPinnedPosts.ids.end();++it)
+    std::cerr << "  Pinned Post: " << forum_group.mPinnedPosts.size() << " messages." << std::endl;
+    for(auto it(forum_group.mPinnedPosts.begin());it!=forum_group.mPinnedPosts.end();++it)
         std::cerr << "    " << *it << std::endl;
 //#endif
 
@@ -278,7 +278,7 @@ void GxsForumsFillThread::run()
 				if( !IS_FORUM_MSG_MODERATION(msgIt->second.mMeta.mMsgFlags) )			// if authors are different the moderation flag needs to be set on the editing msg
 					continue ;
 
-				if( forum_group.mAdminList.ids.find(msgIt->second.mMeta.mAuthorId)==forum_group.mAdminList.ids.end())	// if author is not a moderator, continue
+				if( forum_group.mAdminList.find(msgIt->second.mMeta.mAuthorId)==forum_group.mAdminList.end())	// if author is not a moderator, continue
 					continue ;
 			}
 


### PR DESCRIPTION
This fix is partially backward compatible:
- forum Group data will stay unchanged until the forum is edited (moderators added, posts pinned, name changed, etc)
- old peers will not see forums in new format
- new peers will accept old and new format

This solution is not optimal at all. I'm still trying to find a better way to do this.