### PR TITLE
0.6.5 Disable deprecated messaging

### DIFF
--- a/libretroshare/src/chat/p3chatservice.cc
+++ b/libretroshare/src/chat/p3chatservice.cc
@@ -848,9 +848,18 @@ bool p3ChatService::handleRecvChatMsgItem(RsChatMsgItem *& ci)
             RsServer::notify()->AddPopupMessage(popupChatFlag, ci->PeerId().toStdString(), name, message); /* notify private chat message */
         else
         {
-            /* notify public chat message */
-            RsServer::notify()->AddPopupMessage(RS_POPUP_GROUPCHAT, ci->PeerId().toStdString(), "", message);
-            RsServer::notify()->AddFeedItem(RS_FEED_ITEM_CHAT_NEW, ci->PeerId().toStdString(), message, "");
+#ifdef RS_DIRECT_CHAT
+			/* notify public chat message */
+			RsServer::notify()->AddPopupMessage(
+			            RS_POPUP_GROUPCHAT,
+			            ci->PeerId().toStdString(), "", message );
+			RsServer::notify()->AddFeedItem(
+			            RS_FEED_ITEM_CHAT_NEW,
+			            ci->PeerId().toStdString(), message, "" );
+#else // def RS_DIRECT_CHAT
+			/* Ignore deprecated direct node broadcast chat messages */
+			return false;
+#endif
         }
     }
 

--- a/retroshare-gui/src/gui/FriendsDialog.cpp
+++ b/retroshare-gui/src/gui/FriendsDialog.cpp
@@ -69,9 +69,9 @@ FriendsDialog::FriendsDialog(QWidget *parent)
     /* Invoke the Qt Designer generated object setup routine */
     ui.setupUi(this);
 
-    if (instance == NULL) {
-        instance = this;
-    }
+	if (!instance) instance = this;
+
+#ifdef RS_DIRECT_CHAT
     QString msg = tr("Retroshare broadcast chat: messages are sent to all connected friends.");
     // "<font color='grey'>" + DateTime::formatTime(QTime::currentTime()) + "</font> -
     msg = QString("<font color='blue'><i>" + msg + "</i></font>");
@@ -82,6 +82,10 @@ FriendsDialog::FriendsDialog(QWidget *parent)
             this, SLOT(chatMessageReceived(ChatMessage)));
     connect(NotifyQt::getInstance(), SIGNAL(chatStatusChanged(ChatId,QString)),
             this, SLOT(chatStatusReceived(ChatId,QString)));
+#else // def RS_DIRECT_CHAT
+	ui.tabWidget->removeTab(ui.tabWidget->indexOf(ui.groupChatTab));
+#endif // def RS_DIRECT_CHAT
+
 
     connect( ui.mypersonalstatusLabel, SIGNAL(clicked()), SLOT(statusmessage()));
     connect( ui.actionSet_your_Avatar, SIGNAL(triggered()), this, SLOT(getAvatar()));

--- a/retroshare-gui/src/gui/Identity/IdDialog.h
+++ b/retroshare-gui/src/gui/Identity/IdDialog.h
@@ -89,6 +89,7 @@ private slots:
 	void removeIdentity();
 	void editIdentity();
 	void chatIdentity();
+	void chatIdentityItem(QTreeWidgetItem* item);
 	void sendMsg();
 	void copyRetroshareLink();
   void on_closeInfoFrameButton_clicked();

--- a/retroshare-gui/src/gui/common/FriendList.cpp
+++ b/retroshare-gui/src/gui/common/FriendList.cpp
@@ -120,9 +120,15 @@ FriendList::FriendList(QWidget *parent) :
     ui->setupUi(this);
 
     connect(ui->peerTreeWidget, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(peerTreeWidgetCustomPopupMenu()));
-    connect(ui->peerTreeWidget, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), this, SLOT(chatfriend(QTreeWidgetItem *)));
     connect(ui->peerTreeWidget, SIGNAL(itemExpanded(QTreeWidgetItem *)), this, SLOT(expandItem(QTreeWidgetItem *)));
     connect(ui->peerTreeWidget, SIGNAL(itemCollapsed(QTreeWidgetItem *)), this, SLOT(collapseItem(QTreeWidgetItem *)));
+
+#ifdef RS_DIRECT_CHAT
+	connect(ui->peerTreeWidget, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), this, SLOT(chatfriend(QTreeWidgetItem *)));
+#else
+	connect( ui->peerTreeWidget, SIGNAL(itemClicked(QTreeWidgetItem *, int)),
+	         this, SLOT(expandItem(QTreeWidgetItem *)) );
+#endif
 
     connect(NotifyQt::getInstance(), SIGNAL(groupsChanged(int)), this, SLOT(groupsChanged()));
     connect(NotifyQt::getInstance(), SIGNAL(friendsChanged()), this, SLOT(insertPeers()));
@@ -346,9 +352,10 @@ void FriendList::peerTreeWidgetCustomPopupMenu()
          case TYPE_GROUP:
              {
                  bool standard = c->data(COLUMN_DATA, ROLE_STANDARD).toBool();
-
+#ifdef RS_DIRECT_CHAT
                  contextMenu->addAction(QIcon(IMAGE_MSG), tr("Send message to whole group"), this, SLOT(msgfriend()));
                  contextMenu->addSeparator();
+#endif // RS_DIRECT_CHAT
                  contextMenu->addAction(QIcon(IMAGE_EDIT), tr("Edit Group"), this, SLOT(editGroup()));
 
                  QAction *action = contextMenu->addAction(QIcon(IMAGE_REMOVE), tr("Remove Group"), this, SLOT(removeGroup()));
@@ -357,10 +364,11 @@ void FriendList::peerTreeWidgetCustomPopupMenu()
              break;
          case TYPE_GPG:
         {
+#ifdef RS_DIRECT_CHAT
              contextMenu->addAction(QIcon(IMAGE_CHAT), tr("Chat"), this, SLOT(chatfriendproxy()));
              contextMenu->addAction(QIcon(IMAGE_MSG), tr("Send message"), this, SLOT(msgfriend()));
-
              contextMenu->addSeparator();
+#endif // RS_DIRECT_CHAT
 
              contextMenu->addAction(QIcon(IMAGE_FRIENDINFO), tr("Profile details"), this, SLOT(configurefriend()));
              contextMenu->addAction(QIcon(IMAGE_DENYFRIEND), tr("Deny connections"), this, SLOT(removefriend()));
@@ -437,10 +445,11 @@ void FriendList::peerTreeWidgetCustomPopupMenu()
 
          case TYPE_SSL:
              {
+#ifdef RS_DIRECT_CHAT
                  contextMenu->addAction(QIcon(IMAGE_CHAT), tr("Chat"), this, SLOT(chatfriendproxy()));
                  contextMenu->addAction(QIcon(IMAGE_MSG), tr("Send message to this node"), this, SLOT(msgfriend()));
-
                  contextMenu->addSeparator();
+#endif // RS_DIRECT_CHAT
 
                  contextMenu->addAction(QIcon(IMAGE_FRIENDINFO), tr("Node details"), this, SLOT(configurefriend()));
 

--- a/retroshare-gui/src/gui/msgs/MessageComposer.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageComposer.cpp
@@ -217,9 +217,7 @@ MessageComposer::MessageComposer(QWidget *parent, Qt::WindowFlags flags)
     /* initialize friends list */
     ui.friendSelectionWidget->setHeaderText(tr("Send To:"));
     ui.friendSelectionWidget->setModus(FriendSelectionWidget::MODUS_MULTI);
-    ui.friendSelectionWidget->setShowType(//FriendSelectionWidget::SHOW_GROUP	// removed this because it's too confusing.
-                                            FriendSelectionWidget::SHOW_SSL
-                                          | FriendSelectionWidget::SHOW_GXS);
+	ui.friendSelectionWidget->setShowType(FriendSelectionWidget::SHOW_GXS);
     ui.friendSelectionWidget->start();
 
     QActionGroup *grp = new QActionGroup(this);
@@ -263,11 +261,9 @@ MessageComposer::MessageComposer(QWidget *parent, Qt::WindowFlags flags)
     ui.respond_to_CB->setFlags(IDCHOOSER_ID_REQUIRED) ;
     
     /* Add filter types */
-    ui.filterComboBox->addItem(tr("All addresses (mixed)"));
-    ui.filterComboBox->addItem(tr("Friend Nodes"));
     ui.filterComboBox->addItem(tr("All people"));
     ui.filterComboBox->addItem(tr("My contacts"));
-    ui.filterComboBox->setCurrentIndex(2);
+	ui.filterComboBox->setCurrentIndex(0);
 
     if(rsIdentity->nbRegularContacts() > 0)
     	ui.filterComboBox->setCurrentIndex(3);
@@ -2591,25 +2587,14 @@ void MessageComposer::filterComboBoxChanged(int i)
 {
 	switch(i)
 	{
-		case 0:  ui.friendSelectionWidget->setShowType(FriendSelectionWidget::SHOW_GROUP
-                                          | FriendSelectionWidget::SHOW_SSL
-                                          | FriendSelectionWidget::SHOW_GXS) ;
-				  break ;
-				  
-		case 1: ui.friendSelectionWidget->setShowType(FriendSelectionWidget::SHOW_GROUP
-                                          | FriendSelectionWidget::SHOW_SSL) ;
-				  break ;
-
-		case 2: ui.friendSelectionWidget->setShowType(FriendSelectionWidget::SHOW_GXS) ;
-				  break ;
-
-					  
-		case 3: ui.friendSelectionWidget->setShowType(FriendSelectionWidget::SHOW_CONTACTS) ;
-				  break ;		  
-				  				  
-		default: ;
+	default:
+	case 0:
+		ui.friendSelectionWidget->setShowType(FriendSelectionWidget::SHOW_GXS);
+		break;
+	case 1:
+		ui.friendSelectionWidget->setShowType(FriendSelectionWidget::SHOW_CONTACTS);
+		break;
 	}
-
 }
 
 void MessageComposer::friendSelectionChanged()

--- a/retroshare-gui/src/gui/notifyqt.cpp
+++ b/retroshare-gui/src/gui/notifyqt.cpp
@@ -894,6 +894,7 @@ void NotifyQt::UpdateGUI()
 					}
 					break;
 				case RS_POPUP_GROUPCHAT:
+#ifdef RS_DIRECT_CHAT
 					if ((popupflags & RS_POPUP_GROUPCHAT) && !_disableAllToaster)
 					{
 						MainWindow *mainWindow = MainWindow::getInstance();
@@ -907,6 +908,7 @@ void NotifyQt::UpdateGUI()
 						}
 						toaster = new ToasterItem(new GroupChatToaster(RsPeerId(id), QString::fromUtf8(msg.c_str())));
 					}
+#endif // RS_DIRECT_CHAT
 					break;
 				case RS_POPUP_CHATLOBBY:
 					if ((popupflags & RS_POPUP_CHATLOBBY) && !_disableAllToaster)
@@ -1041,7 +1043,9 @@ void NotifyQt::testToasters(uint notifyFlags, /*RshareSettings::enumToasterPosit
                 toaster = new ToasterItem(new ChatToaster(id, message));
 				break;
 			case RS_POPUP_GROUPCHAT:
+#ifdef RS_DIRECT_CHAT
 				toaster = new ToasterItem(new GroupChatToaster(id, message));
+#endif // RS_DIRECT_CHAT
 				break;
 			case RS_POPUP_CHATLOBBY:
 				{

--- a/retroshare-gui/src/gui/settings/NotifyPage.cpp
+++ b/retroshare-gui/src/gui/settings/NotifyPage.cpp
@@ -322,7 +322,9 @@ void NotifyPage::load()
 	whileBlocking(ui.popup_NewMsg)->setChecked(notifyflags & RS_POPUP_MSG);
 	whileBlocking(ui.popup_DownloadFinished)->setChecked(notifyflags & RS_POPUP_DOWNLOAD);
 	whileBlocking(ui.popup_PrivateChat)->setChecked(notifyflags & RS_POPUP_CHAT);
+#ifdef RS_DIRECT_CHAT
 	whileBlocking(ui.popup_GroupChat)->setChecked(notifyflags & RS_POPUP_GROUPCHAT);
+#endif // def RS_DIRECT_CHAT
 	whileBlocking(ui.popup_ChatLobby)->setChecked(notifyflags & RS_POPUP_CHATLOBBY);
 	whileBlocking(ui.popup_ConnectAttempt)->setChecked(notifyflags & RS_POPUP_CONNECT_ATTEMPT);
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -136,6 +136,11 @@ CONFIG *= rs_gxs_trans
 CONFIG *= no_rs_async_chat
 rs_async_chat:CONFIG -= no_rs_async_chat
 
+# To enable direct chat which has been deprecated since RetroShare 0.6.5 append
+# the following assignation to qmake command line "CONFIG+=direct_chat"
+CONFIG *= no_direct_chat
+direct_chat:CONFIG -= no_direct_chat
+
 # To disable bitdht append the following assignation to qmake command line
 # "CONFIG+=no_bitdht"
 CONFIG *= bitdht
@@ -434,6 +439,11 @@ rs_gxs_trans {
 
 bitdht {
     DEFINES *= RS_USE_BITDHT
+}
+
+direct_chat {
+    warning("You have enabled RetroShare direct chat which is deprecated!")
+    DEFINES *= RS_DIRECT_CHAT
 }
 
 rs_async_chat {


### PR DESCRIPTION
Now that by default own signed GXS identity is spread as gossip to direct friends, direct node chat is not needed anymore.
Improve usability by avoiding user confusion with 4 different type of chats of which 2 are mostly not useful, live only chat rooms and distant chat.
As a bonus now when one double click on an identity on people tab a chat is opened.