### PR TITLE
set the default size of the buttons on the chat window

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -85,8 +85,8 @@ ChatWidget::ChatWidget(QWidget *parent)
 	int iconHeight = QFontMetricsF(font()).height();
 	double fmm = iconHeight > FMM_THRESHOLD ? FMM : FMM_SMALLER;
 	iconHeight *= fmm;
-	QSize iconSize = QSize(iconHeight, iconHeight);
-	int butt_size(iconSize.height() + fmm);
+	QSize iconSize = QSize(QSize(iconHeight*1.3,iconHeight*1.3));
+	int butt_size(iconSize.height() /*+ fmm*/);
 	QSize buttonSize = QSize(butt_size, butt_size);
 
 	lastMsgDate = QDate::currentDate();
@@ -109,7 +109,7 @@ ChatWidget::ChatWidget(QWidget *parent)
 	ui->searchAfter->setFixedHeight(iconHeight);
 	ui->searchButton->setFixedSize(buttonSize);
 	ui->searchButton->setIconSize(iconSize);
-	ui->sendButton->setFixedHeight(iconHeight);
+	ui->sendButton->setFixedSize(buttonSize);
 	ui->sendButton->setIconSize(iconSize);
 
 	//Initialize search


### PR DESCRIPTION
the default size its to small its never goes bigger... on big tv screen or notebook always very small.

i set a default size to look better for your eyes seems nobody see it.

before
![image](https://user-images.githubusercontent.com/47180527/53827241-ef9b4080-3f7a-11e9-90ae-d432a52b1037.png)

after
![image](https://user-images.githubusercontent.com/47180527/53827175-c8447380-3f7a-11e9-925f-d89a05c4806f.png)

