### PR TITLE
Fix jsonapi compilation

### DIFF
--- a/RetroShare.pro
+++ b/RetroShare.pro
@@ -31,7 +31,7 @@ rs_jsonapi:isEmpty(JSONAPI_GENERATOR_EXE) {
 
 SUBDIRS += libbitdht
 libbitdht.file = libbitdht/src/libbitdht.pro
-libretroshare.depends = openpgpsdk libbitdht
+libretroshare.depends += openpgpsdk libbitdht
 
 SUBDIRS += libretroshare
 libretroshare.file = libretroshare/src/libretroshare.pro
@@ -39,7 +39,7 @@ libretroshare.file = libretroshare/src/libretroshare.pro
 libresapi {
     SUBDIRS += libresapi
     libresapi.file = libresapi/src/libresapi.pro
-    libresapi.depends = libretroshare
+    libresapi.depends += libretroshare
 }
 
 retroshare_gui {

--- a/jsonapi-generator/src/jsonapi-generator.cpp
+++ b/jsonapi-generator/src/jsonapi-generator.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
 				QString refid(member.attributes().namedItem("refid").nodeValue());
 				QString methodName(member.firstChildElement("name").toElement().text());
 				bool requiresAuth = true;
-				QString defFilePath(doxPrefix + refid.split('_')[0] + ".xml");
+				QString defFilePath(doxPrefix + refid.left(refid.lastIndexOf('_')) + ".xml");
 
 				qDebug() << "Looking for" << typeName << methodName << "into"
 				         << typeFilePath;

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -862,36 +862,24 @@ rs_jsonapi {
 
     no_rs_cross_compiling {
         DUMMYRESTBEDINPUT = FORCE
+        CMAKE_GENERATOR_OVERRIDE=""
+        win32-g++:CMAKE_GENERATOR_OVERRIDE="-G \"MSYS Makefiles\""
         genrestbedlib.name = Generating libresbed.
         genrestbedlib.input = DUMMYRESTBEDINPUT
         genrestbedlib.output = $$clean_path($${RESTBED_BUILD_PATH}/librestbed.a)
         genrestbedlib.CONFIG += target_predeps combine
         genrestbedlib.variable_out = PRE_TARGETDEPS
-        win32-g++ {
-            genrestbedlib.commands = \
-                cd $${RS_SRC_PATH} && \
-                git submodule update --init --recommend-shallow supportlibs/restbed && \
-                cd $${RESTBED_SRC_PATH} && \
-                git submodule update --init --recommend-shallow dependency/asio && \
-                git submodule update --init --recommend-shallow dependency/catch && \
-                git submodule update --init --recommend-shallow dependency/kashmir && \
-                mkdir -p $${RESTBED_BUILD_PATH}; cd $${RESTBED_BUILD_PATH} && \
-                cmake -DCMAKE_CXX_COMPILER=$$QMAKE_CXX -G \"MSYS Makefiles\" -DBUILD_SSL=OFF \
-                    -DCMAKE_INSTALL_PREFIX=. -B. -H$$shell_path($${RESTBED_SRC_PATH}) && \
-                make
-        } else {
-            genrestbedlib.commands = \
-                cd $${RS_SRC_PATH};\
-                git submodule update --init --recommend-shallow supportlibs/restbed;\
-                cd $${RESTBED_SRC_PATH};\
-                git submodule update --init --recommend-shallow dependency/asio;\
-                git submodule update --init --recommend-shallow dependency/catch;\
-                git submodule update --init --recommend-shallow dependency/kashmir;\
-                mkdir -p $${RESTBED_BUILD_PATH}; cd $${RESTBED_BUILD_PATH};\
-                cmake -DCMAKE_CXX_COMPILER=$$QMAKE_CXX -DBUILD_SSL=OFF \
-                    -DCMAKE_INSTALL_PREFIX=. -B. -H$$shell_path($${RESTBED_SRC_PATH});\
-                make
-        }
+        genrestbedlib.commands = \
+            cd $${RS_SRC_PATH} && \
+            git submodule update --init --recommend-shallow supportlibs/restbed && \
+            cd $${RESTBED_SRC_PATH} && \
+            git submodule update --init --recommend-shallow dependency/asio && \
+            git submodule update --init --recommend-shallow dependency/catch && \
+            git submodule update --init --recommend-shallow dependency/kashmir && \
+            mkdir -p $${RESTBED_BUILD_PATH}; cd $${RESTBED_BUILD_PATH} && \
+            cmake -DCMAKE_CXX_COMPILER=$$QMAKE_CXX $${CMAKE_GENERATOR_OVERRIDE} -DBUILD_SSL=OFF \
+                -DCMAKE_INSTALL_PREFIX=. -B. -H$$shell_path($${RESTBED_SRC_PATH}) && \
+            make
         QMAKE_EXTRA_COMPILERS += genrestbedlib
 
         RESTBED_HEADER_FILE=$$clean_path($${RESTBED_BUILD_PATH}/include/restbed)

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -893,12 +893,15 @@ rs_jsonapi {
     }
 
     INCLUDEPATH *= $${JSONAPI_GENERATOR_OUT}
+    DEPENDPATH *= $${JSONAPI_GENERATOR_OUT}
     apiheaders = $$files($${RS_SRC_PATH}/libretroshare/src/retroshare/*.h)
+    #Make sure that the jsonapigenerator executable are ready
+    apiheaders += $${JSONAPI_GENERATOR_EXE}
 
     genjsonapi.name = Generating jsonapi headers.
     genjsonapi.input = apiheaders
-    genjsonapi.output = $${WRAPPERS_INCL_FILE} $${WRAPPERS_INCL_FILE}
-    genjsonapi.clean = $${WRAPPERS_INCL_FILE} $${WRAPPERS_INCL_FILE}
+    genjsonapi.output = $${WRAPPERS_INCL_FILE} $${WRAPPERS_REG_FILE}
+    genjsonapi.clean = $${WRAPPERS_INCL_FILE} $${WRAPPERS_REG_FILE}
     genjsonapi.CONFIG += target_predeps combine no_link
     genjsonapi.variable_out = HEADERS
     genjsonapi.commands = \

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -900,8 +900,8 @@ rs_jsonapi {
     jsonwrappersincl.commands = \
         mkdir -p $${JSONAPI_GENERATOR_OUT} && \
         cp $${DOXIGEN_CONFIG_SRC} $${DOXIGEN_CONFIG_OUT} && \
-        echo OUTPUT_DIRECTORY=$$shell_path($${JSONAPI_GENERATOR_OUT}) >> $${DOXIGEN_CONFIG_OUT} && \
-        echo INPUT=$$shell_path($${DOXIGEN_INPUT_DIRECTORY}) >> $${DOXIGEN_CONFIG_OUT} && \
+        echo OUTPUT_DIRECTORY=$${JSONAPI_GENERATOR_OUT} >> $${DOXIGEN_CONFIG_OUT} && \
+        echo INPUT=$${DOXIGEN_INPUT_DIRECTORY} >> $${DOXIGEN_CONFIG_OUT} && \
         doxygen $${DOXIGEN_CONFIG_OUT} && \
         $${JSONAPI_GENERATOR_EXE} $${JSONAPI_GENERATOR_SRC} $${JSONAPI_GENERATOR_OUT};
     QMAKE_EXTRA_TARGETS += jsonwrappersincl

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -892,28 +892,23 @@ rs_jsonapi {
         PRE_TARGETDEPS *= $${restbed.target}
     }
 
-    PRE_TARGETDEPS *= $${JSONAPI_GENERATOR_EXE}
     INCLUDEPATH *= $${JSONAPI_GENERATOR_OUT}
-    GENERATED_HEADERS += $${WRAPPERS_INCL_FILE}
+    apiheaders = $$files($${RS_SRC_PATH}/libretroshare/src/retroshare/*.h)
 
-    jsonwrappersincl.target = $${WRAPPERS_INCL_FILE}
-    jsonwrappersincl.commands = \
+    genjsonapi.name = Generating jsonapi headers.
+    genjsonapi.input = apiheaders
+    genjsonapi.output = $${WRAPPERS_INCL_FILE} $${WRAPPERS_INCL_FILE}
+    genjsonapi.clean = $${WRAPPERS_INCL_FILE} $${WRAPPERS_INCL_FILE}
+    genjsonapi.CONFIG += target_predeps combine no_link
+    genjsonapi.variable_out = HEADERS
+    genjsonapi.commands = \
         mkdir -p $${JSONAPI_GENERATOR_OUT} && \
         cp $${DOXIGEN_CONFIG_SRC} $${DOXIGEN_CONFIG_OUT} && \
         echo OUTPUT_DIRECTORY=$${JSONAPI_GENERATOR_OUT} >> $${DOXIGEN_CONFIG_OUT} && \
         echo INPUT=$${DOXIGEN_INPUT_DIRECTORY} >> $${DOXIGEN_CONFIG_OUT} && \
         doxygen $${DOXIGEN_CONFIG_OUT} && \
         $${JSONAPI_GENERATOR_EXE} $${JSONAPI_GENERATOR_SRC} $${JSONAPI_GENERATOR_OUT};
-    QMAKE_EXTRA_TARGETS += jsonwrappersincl
-    libretroshare.depends += jsonwrappersincl
-    PRE_TARGETDEPS *= $${WRAPPERS_INCL_FILE}
-
-    jsonwrappersreg.target = $${WRAPPERS_REG_FILE}
-    jsonwrappersreg.commands = touch $${WRAPPERS_REG_FILE}
-    jsonwrappersreg.depends = jsonwrappersincl
-    QMAKE_EXTRA_TARGETS += jsonwrappersreg
-    libretroshare.depends += jsonwrappersreg
-    PRE_TARGETDEPS *= $${WRAPPERS_REG_FILE}
+    QMAKE_EXTRA_COMPILERS += genjsonapi
 
     # Force recalculation of libretroshare dependencies see https://stackoverflow.com/a/47884045
     QMAKE_EXTRA_TARGETS += libretroshare

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -862,17 +862,31 @@ rs_jsonapi {
 
     no_rs_cross_compiling {
         restbed.target = $$clean_path($${RESTBED_BUILD_PATH}/library/librestbed.a)
-        restbed.commands = \
-            cd $${RS_SRC_PATH};\
-            git submodule update --init --recommend-shallow supportlibs/restbed;\
-            cd $${RESTBED_SRC_PATH};\
-            git submodule update --init --recommend-shallow dependency/asio;\
-            git submodule update --init --recommend-shallow dependency/catch;\
-            git submodule update --init --recommend-shallow dependency/kashmir;\
-            mkdir -p $${RESTBED_BUILD_PATH}; cd $${RESTBED_BUILD_PATH};\
-            cmake -DCMAKE_CXX_COMPILER=$$QMAKE_CXX -DBUILD_SSL=OFF \
-                -DCMAKE_INSTALL_PREFIX=. -B. -H$$shell_path($${RESTBED_SRC_PATH});\
-            make; make install
+        win32-g++ {
+            restbed.commands = \
+                cd $${RS_SRC_PATH} && \
+                git submodule update --init --recommend-shallow supportlibs/restbed && \
+                cd $${RESTBED_SRC_PATH} && \
+                git submodule update --init --recommend-shallow dependency/asio && \
+                git submodule update --init --recommend-shallow dependency/catch && \
+                git submodule update --init --recommend-shallow dependency/kashmir && \
+                mkdir -p $${RESTBED_BUILD_PATH}; cd $${RESTBED_BUILD_PATH} && \
+                cmake -DCMAKE_CXX_COMPILER=$$QMAKE_CXX -G \"MSYS Makefiles\" -DBUILD_SSL=OFF \
+                    -DCMAKE_INSTALL_PREFIX=. -B. -H$$shell_path($${RESTBED_SRC_PATH}) && \
+                make && make install
+        } else {
+            restbed.commands = \
+                cd $${RS_SRC_PATH};\
+                git submodule update --init --recommend-shallow supportlibs/restbed;\
+                cd $${RESTBED_SRC_PATH};\
+                git submodule update --init --recommend-shallow dependency/asio;\
+                git submodule update --init --recommend-shallow dependency/catch;\
+                git submodule update --init --recommend-shallow dependency/kashmir;\
+                mkdir -p $${RESTBED_BUILD_PATH}; cd $${RESTBED_BUILD_PATH};\
+                cmake -DCMAKE_CXX_COMPILER=$$QMAKE_CXX -DBUILD_SSL=OFF \
+                    -DCMAKE_INSTALL_PREFIX=. -B. -H$$shell_path($${RESTBED_SRC_PATH});\
+                make; make install
+        }
         QMAKE_EXTRA_TARGETS += restbed
         libretroshare.depends += restbed
         PRE_TARGETDEPS *= $${restbed.target}

--- a/libretroshare/src/use_libretroshare.pri
+++ b/libretroshare/src/use_libretroshare.pri
@@ -55,9 +55,10 @@ rs_jsonapi {
         RESTBED_SRC_PATH=$$clean_path($${RS_SRC_PATH}/supportlibs/restbed)
         RESTBED_BUILD_PATH=$$clean_path($${RS_BUILD_PATH}/supportlibs/restbed)
         INCLUDEPATH *= $$clean_path($${RESTBED_BUILD_PATH}/include/)
-        QMAKE_LIBDIR *= $$clean_path($${RESTBED_BUILD_PATH}/library/)
+        DEPENDPATH *= $$clean_path($${RESTBED_BUILD_PATH}/include/)
+        QMAKE_LIBDIR *= $$clean_path($${RESTBED_BUILD_PATH}/)
         # Using sLibs would fail as librestbed.a is generated at compile-time
-        LIBS *= -L$$clean_path($${RESTBED_BUILD_PATH}/library/) -lrestbed
+        LIBS *= -L$$clean_path($${RESTBED_BUILD_PATH}/) -lrestbed
     } else:sLibs *= restbed
 
     win32-g++:dLibs *= wsock32


### PR DESCRIPTION
- Fixed issues on Windows
- Fixed issues with multi core compilation
- Fixed Libretroshare compilation starts before headers from restbed are ready, and compilation fails at the first time.