### PR TITLE
fixed wrong file hash daylight saving time warnings on windows

### DIFF
--- a/libretroshare/src/file_sharing/hash_cache.cc
+++ b/libretroshare/src/file_sharing/hash_cache.cc
@@ -133,12 +133,7 @@ void HashStorage::data_tick()
 
                 if(!mChanged)	// otherwise it might prevent from saving the hash cache
                 {
-                    std::cerr << "Stopping hashing thread." << std::endl;
-                    shutdown();
-                    mRunning = false ;
-                    mTotalSizeToHash = 0;
-                    mTotalFilesToHash = 0;
-                    std::cerr << "done." << std::endl;
+                    stopHashThread();
                 }
 
                 RsServer::notify()->notifyHashingInfo(NOTIFY_HASHTYPE_FINISH, "") ;
@@ -261,6 +256,16 @@ bool HashStorage::requestHash(const std::string& full_path,uint64_t size,rstime_
     {
         it->second.time_stamp = now ;
 
+#ifdef WINDOWS_SYS
+        if(it->second.modf_stamp != (uint64_t)mod_time)
+        {
+            std::cerr << "(WW) detected a 1 hour shift in file modification time. This normally happens to many files at once, when daylight saving time shifts (file=\"" << full_path << "\")." << std::endl;
+            it->second.modf_stamp = (uint64_t)mod_time;
+            mChanged = true;
+            startHashThread();
+        }
+#endif
+
         known_hash = it->second.hash;
 #ifdef HASHSTORAGE_DEBUG
         std::cerr << "Found in cache." << std::endl ;
@@ -293,6 +298,13 @@ bool HashStorage::requestHash(const std::string& full_path,uint64_t size,rstime_
     mTotalSizeToHash += size ;
     ++mTotalFilesToHash;
 
+    startHashThread();
+
+    return false;
+}
+
+void HashStorage::startHashThread()
+{
     if(!mRunning)
     {
         mRunning = true ;
@@ -300,10 +312,21 @@ bool HashStorage::requestHash(const std::string& full_path,uint64_t size,rstime_
         mHashCounter = 0;
         mTotalHashedSize = 0;
 
-		start("fs hash cache") ;
+        start("fs hash cache") ;
     }
+}
 
-    return false;
+void HashStorage::stopHashThread()
+{
+    if (mRunning)
+    {
+        std::cerr << "Stopping hashing thread." << std::endl;
+        shutdown();
+        mRunning = false ;
+        mTotalSizeToHash = 0;
+        mTotalFilesToHash = 0;
+        std::cerr << "done." << std::endl;
+    }
 }
 
 void HashStorage::clean()

--- a/libretroshare/src/file_sharing/hash_cache.cc
+++ b/libretroshare/src/file_sharing/hash_cache.cc
@@ -261,14 +261,6 @@ bool HashStorage::requestHash(const std::string& full_path,uint64_t size,rstime_
     {
         it->second.time_stamp = now ;
 
-#ifdef WINDOWS_SYS
-        if(it->second.time_stamp != (uint64_t)mod_time)
-        {
-            std::cerr << "(WW) detected a 1 hour shift in file modification time. This normally happens to many files at once, when daylight saving time shifts (file=\"" << full_path << "\")." << std::endl;
-            it->second.time_stamp = (uint64_t)mod_time;
-        }
-#endif
-
         known_hash = it->second.hash;
 #ifdef HASHSTORAGE_DEBUG
         std::cerr << "Found in cache." << std::endl ;

--- a/libretroshare/src/file_sharing/hash_cache.h
+++ b/libretroshare/src/file_sharing/hash_cache.h
@@ -97,6 +97,9 @@ private:
      */
     void clean() ;
 
+    void startHashThread();
+    void stopHashThread();
+
     // loading/saving the entire hash database to a file
 
     void locked_save() ;

--- a/libretroshare/src/util/rsthreads.cc
+++ b/libretroshare/src/util/rsthreads.cc
@@ -201,7 +201,7 @@ void RsThread::start(const std::string &threadName)
                 if(threadName.length() > 15)
                 {
 #ifdef DEBUG_THREADS
-                    THREAD_DEBUG << "RsThread::start called with to long name '" << name << "' truncating..." << std::endl;
+                    THREAD_DEBUG << "RsThread::start called with to long name '" << threadName << "' truncating..." << std::endl;
 #endif
                     RS_pthread_setname_np(mTid, threadName.substr(0, 15).c_str());
                 } else {


### PR DESCRIPTION
On Windows, there's a check for +1/-1 hours because NTFS can change the modification time of a file twice per year during the DST change. The warning is wrong though because Retroshare emits it everytime it's launched for every file shared (DST or not).