### PR TITLE
Improve on top of the work made by Cyril on channel API

### DIFF
--- a/libretroshare/src/retroshare/rsgxschannels.h
+++ b/libretroshare/src/retroshare/rsgxschannels.h
@@ -108,6 +108,28 @@ public:
 	virtual bool createChannel(RsGxsChannelGroup& channel) = 0;
 
 	/**
+	 * @brief Create channel. Blocking API.
+	 * @jsonapi{development}
+	 * @param[in]  name              Name of the channel
+	 * @param[in]  description       Description of the channel
+	 * @param[in]  image             Thumbnail that is shown to advertise the channel. Possibly empty.
+	 * @param[in]  author_id         GxsId of the contact author. For an anonymous channel, leave this to RsGxsId()="00000....0000"
+	 * @param[in]  circle_type       Type of visibility restriction, among { GXS_CIRCLE_TYPE_PUBLIC, GXS_CIRCLE_TYPE_EXTERNAL, GXS_CIRCLE_TYPE_YOUR_FRIENDS_ONLY, GXS_CIRCLE_TYPE_YOUR_EYES_ONLY }
+	 * @param[in]  circle_id         Id of the circle (should be an external circle or GXS_CIRCLE_TYPE_EXTERNAL, a local friend group for GXS_CIRCLE_TYPE_YOUR_FRIENDS_ONLY, GxsCircleId()="000....000" otherwise
+	 * @param[out] channel_group_id  Group id of the created channel, if command succeeds.
+	 * @param[out] error_message     Error messsage supplied when the channel creation fails.
+	 * @return                       False on error, true otherwise.
+	 */
+	virtual bool createChannel(const std::string& name,
+                               const std::string& description,
+                               const RsGxsImage& image,
+                               const RsGxsId& author_id,
+                               uint32_t circle_type,
+                               RsGxsCircleId& circle_id,
+                               RsGxsGroupId& channel_group_id,
+                               std::string& error_message)=0;
+
+	/**
 	 * @brief Add a comment on a post or on another comment
 	 * @jsonapi{development}
 	 * @param[inout] comment

--- a/libretroshare/src/retroshare/rsgxschannels.h
+++ b/libretroshare/src/retroshare/rsgxschannels.h
@@ -99,6 +99,7 @@ public:
 	explicit RsGxsChannels(RsGxsIface& gxs) : RsGxsIfaceHelper(gxs) {}
 	virtual ~RsGxsChannels() {}
 
+#ifdef REMOVED
 	/**
 	 * @brief Create channel. Blocking API.
 	 * @jsonapi{development}
@@ -106,6 +107,7 @@ public:
 	 * @return false on error, true otherwise
 	 */
 	virtual bool createChannel(RsGxsChannelGroup& channel) = 0;
+#endif
 
 	/**
 	 * @brief Create channel. Blocking API.
@@ -115,43 +117,76 @@ public:
 	 * @param[in]  image             Thumbnail that is shown to advertise the channel. Possibly empty.
 	 * @param[in]  author_id         GxsId of the contact author. For an anonymous channel, leave this to RsGxsId()="00000....0000"
 	 * @param[in]  circle_type       Type of visibility restriction, among { GXS_CIRCLE_TYPE_PUBLIC, GXS_CIRCLE_TYPE_EXTERNAL, GXS_CIRCLE_TYPE_YOUR_FRIENDS_ONLY, GXS_CIRCLE_TYPE_YOUR_EYES_ONLY }
-	 * @param[in]  circle_id         Id of the circle (should be an external circle or GXS_CIRCLE_TYPE_EXTERNAL, a local friend group for GXS_CIRCLE_TYPE_YOUR_FRIENDS_ONLY, GxsCircleId()="000....000" otherwise
+	 * @param[in]  circle_id         Id of the circle (should be an external circle for GXS_CIRCLE_TYPE_EXTERNAL, a local friend group for GXS_CIRCLE_TYPE_YOUR_FRIENDS_ONLY, GxsCircleId()="000....000" otherwise
 	 * @param[out] channel_group_id  Group id of the created channel, if command succeeds.
 	 * @param[out] error_message     Error messsage supplied when the channel creation fails.
 	 * @return                       False on error, true otherwise.
 	 */
 	virtual bool createChannel(const std::string& name,
                                const std::string& description,
-                               const RsGxsImage& image,
-                               const RsGxsId& author_id,
-                               uint32_t circle_type,
-                               RsGxsCircleId& circle_id,
-                               RsGxsGroupId& channel_group_id,
-                               std::string& error_message)=0;
+                               const RsGxsImage&  image,
+                               const RsGxsId&     author_id,
+                               uint32_t           circle_type,
+                               RsGxsCircleId&     circle_id,
+                               RsGxsGroupId&      channel_group_id,
+                               std::string&       error_message     )=0;
 
 	/**
 	 * @brief Add a comment on a post or on another comment
 	 * @jsonapi{development}
-	 * @param[inout] comment
+	 * @param[in]  groupId           Id of the channel in which the comment is to be posted
+	 * @param[in]  parentMsgId       Id of the parent of the comment that is either a channel post Id or the Id of another comment.
+	 * @param[in]  comment           UTF-8 string containing the comment
+	 * @param[out] commentMessageId  Id of the comment that was created
+	 * @param[out] error_string      Error message supplied when the comment creation fails.
 	 * @return false on error, true otherwise
 	 */
-	virtual bool createComment(RsGxsComment& comment) = 0;
+	virtual bool createComment(const RsGxsGroupId&   groupId,
+	                           const RsGxsMessageId& parentMsgId,
+	                           const std::string&    comment,
+	                           RsGxsMessageId&       commentMessageId,
+                               std::string&          error_message     )=0;
 
 	/**
 	 * @brief Create channel post. Blocking API.
 	 * @jsonapi{development}
-	 * @param[inout] post
+	 * @param[in] groupId        Id of the channel where to put the post (publish rights needed!)
+	 * @param[in] origMsgId      Id of the post you are replacing. If left blank (RsGxsMssageId()="0000.....0000", a new post will be created
+	 * @param[in] msgName        Title of the post
+	 * @param[in] msg            Text content of the post
+	 * @param[in] files          List of attached files. These are supposed to be shared otherwise (use ExtraFileHash() below)
+	 * @param[in] thumbnail      Image displayed in the list of posts. Can be left blank.
+	 * @param[out] messsageId    Id of the message that was created
+	 * @param[out] error_message Error text if anything bad happens
 	 * @return false on error, true otherwise
 	 */
-	virtual bool createPost(RsGxsChannelPost& post) = 0;
-
+	virtual bool createPost(const RsGxsGroupId&         groupId,
+    						const RsGxsMessageId&       origMsgId,
+							const std::string&          msgName,
+							const std::string&          msg,
+							const std::list<RsGxsFile>& files,
+							const RsGxsImage&           thumbnail,
+							RsGxsMessageId&             messageId,
+                            std::string&                error_message) = 0;
 	/**
 	 * @brief createVote
 	 * @jsonapi{development}
-	 * @param[inout] vote
+	 * @param[in]  groupId             Id of the channel where to put the post (publish rights needed!)
+	 * @param[in]  threadId            Id of the channel post in which a comment is voted
+	 * @param[in]  commentMesssageId   Id of the comment that is voted
+	 * @param[in]  authorId            Id of the author. Needs to be your identity.
+	 * @param[in]  voteType            Type of vote (GXS_VOTE_NONE=0x00, GXS_VOTE_DOWN=0x01, GXS_VOTE_UP=0x02)
+	 * @param[out] voteMessageId       Id of the vote message produced
+	 * @param[out] error_message       Error text if anything bad happens
 	 * @return false on error, true otherwise
 	 */
-	virtual bool createVote(RsGxsVote& vote) = 0;
+	virtual bool createVote( const RsGxsGroupId&         groupId,
+                             const RsGxsMessageId&       threadId,
+                             const RsGxsMessageId&       commentMessageId,
+                             const RsGxsId&              authorId,
+                             uint32_t                    voteType,
+                             RsGxsMessageId&             voteMessageId,
+                             std::string&                error_message)=0;
 
 	/**
 	 * @brief Edit channel details.

--- a/libretroshare/src/retroshare/rsgxscircles.h
+++ b/libretroshare/src/retroshare/rsgxscircles.h
@@ -42,23 +42,34 @@ class RsGxsCircles;
  */
 extern RsGxsCircles* rsGxsCircles;
 
+enum class RsGxsCircleType : uint32_t // 32 bit overkill, just for retrocompat
+{
+	UNKNOWN           = 0, /// Used to detect uninizialized values.
+	PUBLIC            = 1, /// Public distribution
+	EXTERNAL          = 2, /// Restricted to an external circle
 
-// TODO: convert to enum
-/// The meaning of the different circle types is:
-static const uint32_t GXS_CIRCLE_TYPE_UNKNOWN           = 0x0000 ;	/// Used to detect uninizialized values.
-static const uint32_t GXS_CIRCLE_TYPE_PUBLIC            = 0x0001 ;	// not restricted to a circle
-static const uint32_t GXS_CIRCLE_TYPE_EXTERNAL          = 0x0002 ;	// restricted to an external circle, made of RsGxsId
-static const uint32_t GXS_CIRCLE_TYPE_YOUR_FRIENDS_ONLY = 0x0003 ;	// restricted to a subset of friend nodes of a given RS node given by a RsPgpId list
-static const uint32_t GXS_CIRCLE_TYPE_LOCAL             = 0x0004 ;	// not distributed at all
-static const uint32_t GXS_CIRCLE_TYPE_EXT_SELF          = 0x0005 ;	// self-restricted. Not used, except at creation time when the circle ID isn't known yet. Set to EXTERNAL afterwards.
-static const uint32_t GXS_CIRCLE_TYPE_YOUR_EYES_ONLY    = 0x0006 ;	// distributed to nodes signed by your own PGP key only.
+	/** Restricted to a group of friend nodes, the administrator of the circle
+	 * behave as a hub for them */
+	NODES_GROUP        = 3,
 
+	LOCAL              = 4, /// not distributed at all
+
+	/** Self-restricted. Used only at creation time of self-restricted circles
+	 *  when the circle id isn't known yet. Once the circle id is known the type
+	 *  is set to EXTERNAL, and the external circle id is set to the id of the
+	 *  circle itself.
+	 */
+	EXT_SELF           = 5,
+
+	/// distributed to nodes signed by your own PGP key only.
+	YOUR_EYES_ONLY     = 6
+};
+
+// TODO: convert to enum class
 static const uint32_t GXS_EXTERNAL_CIRCLE_FLAGS_IN_ADMIN_LIST = 0x0001 ;// user is validated by circle admin
 static const uint32_t GXS_EXTERNAL_CIRCLE_FLAGS_SUBSCRIBED    = 0x0002 ;// user has subscribed the group
 static const uint32_t GXS_EXTERNAL_CIRCLE_FLAGS_KEY_AVAILABLE = 0x0004 ;// key is available, so we can encrypt for this circle
 static const uint32_t GXS_EXTERNAL_CIRCLE_FLAGS_ALLOWED       = 0x0007 ;// user is allowed. Combines all flags above.
-
-static const uint32_t GXS_CIRCLE_FLAGS_IS_EXTERNAL   = 0x0008 ;// user is allowed
 
 
 struct RsGxsCircleGroup : RsSerializable
@@ -110,8 +121,9 @@ struct RsGxsCircleMsg : RsSerializable
 struct RsGxsCircleDetails : RsSerializable
 {
 	RsGxsCircleDetails() :
-	    mCircleType(GXS_CIRCLE_TYPE_EXTERNAL), mAmIAllowed(false) {}
-	~RsGxsCircleDetails() {}
+	    mCircleType(static_cast<uint32_t>(RsGxsCircleType::EXTERNAL)),
+	    mAmIAllowed(false) {}
+	~RsGxsCircleDetails() override {}
 
 	RsGxsCircleId mCircleId;
 	std::string mCircleName;
@@ -264,3 +276,34 @@ public:
 	RS_DEPRECATED_FOR("editCircle, inviteIdsToCircle")
 	virtual void updateGroup(uint32_t &token, RsGxsCircleGroup &group) = 0;
 };
+
+
+/// @deprecated Used to detect uninizialized values.
+RS_DEPRECATED_FOR("RsGxsCircleType::UNKNOWN")
+static const uint32_t GXS_CIRCLE_TYPE_UNKNOWN           = 0x0000;
+
+/// @deprecated not restricted to a circle
+RS_DEPRECATED_FOR("RsGxsCircleType::PUBLIC")
+static const uint32_t GXS_CIRCLE_TYPE_PUBLIC            = 0x0001;
+
+/// @deprecated restricted to an external circle, made of RsGxsId
+RS_DEPRECATED_FOR("RsGxsCircleType::EXTERNAL")
+static const uint32_t GXS_CIRCLE_TYPE_EXTERNAL          = 0x0002;
+
+/// @deprecated restricted to a subset of friend nodes of a given RS node given
+/// by a RsPgpId list
+RS_DEPRECATED_FOR("RsGxsCircleType::NODES_GROUP")
+static const uint32_t GXS_CIRCLE_TYPE_YOUR_FRIENDS_ONLY = 0x0003;
+
+/// @deprecated not distributed at all
+RS_DEPRECATED_FOR("RsGxsCircleType::LOCAL")
+static const uint32_t GXS_CIRCLE_TYPE_LOCAL             = 0x0004;
+
+/// @deprecated self-restricted. Not used, except at creation time when the
+/// circle ID isn't known yet. Set to EXTERNAL afterwards.
+RS_DEPRECATED_FOR("RsGxsCircleType::EXT_SELF")
+static const uint32_t GXS_CIRCLE_TYPE_EXT_SELF          = 0x0005;
+
+/// @deprecated distributed to nodes signed by your own PGP key only.
+RS_DEPRECATED_FOR("RsGxsCircleType::YOUR_EYES_ONLY")
+static const uint32_t GXS_CIRCLE_TYPE_YOUR_EYES_ONLY    = 0x0006;

--- a/libretroshare/src/retroshare/rsgxscommon.h
+++ b/libretroshare/src/retroshare/rsgxscommon.h
@@ -19,11 +19,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+#pragma once
 
-#ifndef RETROSHARE_GXS_COMMON_OBJS_INTERFACE_H
-#define RETROSHARE_GXS_COMMON_OBJS_INTERFACE_H
-
-#include <inttypes.h>
+#include <cstdint>
 #include <string>
 #include <list>
 
@@ -79,10 +77,12 @@ struct RsGxsImage  : RsSerializable
 	}
 };
 
-
-#define GXS_VOTE_NONE 	0x0000
-#define GXS_VOTE_DOWN 	0x0001
-#define GXS_VOTE_UP	0x0002
+enum class RsGxsVoteType : uint32_t
+{
+	NONE = 0, /// Used to detect unset vote?
+	DOWN = 1, /// Negative vote
+	UP = 2    /// Positive vote
+};
 
 
 // Status Flags to indicate Voting....
@@ -181,7 +181,11 @@ struct RsGxsCommentService
 	        std::pair<RsGxsGroupId, RsGxsMessageId>& msgId ) = 0;
 };
 
+/// @deprecated use RsGxsVoteType::NONE instead @see RsGxsVoteType
+#define GXS_VOTE_NONE 0x0000
 
+/// @deprecated use RsGxsVoteType::DOWN instead @see RsGxsVoteType
+#define GXS_VOTE_DOWN 0x0001
 
-#endif
-
+/// @deprecated use RsGxsVoteType::UP instead @see RsGxsVoteType
+#define GXS_VOTE_UP	0x0002

--- a/libretroshare/src/retroshare/rsgxsflags.h
+++ b/libretroshare/src/retroshare/rsgxsflags.h
@@ -52,14 +52,15 @@ namespace GXS_SERV {
     static const uint32_t FLAG_AUTHOR_AUTHENTICATION_MASK           = 0x0000ff00;
     static const uint32_t FLAG_AUTHOR_AUTHENTICATION_NONE           = 0x00000000;
     static const uint32_t FLAG_AUTHOR_AUTHENTICATION_GPG            = 0x00000100;   // Anti-spam feature. Allows to ask higher reputation to anonymous IDs
-    static const uint32_t FLAG_AUTHOR_AUTHENTICATION_REQUIRED       = 0x00000200;
-    static const uint32_t FLAG_AUTHOR_AUTHENTICATION_IFNOPUBSIGN    = 0x00000400;
+    static const uint32_t FLAG_AUTHOR_AUTHENTICATION_REQUIRED       = 0x00000200;   // unused
+    static const uint32_t FLAG_AUTHOR_AUTHENTICATION_IFNOPUBSIGN    = 0x00000400;	// ???
     static const uint32_t FLAG_AUTHOR_AUTHENTICATION_TRACK_MESSAGES = 0x00000800;	// not used anymore
     static const uint32_t FLAG_AUTHOR_AUTHENTICATION_GPG_KNOWN      = 0x00001000;   // Anti-spam feature. Allows to ask higher reputation to unknown IDs and anonymous IDs
 
+    // These are *not used*
     static const uint32_t FLAG_GROUP_SIGN_PUBLISH_MASK       = 0x000000ff;
     static const uint32_t FLAG_GROUP_SIGN_PUBLISH_ENCRYPTED  = 0x00000001;
-    static const uint32_t FLAG_GROUP_SIGN_PUBLISH_ALLSIGNED  = 0x00000002;
+    static const uint32_t FLAG_GROUP_SIGN_PUBLISH_ALLSIGNED  = 0x00000002;	// unused
     static const uint32_t FLAG_GROUP_SIGN_PUBLISH_THREADHEAD = 0x00000004;
     static const uint32_t FLAG_GROUP_SIGN_PUBLISH_NONEREQ    = 0x00000008;
     

--- a/libretroshare/src/retroshare/rsgxsifacehelper.h
+++ b/libretroshare/src/retroshare/rsgxsifacehelper.h
@@ -314,7 +314,7 @@ LLwaitTokenBeginLabel:
 #if defined(__ANDROID__) && (__ANDROID_API__ < 24)
 		/* Work around for very slow/old android devices, we don't expect this
 		 * to be necessary on newer devices. If it take unreasonably long
-		 * something worser is already happening elsewere amd we return anyway.
+		 * something worser is already happening elsewere and we return anyway.
 		 */
 		if( st > RsTokenService::FAILED && st < RsTokenService::COMPLETE
 		        && maxWorkAroundCnt-- > 0 )

--- a/libretroshare/src/retroshare/rsgxsifacehelper.h
+++ b/libretroshare/src/retroshare/rsgxsifacehelper.h
@@ -4,7 +4,7 @@
  * libretroshare: retroshare core library                                      *
  *                                                                             *
  * Copyright 2011 by Christopher Evi-Parker                                    *
- * Copyright (C) 2018  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2018-2019  Gioacchino Mazzurco <gio@eigenlab.org>             *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -20,9 +20,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-
-#ifndef RSGXSIFACEIMPL_H
-#define RSGXSIFACEIMPL_H
+#pragma once
 
 #include <chrono>
 #include <thread>
@@ -292,19 +290,51 @@ protected:
 	 * Useful for blocking API implementation.
 	 * @param[in] token token associated to the request caller is waiting for
 	 * @param[in] maxWait maximum waiting time in milliseconds
+	 * @param[in] checkEvery time in millisecond between status checks
 	 */
 	RsTokenService::GxsRequestStatus waitToken(
 	        uint32_t token,
-	        std::chrono::milliseconds maxWait = std::chrono::milliseconds(500) )
+	        std::chrono::milliseconds maxWait = std::chrono::milliseconds(500),
+	        std::chrono::milliseconds checkEvery = std::chrono::milliseconds(2))
 	{
+#if defined(__ANDROID__) && (__ANDROID_API__ < 24)
+		auto wkStartime = std::chrono::steady_clock::now();
+		int maxWorkAroundCnt = 10;
+LLwaitTokenBeginLabel:
+#endif
 		auto timeout = std::chrono::steady_clock::now() + maxWait;
 		auto st = requestStatus(token);
 		while( !(st == RsTokenService::FAILED || st >= RsTokenService::COMPLETE)
 		       && std::chrono::steady_clock::now() < timeout )
 		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(2));
+			std::this_thread::sleep_for(checkEvery);
 			st = requestStatus(token);
 		}
+
+#if defined(__ANDROID__) && (__ANDROID_API__ < 24)
+		/* Work around for very slow/old android devices, we don't expect this
+		 * to be necessary on newer devices. If it take unreasonably long
+		 * something worser is already happening elsewere amd we return anyway.
+		 */
+		if( st > RsTokenService::FAILED && st < RsTokenService::COMPLETE
+		        && maxWorkAroundCnt-- > 0 )
+		{
+			maxWait *= 10;
+			checkEvery *= 3;
+			std::cerr << __PRETTY_FUNCTION__ << " Slow Android device "
+			          << " workaround st: " << st
+			          << " maxWorkAroundCnt: " << maxWorkAroundCnt
+			          << " maxWait: " << maxWait.count()
+			          << " checkEvery: " << checkEvery.count() << std::endl;
+			goto LLwaitTokenBeginLabel;
+		}
+		std::cerr << __PRETTY_FUNCTION__ << " lasted: "
+		          << std::chrono::duration_cast<std::chrono::milliseconds>(
+		                 std::chrono::steady_clock::now() - wkStartime ).count()
+		          << "ms" << std::endl;
+
+#endif
+
 		return st;
 	}
 
@@ -312,5 +342,3 @@ private:
 	RsGxsIface& mGxs;
 	RsTokenService& mTokenService;
 };
-
-#endif // RSGXSIFACEIMPL_H

--- a/libretroshare/src/retroshare/rstokenservice.h
+++ b/libretroshare/src/retroshare/rstokenservice.h
@@ -121,14 +121,13 @@ public:
 
 	enum GxsRequestStatus : uint8_t
 	{
-		FAILED,
-		PENDING,
-		PARTIAL,
-		COMPLETE,
-		DONE,      /// Once all data has been retrived
-		CANCELLED
+		FAILED    = 0,
+		PENDING   = 1,
+		PARTIAL   = 2,
+		COMPLETE  = 3,
+		DONE      = 4, /// Once all data has been retrived
+		CANCELLED = 5
 	};
-
 
 	RsTokenService() {}
 	virtual ~RsTokenService() {}

--- a/libretroshare/src/services/p3gxschannels.h
+++ b/libretroshare/src/services/p3gxschannels.h
@@ -194,8 +194,10 @@ virtual bool ExtraFileRemove(const RsFileHash &hash);
 	virtual bool getContentSummaries( const RsGxsGroupId& channelId,
 	                                  std::vector<RsMsgMetaData>& summaries );
 
+#ifdef REMOVED
 	/// Implementation of @see RsGxsChannels::createChannel
 	virtual bool createChannel(RsGxsChannelGroup& channel);
+#endif
 
 	/// Implementation of @see RsGxsChannels::createChannel
 	virtual bool createChannel(const std::string& name,
@@ -207,17 +209,48 @@ virtual bool ExtraFileRemove(const RsFileHash &hash);
                                RsGxsGroupId& channel_group_id,
                                std::string& error_message);
 
+#ifdef REMOVED
 	/// Implementation of @see RsGxsChannels::createComment
 	virtual bool createComment(RsGxsComment& comment);
+#endif
+
+	/// Implementation of @see RsGxsChannels::createComment
+	virtual bool createComment(const RsGxsGroupId&   groupId,
+	                           const RsGxsMessageId& parentMsgId,
+                               const std::string&    comment,
+	                           RsGxsMessageId&       commentMessageId,
+                               std::string&          error_message);
 
 	/// Implementation of @see RsGxsChannels::editChannel
 	virtual bool editChannel(RsGxsChannelGroup& channel);
 
+#ifdef REMOVED
 	/// Implementation of @see RsGxsChannels::createPost
 	virtual bool createPost(RsGxsChannelPost& post);
+#endif
+	/// Implementation of @see RsGxsChannels::createPost
+	virtual bool createPost(const RsGxsGroupId& groupId,
+    						const RsGxsMessageId& origMsgId,
+	                        const std::string& msgName,
+							const std::string& msg,
+							const std::list<RsGxsFile>& files,
+							const RsGxsImage& thumbnail,
+                            RsGxsMessageId &message_id,
+                            std::string& error_message) ;
 
+#ifdef REMOVED
 	/// Implementation of @see RsGxsChannels::createVote
 	virtual bool createVote(RsGxsVote& vote);
+#endif
+
+	/// Implementation of @see RsGxsChannels::createVote
+	virtual bool createVote(const RsGxsGroupId&         groupId,
+                             const RsGxsMessageId&       threadId,
+                             const RsGxsMessageId&       commentMessageId,
+                             const RsGxsId&              authorId,
+                             uint32_t                    voteType,
+                             RsGxsMessageId&             voteMessageId,
+                             std::string&                error_message);
 
 	/// Implementation of @see RsGxsChannels::subscribeToChannel
 	virtual bool subscribeToChannel( const RsGxsGroupId &groupId,

--- a/libretroshare/src/services/p3gxschannels.h
+++ b/libretroshare/src/services/p3gxschannels.h
@@ -4,7 +4,7 @@
  * libretroshare: retroshare core library                                      *
  *                                                                             *
  * Copyright (C) 2012  Robert Fernie <retroshare@lunamutt.com>                 *
- * Copyright (C) 2018  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2018-2019  Gioacchino Mazzurco <gio@eigenlab.org>             *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -20,19 +20,20 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef P3_GXSCHANNELS_SERVICE_HEADER
-#define P3_GXSCHANNELS_SERVICE_HEADER
+#pragma once
 
 
 #include "retroshare/rsgxschannels.h"
 #include "services/p3gxscommon.h"
 #include "gxs/rsgenexchange.h"
 #include "gxs/gxstokenqueue.h"
+#include "util/rsmemory.h"
 
 #include "util/rstickevent.h"
 
 #include <map>
 #include <string>
+
 
 
 class SSGxsChannelGroup
@@ -191,66 +192,63 @@ virtual bool ExtraFileRemove(const RsFileHash &hash);
 	                       std::vector<RsGxsComment>& comments );
 
 	/// Implementation of @see RsGxsChannels::getContentSummaries
-	virtual bool getContentSummaries( const RsGxsGroupId& channelId,
-	                                  std::vector<RsMsgMetaData>& summaries );
+	virtual bool getContentSummaries(
+	        const RsGxsGroupId& channelId,
+	        std::vector<RsMsgMetaData>& summaries ) override;
 
-#ifdef REMOVED
-	/// Implementation of @see RsGxsChannels::createChannel
-	virtual bool createChannel(RsGxsChannelGroup& channel);
-#endif
+	/// Implementation of @see RsGxsChannels::createChannelV2
+	virtual bool createChannelV2(
+	        const std::string& name, const std::string& description,
+	        const RsGxsImage& thumbnail = RsGxsImage(),
+	        const RsGxsId& authorId = RsGxsId(),
+	        RsGxsCircleType circleType = RsGxsCircleType::PUBLIC,
+	        const RsGxsCircleId& circleId = RsGxsCircleId(),
+	        RsGxsGroupId& channelId = RS_DEFAULT_STORAGE_PARAM(RsGxsGroupId),
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) override;
 
-	/// Implementation of @see RsGxsChannels::createChannel
-	virtual bool createChannel(const std::string& name,
-                               const std::string& description,
-                               const RsGxsImage& image,
-                               const RsGxsId& author_id,
-                               uint32_t circle_type,
-                               RsGxsCircleId& circle_id,
-                               RsGxsGroupId& channel_group_id,
-                               std::string& error_message);
-
-#ifdef REMOVED
-	/// Implementation of @see RsGxsChannels::createComment
-	virtual bool createComment(RsGxsComment& comment);
-#endif
+	/// @deprecated Implementation of @see RsGxsChannels::createComment
+	RS_DEPRECATED_FOR(createCommentV2)
+	virtual bool createComment(RsGxsComment& comment) override;
 
 	/// Implementation of @see RsGxsChannels::createComment
-	virtual bool createComment(const RsGxsGroupId&   groupId,
-	                           const RsGxsMessageId& parentMsgId,
-                               const std::string&    comment,
-	                           RsGxsMessageId&       commentMessageId,
-                               std::string&          error_message);
+	virtual bool createCommentV2(
+	        const RsGxsGroupId& channelId, const RsGxsMessageId& parentId,
+	        const std::string& comment,
+	        RsGxsMessageId& commentMessageId = RS_DEFAULT_STORAGE_PARAM(RsGxsMessageId),
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) override;
 
 	/// Implementation of @see RsGxsChannels::editChannel
-	virtual bool editChannel(RsGxsChannelGroup& channel);
+	virtual bool editChannel(RsGxsChannelGroup& channel) override;
 
-#ifdef REMOVED
-	/// Implementation of @see RsGxsChannels::createPost
-	virtual bool createPost(RsGxsChannelPost& post);
-#endif
-	/// Implementation of @see RsGxsChannels::createPost
-	virtual bool createPost(const RsGxsGroupId& groupId,
-    						const RsGxsMessageId& origMsgId,
-	                        const std::string& msgName,
-							const std::string& msg,
-							const std::list<RsGxsFile>& files,
-							const RsGxsImage& thumbnail,
-                            RsGxsMessageId &message_id,
-                            std::string& error_message) ;
+	/// @deprecated Implementation of @see RsGxsChannels::createPost
+	RS_DEPRECATED_FOR(createPostV2)
+	virtual bool createPost(RsGxsChannelPost& post) override;
 
-#ifdef REMOVED
-	/// Implementation of @see RsGxsChannels::createVote
-	virtual bool createVote(RsGxsVote& vote);
-#endif
+	/// Implementation of @see RsGxsChannels::createPostV2
+	bool createPostV2(
+	        const RsGxsGroupId& channelId, const std::string& title,
+	        const std::string& body,
+	        const std::list<RsGxsFile>& files = std::list<RsGxsFile>(),
+	        const RsGxsImage& thumbnail = RsGxsImage(),
+	        const RsGxsMessageId& origPostId = RsGxsMessageId(),
+	        RsGxsMessageId& postId = RS_DEFAULT_STORAGE_PARAM(RsGxsMessageId),
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) override;
 
-	/// Implementation of @see RsGxsChannels::createVote
-	virtual bool createVote(const RsGxsGroupId&         groupId,
-                             const RsGxsMessageId&       threadId,
-                             const RsGxsMessageId&       commentMessageId,
-                             const RsGxsId&              authorId,
-                             uint32_t                    voteType,
-                             RsGxsMessageId&             voteMessageId,
-                             std::string&                error_message);
+	/// @deprecated Implementation of @see RsGxsChannels::createVote
+	RS_DEPRECATED_FOR(createVoteV2)
+	virtual bool createVote(RsGxsVote& vote) override;
+
+	/// Implementation of @see RsGxsChannels::createVoteV2
+	virtual bool createVoteV2(
+	        const RsGxsGroupId& channelId, const RsGxsMessageId& postId,
+	        const RsGxsMessageId& commentId, const RsGxsId& authorId,
+	        RsGxsVoteType vote,
+	        RsGxsMessageId& voteId = RS_DEFAULT_STORAGE_PARAM(RsGxsMessageId),
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) override;
 
 	/// Implementation of @see RsGxsChannels::subscribeToChannel
 	virtual bool subscribeToChannel( const RsGxsGroupId &groupId,
@@ -261,6 +259,10 @@ virtual bool ExtraFileRemove(const RsFileHash &hash);
 
 	virtual bool shareChannelKeys(
 	        const RsGxsGroupId& channelId, const std::set<RsPeerId>& peers );
+
+	/// Implementation of @see RsGxsChannels::createChannel
+	RS_DEPRECATED_FOR(createChannelV2)
+	virtual bool createChannel(RsGxsChannelGroup& channel) override;
 
 protected:
 	// Overloaded from GxsTokenQueue for Request callbacks.
@@ -306,9 +308,11 @@ bool generateGroup(uint32_t &token, std::string groupName);
 	class ChannelDummyRef
 	{
 		public:
-		ChannelDummyRef() { return; }
-		ChannelDummyRef(const RsGxsGroupId &grpId, const RsGxsMessageId &threadId, const RsGxsMessageId &msgId)
-		:mGroupId(grpId), mThreadId(threadId), mMsgId(msgId) { return; }
+		ChannelDummyRef() {}
+		ChannelDummyRef(
+		        const RsGxsGroupId &grpId, const RsGxsMessageId &threadId,
+		        const RsGxsMessageId &msgId ) :
+		    mGroupId(grpId), mThreadId(threadId), mMsgId(msgId) {}
 
 		RsGxsGroupId mGroupId;
 		RsGxsMessageId mThreadId;
@@ -352,5 +356,3 @@ bool generateGroup(uint32_t &token, std::string groupName);
 	/// Cleanup mSearchCallbacksMap and mDistantChannelsCallbacksMap
 	void cleanTimedOutCallbacks();
 };
-
-#endif 

--- a/libretroshare/src/services/p3gxschannels.h
+++ b/libretroshare/src/services/p3gxschannels.h
@@ -197,6 +197,16 @@ virtual bool ExtraFileRemove(const RsFileHash &hash);
 	/// Implementation of @see RsGxsChannels::createChannel
 	virtual bool createChannel(RsGxsChannelGroup& channel);
 
+	/// Implementation of @see RsGxsChannels::createChannel
+	virtual bool createChannel(const std::string& name,
+                               const std::string& description,
+                               const RsGxsImage& image,
+                               const RsGxsId& author_id,
+                               uint32_t circle_type,
+                               RsGxsCircleId& circle_id,
+                               RsGxsGroupId& channel_group_id,
+                               std::string& error_message);
+
 	/// Implementation of @see RsGxsChannels::createComment
 	virtual bool createComment(RsGxsComment& comment);
 

--- a/libretroshare/src/util/rsmemory.h
+++ b/libretroshare/src/util/rsmemory.h
@@ -3,7 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2012-2012 by Cyril Soler <csoler@users.sourceforge.net>           *
+ * Copyright 2012 Cyril Soler <csoler@users.sourceforge.net>                   *
+ * Copyright 2019 Gioacchino Mazzurco <gio@altermundi.net>                     *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -21,11 +22,44 @@
  *******************************************************************************/
 #pragma once
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
-#include <util/stacktrace.h>
 
+#include "util/stacktrace.h"
+
+/**
+ * @brief Shorthand macro to declare optional functions output parameters
+ * To define an optional output paramether use the following syntax
+ *
+\code{.cpp}
+bool myFunnyFunction(
+	int mandatoryParamether,
+	BigType& myOptionalOutput = RS_DEFAULT_STORAGE_PARAM(BigType) )
+\endcode
+ *
+ * The function caller then can call myFunnyFunction either passing
+ * myOptionalOutput parameter or not.
+ * @see RsGxsChannels methods for real usage examples.
+ *
+ * @details
+ * When const references are used to pass function parameters it is easy do make
+ * those params optional by defining a default value in the function
+ * declaration, because a temp is accepted as default parameter in those cases.
+ * It is not as simple when one want to make optional a non-const reference
+ * parameter that is usually used as output, in that case as a temp is in theory
+ * not acceptable.
+ * Yet it is possible to overcome that limitation with the following trick:
+ * If not passed as parameter the storage for the output parameter can be
+ * dinamically allocated directly by the function call, to avoid leaking memory
+ * on each function call the pointer to that storage is made unique so once the
+ * function returns it goes out of scope and is automatically deleted.
+ * About performance overhead: std::unique_ptr have very good performance and
+ * modern compilers may be even able to avoid the dynamic allocation in this
+ * case, any way the allocation would only happen if the parameter is not
+ * passed, so any effect on performace would happen only in case where the
+ * function is called without the parameter.
+ */
 #define RS_DEFAULT_STORAGE_PARAM(Type) *std::unique_ptr<Type>(new Type)
 
 void *rs_malloc(size_t size) ;

--- a/libretroshare/src/util/rsmemory.h
+++ b/libretroshare/src/util/rsmemory.h
@@ -23,7 +23,10 @@
 
 #include <stdlib.h>
 #include <iostream>
+#include <memory>
 #include <util/stacktrace.h>
+
+#define RS_DEFAULT_STORAGE_PARAM(Type) *std::unique_ptr<Type>(new Type)
 
 void *rs_malloc(size_t size) ;
 

--- a/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
@@ -755,12 +755,12 @@ void GxsGroupDialog::setGroupSignFlags(uint32_t signFlags)
         	// (cyril) very weird piece of code. Need to clear this up.
         
 		ui.comments_allowed->setChecked(true);
-        	ui.commentsValueLabel->setText("Allowed") ;
+		ui.commentsValueLabel->setText("Allowed") ;
 	}
 	else
 	{
 		ui.comments_no->setChecked(true);
-        	ui.commentsValueLabel->setText("Allowed") ;
+		ui.commentsValueLabel->setText("Forbidden") ;
 	}
 }
 

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelGroupDialog.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelGroupDialog.cpp
@@ -61,11 +61,15 @@ const uint32_t ChannelEditDefaultsFlags = ChannelCreateDefaultsFlags;
 GxsChannelGroupDialog::GxsChannelGroupDialog(TokenQueue *tokenQueue, QWidget *parent)
     : GxsGroupDialog(tokenQueue, ChannelCreateEnabledFlags, ChannelCreateDefaultsFlags, parent)
 {
+    ui.commentGroupBox->setEnabled(false);	// These are here because comments_allowed are actually not used yet, so the group will not be changed by the setting and when
+    ui.comments_allowed->setChecked(true);	// the group info is displayed it will therefore be set to "disabled" in all cases although it is enabled.
 }
 
 GxsChannelGroupDialog::GxsChannelGroupDialog(TokenQueue *tokenExternalQueue, RsTokenService *tokenService, Mode mode, RsGxsGroupId groupId, QWidget *parent)
     : GxsGroupDialog(tokenExternalQueue, tokenService, mode, groupId, ChannelEditEnabledFlags, ChannelEditDefaultsFlags, parent)
 {
+    ui.commentGroupBox->setEnabled(false);	// These are here because comments_allowed are actually not used yet, so the group will not be changed by the setting and when
+    ui.comments_allowed->setChecked(true);	// the group info is displayed it will therefore be set to "disabled" in all cases although it is enabled.
 }
 
 void GxsChannelGroupDialog::initUi()


### PR DESCRIPTION
Fix compilation, retrocompatibility and enums
    
    Workaround miss-behaviour on old Android phones
    Cleanup indentation a bit
    Consistent param naming
    Introduce default parameter values also for output paramethers
