### PR TITLE
RFC: Add support for short invites

### DIFF
--- a/libretroshare/src/chat/distantchat.cc
+++ b/libretroshare/src/chat/distantchat.cc
@@ -67,13 +67,10 @@ uint32_t msecs_of_day()
 
 static const uint32_t DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID = 0xa0001 ;
 
-typedef RsGxsTunnelService::RsGxsTunnelId RsGxsTunnelId;
-
-DistantChatService::DistantChatService()  : mDistantChatMtx("distant chat")
-{
-	mGxsTunnels = NULL ;
-	mDistantChatPermissions = RS_DISTANT_CHAT_CONTACT_PERMISSION_FLAG_FILTER_NONE ;	// default: accept everyone
-}
+DistantChatService::DistantChatService() :
+    // default: accept everyone
+    mDistantChatPermissions(RS_DISTANT_CHAT_CONTACT_PERMISSION_FLAG_FILTER_NONE),
+    mGxsTunnels(nullptr), mDistantChatMtx("distant chat") {}
 
 void DistantChatService::connectToGxsTunnelService(RsGxsTunnelService *tr)
 {
@@ -181,7 +178,8 @@ bool DistantChatService::acceptDataFromPeer(const RsGxsId& gxs_id,const RsGxsTun
     return res ;
 }
 
-void DistantChatService::notifyTunnelStatus(const RsGxsTunnelService::RsGxsTunnelId &tunnel_id, uint32_t tunnel_status)
+void DistantChatService::notifyTunnelStatus(
+        const RsGxsTunnelId& tunnel_id, uint32_t tunnel_status )
 {
 #ifdef DEBUG_DISTANT_CHAT    
     DISTANT_CHAT_DEBUG() << "DistantChatService::notifyTunnelStatus(): got notification " << std::hex << tunnel_status << std::dec << " for tunnel " << tunnel_id << std::endl;
@@ -207,7 +205,8 @@ void DistantChatService::notifyTunnelStatus(const RsGxsTunnelService::RsGxsTunne
     }
 }
 
-void DistantChatService::receiveData(const RsGxsTunnelService::RsGxsTunnelId &tunnel_id, unsigned char *data, uint32_t data_size)
+void DistantChatService::receiveData(
+        const RsGxsTunnelId& tunnel_id, unsigned char* data, uint32_t data_size)
 {
 #ifdef DEBUG_DISTANT_CHAT    
     DISTANT_CHAT_DEBUG() << "DistantChatService::receiveData(): got data of size " << std::dec << data_size << " for tunnel " << tunnel_id << std::endl;
@@ -249,7 +248,8 @@ void DistantChatService::receiveData(const RsGxsTunnelService::RsGxsTunnelId &tu
 
 void DistantChatService::markDistantChatAsClosed(const DistantChatPeerId& dcpid)
 {
-    mGxsTunnels->closeExistingTunnel(RsGxsTunnelService::RsGxsTunnelId(dcpid),DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID) ;
+	mGxsTunnels->closeExistingTunnel(
+	            RsGxsTunnelId(dcpid), DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID );
     
     RS_STACK_MUTEX(mDistantChatMtx) ;
     

--- a/libretroshare/src/chat/distantchat.h
+++ b/libretroshare/src/chat/distantchat.h
@@ -33,9 +33,6 @@ static const uint32_t DISTANT_CHAT_AES_KEY_SIZE = 16 ;
 class DistantChatService: public RsGxsTunnelService::RsGxsTunnelClientService
 {
 public:
-    // So, public interface only uses DistandChatPeerId, but internally, this is converted into a RsGxsTunnelService::RsGxsTunnelId
-    
-   
     DistantChatService() ;
 
     virtual void triggerConfigSave()=0 ;
@@ -91,9 +88,13 @@ public:
     virtual void connectToGxsTunnelService(RsGxsTunnelService *tunnel_service) ;
     
 private:
-    virtual bool acceptDataFromPeer(const RsGxsId& gxs_id, const RsGxsTunnelService::RsGxsTunnelId& tunnel_id, bool am_I_client_side) ;
-    virtual void notifyTunnelStatus(const RsGxsTunnelService::RsGxsTunnelId& tunnel_id,uint32_t tunnel_status) ;
-    virtual void receiveData(const RsGxsTunnelService::RsGxsTunnelId& id,unsigned char *data,uint32_t data_size) ;
+	virtual bool acceptDataFromPeer(
+	        const RsGxsId& gxs_id, const RsGxsTunnelId& tunnel_id,
+	        bool am_I_client_side);
+	virtual void notifyTunnelStatus(
+	        const RsGxsTunnelId& tunnel_id, uint32_t tunnel_status);
+	virtual void receiveData(
+	        const RsGxsTunnelId& id, unsigned char* data, uint32_t data_size );
 
     // Utility functions.
     

--- a/libretroshare/src/chat/distantchat.h
+++ b/libretroshare/src/chat/distantchat.h
@@ -30,6 +30,10 @@ class RsGixs ;
 
 static const uint32_t DISTANT_CHAT_AES_KEY_SIZE = 16 ;
 
+/**
+ * Public interface only uses DistandChatPeerId, but internally, this is
+ * converted into a RsGxsTunnelId
+ */
 class DistantChatService: public RsGxsTunnelService::RsGxsTunnelClientService
 {
 public:

--- a/libretroshare/src/crypto/hashstream.h
+++ b/libretroshare/src/crypto/hashstream.h
@@ -47,10 +47,10 @@ namespace librs
 
 			template<class T> friend HashStream& operator<<(HashStream& u, const T&) ;
 
-			template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
-			friend HashStream& operator<<(HashStream& u,const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& r)
+			template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
+			friend HashStream& operator<<(HashStream& u, const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& r)
 			{
-				EVP_DigestUpdate(u.mdctx,r.toByteArray(),ID_SIZE_IN_BYTES);
+				EVP_DigestUpdate(u.mdctx, r.toByteArray(), ID_SIZE_IN_BYTES);
 				return u;
 			}
 			private:

--- a/libretroshare/src/gxs/rsgixs.h
+++ b/libretroshare/src/gxs/rsgixs.h
@@ -92,8 +92,6 @@
  * as these will be used very frequently.
  *****/
 
-typedef PGPIdType RsPgpId;
-
 /* Identity Interface for GXS Message Verification.
  */
 class RsGixs

--- a/libretroshare/src/gxs/rsgxsnetutils.cc
+++ b/libretroshare/src/gxs/rsgxsnetutils.cc
@@ -217,7 +217,9 @@ bool GrpCircleVetting::expired()
 {
 	return  time(NULL) > (mTimeStamp + EXPIRY_PERIOD_OFFSET);
 }
-bool GrpCircleVetting::canSend(const SSLIdType& peerId, const RsGxsCircleId& circleId,bool& should_encrypt)
+bool GrpCircleVetting::canSend(
+        const RsPeerId& peerId, const RsGxsCircleId& circleId,
+        bool& should_encrypt )
 {
 	if(mCircles->isLoaded(circleId))
 	{

--- a/libretroshare/src/gxstunnel/p3gxstunnel.cc
+++ b/libretroshare/src/gxstunnel/p3gxstunnel.cc
@@ -1062,7 +1062,7 @@ void p3GxsTunnelService::handleRecvDHPublicKey(RsGxsTunnelDHPublicKeyItem *item)
 
 // Note: for some obscure reason, the typedef does not work here. Looks like a compiler error. So I use the primary type.
 
-/*static*/ GXSTunnelId p3GxsTunnelService::makeGxsTunnelId(
+/*static*/ RsGxsTunnelId p3GxsTunnelService::makeGxsTunnelId(
         const RsGxsId &own_id, const RsGxsId &distant_id )
 {
     unsigned char mem[RsGxsId::SIZE_IN_BYTES * 2] ;

--- a/libretroshare/src/pgp/pgphandler.cc
+++ b/libretroshare/src/pgp/pgphandler.cc
@@ -908,12 +908,14 @@ bool PGPHandler::checkAndImportKeyPair(ops_keyring_t *tmp_keyring, RsPgpId &impo
 		return false ;
 	}
 
-	if(pubkey == NULL || seckey == NULL || pubkey == seckey)
+	if(pubkey == nullptr || seckey == nullptr || pubkey == seckey)
 	{
 		import_error = "File does not contain a public and a private key. Sorry." ;
 		return false ;
 	}
-	if(memcmp(pubkey->fingerprint.fingerprint,seckey->fingerprint.fingerprint,PGP_KEY_FINGERPRINT_SIZE) != 0)
+	if(memcmp( pubkey->fingerprint.fingerprint,
+	           seckey->fingerprint.fingerprint,
+	           RsPpgFingerprint::SIZE_IN_BYTES ) != 0)
 	{
 		import_error = "Public and private keys do nt have the same fingerprint. Sorry!" ;
 		return false ;
@@ -940,7 +942,10 @@ bool PGPHandler::checkAndImportKeyPair(ops_keyring_t *tmp_keyring, RsPgpId &impo
 	bool found = false ;
 
 	for(uint32_t i=0;i<result->valid_count;++i)
-		if(!memcmp((unsigned char*)result->valid_sigs[i].signer_id,pubkey->key_id,PGP_KEY_ID_SIZE)) 
+		if(!memcmp(
+		            static_cast<uint8_t*>(result->valid_sigs[i].signer_id),
+		            pubkey->key_id,
+		            RsPpgFingerprint::SIZE_IN_BYTES ))
 		{
 			found = true ;
 			break ;
@@ -1087,7 +1092,10 @@ bool PGPHandler::LoadCertificateFromString(const std::string& pgp_cert,RsPgpId& 
 	bool found = false ;
 
 	for(uint32_t i=0;i<result->valid_count;++i)
-		if(!memcmp((unsigned char*)result->valid_sigs[i].signer_id,keydata->key_id,PGP_KEY_ID_SIZE)) 
+		if(!memcmp(
+		            static_cast<uint8_t*>(result->valid_sigs[i].signer_id),
+		            keydata->key_id,
+		            RsPpgFingerprint::SIZE_IN_BYTES ))
 		{
 			found = true ;
 			break ;
@@ -1164,7 +1172,9 @@ bool PGPHandler::locked_addOrMergeKey(ops_keyring_t *keyring,std::map<RsPgpId,PG
 	}
 	else
 	{
-		if(memcmp(existing_key->fingerprint.fingerprint, keydata->fingerprint.fingerprint,PGP_KEY_FINGERPRINT_SIZE))
+		if(memcmp( existing_key->fingerprint.fingerprint,
+		           keydata->fingerprint.fingerprint,
+		           RsPpgFingerprint::SIZE_IN_BYTES ))
 		{
 			std::cerr << "(EE) attempt to merge key with identical id, but different fingerprint!" << std::endl;
 			return false ;
@@ -1792,7 +1802,8 @@ bool PGPHandler::privateTrustCertificate(const RsPgpId& id,int trustlvl)
 
 struct PrivateTrustPacket
 {
-	unsigned char user_id[PGP_KEY_ID_SIZE] ;  	// pgp id in unsigned char format.
+	/// pgp id in unsigned char format.
+	unsigned char user_id[RsPgpId::SIZE_IN_BYTES];
 	uint8_t trust_level ;						// trust level. From 0 to 6.
 	uint32_t time_stamp ;						// last time the cert was ever used, in seconds since the epoch. 0 means not initialized.
 };
@@ -1854,9 +1865,12 @@ bool PGPHandler::locked_writePrivateTrustDatabase()
 	}
 	PrivateTrustPacket trustpacket ;
 
-	for(std::map<RsPgpId,PGPCertificateInfo>::iterator it = _public_keyring_map.begin();it!=_public_keyring_map.end() ;++it)
+	for( std::map<RsPgpId,PGPCertificateInfo>::iterator it =
+	     _public_keyring_map.begin(); it!=_public_keyring_map.end(); ++it )
 	{
-		memcpy(trustpacket.user_id,RsPgpId(it->first).toByteArray(),PGP_KEY_ID_SIZE) ;
+		memcpy( trustpacket.user_id,
+		        it->first.toByteArray(),
+		        RsPgpId::SIZE_IN_BYTES );
 		trustpacket.trust_level = it->second._trustLvl ;
 		trustpacket.time_stamp = it->second._time_stamp ;
 

--- a/libretroshare/src/pgp/rscertificate.cc
+++ b/libretroshare/src/pgp/rscertificate.cc
@@ -31,6 +31,7 @@
 #include "rscertificate.h"
 #include "util/rsstring.h"
 #include "util/stacktrace.h"
+#include "util/rsdebug.h"
 
 //#define DEBUG_RSCERTIFICATE
 
@@ -175,9 +176,9 @@ RsCertificate::RsCertificate(const std::string& str) :
 
 	if(!initializeFromString(str, err_code))
 	{
-		std::cerr << __PRETTY_FUNCTION__ << " is deprecated because it can "
-		          << "miserably fail like this! str: " << str
-		          << " err_code: " << err_code << std::endl;
+		RsErr() << __PRETTY_FUNCTION__ << " is deprecated because it can "
+		        << "miserably fail like this! str: " << str
+		        << " err_code: " << err_code << std::endl;
 		print_stacktrace();
 		throw err_code;
 	}
@@ -186,8 +187,13 @@ RsCertificate::RsCertificate(const std::string& str) :
 RsCertificate::RsCertificate(const RsPeerDetails& Detail, const unsigned char *binary_pgp_block,size_t binary_pgp_block_size)
 	:pgp_version("Version: OpenPGP:SDK v0.9")
 {
-	if(binary_pgp_block_size == 0 || binary_pgp_block == NULL)
-		throw std::runtime_error("Cannot init a certificate with a void key block.") ;
+	if(binary_pgp_block_size == 0 || binary_pgp_block == nullptr)
+	{
+		RsErr() << __PRETTY_FUNCTION__ << " is deprecated because it can "
+		        << "miserably fail like this! " << std::endl;
+		print_stacktrace();
+		throw std::runtime_error("Cannot init a certificate with a void key block.");
+	}
 
 	binary_pgp_key = new unsigned char[binary_pgp_block_size] ;
 	memcpy(binary_pgp_key,binary_pgp_block,binary_pgp_block_size) ;

--- a/libretroshare/src/pgp/rscertificate.h
+++ b/libretroshare/src/pgp/rscertificate.h
@@ -54,7 +54,7 @@ public:
 	bool initializeFromString(const std::string& str, uint32_t& errCode);
 
 	/// Constructs from binary gpg key, and RsPeerDetails.
-	RsCertificate( const RsPeerDetails& details,
+	RS_DEPRECATED RsCertificate( const RsPeerDetails& details,
 	               const unsigned char *gpg_mem_block,
 	               size_t gpg_mem_block_size );
 

--- a/libretroshare/src/pgp/rscertificate.h
+++ b/libretroshare/src/pgp/rscertificate.h
@@ -3,7 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2016 Cyril Soler <csoler@users.sourceforge.net>                   *
+ * Copyright (C) 2016  Cyril Soler <csoler@users.sourceforge.net>              *
+ * Copyright (C) 2018-2019  Gioacchino Mazzurco <gio@eigenlab.org>             *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -23,9 +24,11 @@
 
 #include "retroshare/rstypes.h"
 #include "util/rsurl.h"
+#include "util/rsmemory.h"
 
 #include <set>
 #include <string>
+#include <memory>
 
 struct RsPeerDetails;
 
@@ -35,30 +38,30 @@ public:
 	typedef enum { RS_CERTIFICATE_OLD_FORMAT, RS_CERTIFICATE_RADIX } Format;
 
 	/**
-	 * @brief Costruct an empty certificate, use toghether with
-	 * if(initializeFromString) for safe certificate radix string parsing
+	 * @brief Create certificate object from certificate string
+	 * @param[in] str radix format string
+	 * @param[out] errorCode Optional storage for eventual error code,
+	 *	meaningful only on failure
+	 * @return nullptr on failure, pointer to the generated certificate
+	 *	otherwise
 	 */
-	RsCertificate() :
-	    ipv4_external_ip_and_port{0,0,0,0,0,0},
-	    ipv4_internal_ip_and_port{0,0,0,0,0,0},
-	    binary_pgp_key(nullptr), binary_pgp_key_size(0),
-	    pgp_version("Version: OpenPGP:SDK v0.9"), only_pgp(true),
-	    hidden_node(false) {}
+	static std::unique_ptr<RsCertificate> fromString(
+	        const std::string& str,
+	        uint32_t& errorCode = RS_DEFAULT_STORAGE_PARAM(uint32_t) );
 
 	/**
-	 * @brief Initialize from certificate string
-	 * @param[in] str radix format string
-	 * @param[out] errCode storage for eventual error code
-	 * @return false on failure, true otherwise
+	 * @brief Create certificate object from details and PGP memory block
+	 * @param[in] details peer details
+	 * @param[in] binary_pgp_block pointer to PGP memory block
+	 * @param[in] binary_pgp_block_size size of PGP memory block
+	 * @return nullptr on failure, pointer to the generated certificate
+	 *	otherwise
 	 */
-	bool initializeFromString(const std::string& str, uint32_t& errCode);
+	static std::unique_ptr<RsCertificate> fromMemoryBlock(
+	        const RsPeerDetails& details, const uint8_t* binary_pgp_block,
+	        size_t binary_pgp_block_size);
 
-	/// Constructs from binary gpg key, and RsPeerDetails.
-	RS_DEPRECATED RsCertificate( const RsPeerDetails& details,
-	               const unsigned char *gpg_mem_block,
-	               size_t gpg_mem_block_size );
-
-	virtual ~RsCertificate();
+	~RsCertificate();
 
 	/// Convert to certificate radix string
 	std::string toStdString() const;
@@ -86,10 +89,12 @@ public:
 
 	/**
 	 * @deprecated using this costructor may raise exception that cause
-	 *	crash if not handled, use empty constructor + if(initFromString) for a
-	 *	safer behaviour.
+	 *	crash if not handled.
 	 */
-	RS_DEPRECATED explicit RsCertificate(const std::string& input_string);
+	RS_DEPRECATED_FOR("RsCertificate::fromMemoryBlock(...)")
+	RsCertificate( const RsPeerDetails& details,
+	               const unsigned char *gpg_mem_block,
+	               size_t gpg_mem_block_size );
 
 private:
 	// new radix format
@@ -104,6 +109,14 @@ private:
 
 	RsCertificate(const RsCertificate&) {} /// non copy-able
 	const RsCertificate& operator=(const RsCertificate&); /// non copy-able
+
+	/// @brief Costruct an empty certificate
+	RsCertificate() :
+	    ipv4_external_ip_and_port{0,0,0,0,0,0},
+	    ipv4_internal_ip_and_port{0,0,0,0,0,0},
+	    binary_pgp_key(nullptr), binary_pgp_key_size(0),
+	    pgp_version("Version: OpenPGP:SDK v0.9"), only_pgp(true),
+	    hidden_node(false) {}
 
 	unsigned char ipv4_external_ip_and_port[6];
 	unsigned char ipv4_internal_ip_and_port[6];

--- a/libretroshare/src/pqi/authgpg.cc
+++ b/libretroshare/src/pqi/authgpg.cc
@@ -445,17 +445,15 @@ bool AuthGPG::isKeySupported(const RsPgpId& id) const
 
 bool AuthGPG::getGPGDetails(const RsPgpId& pgp_id, RsPeerDetails &d)
 {
-	RsStackMutex stack(gpgMtxData); /******* LOCKED ******/
+	RS_STACK_MUTEX(gpgMtxData);
 
-	const PGPCertificateInfo *pc = PGPHandler::getCertificateInfo(pgp_id) ;
+	const PGPCertificateInfo* pc = PGPHandler::getCertificateInfo(pgp_id);
+	if(!pc) return false;
 
-	if(pc == NULL)
-		return false ;
-
-	const PGPCertificateInfo& cert(*pc) ;
+	const PGPCertificateInfo& cert(*pc);
 
 	d.id.clear() ;
-	d.gpg_id = pgp_id ;
+	d.gpg_id = pgp_id;
 	d.name = cert._name;
 	d.lastUsed = cert._time_stamp;
 	d.email = cert._email;

--- a/libretroshare/src/pqi/authssl.cc
+++ b/libretroshare/src/pqi/authssl.cc
@@ -1083,7 +1083,7 @@ bool AuthSSLimpl::checkX509PgpSignature(X509 *x509, uint32_t& diagnostic)
 
 		/* NOW check sign via GPG Functions */
 
-		Dbg1() << __PRETTY_FUNCTION__
+		Dbg2() << __PRETTY_FUNCTION__
 		       << " verifying the PGP Key signature with finger print: "
 		       << pd.fpr << std::endl;
 
@@ -1159,10 +1159,11 @@ bool AuthSSLimpl::checkX509PgpSignature(X509 *x509, uint32_t& diagnostic)
 			goto err;
 		}
 
-		Dbg1() << __PRETTY_FUNCTION__ <<  "Verified: " << sigtypestring
-		       << " signature of certificate " << sslcert::getCertSslId(*x509)
+		Dbg1() << __PRETTY_FUNCTION__ << " Verified: " << sigtypestring
+		       << " signature of certificate sslId: "
+		       << sslcert::getCertSslId(*x509)
 		       << ", Version " << std::hex << certificate_version << std::dec
-		       << " using PGP key " << pd.fpr << std::endl;
+		       << " using PGP key " << pd.fpr << " " << pd.name << std::endl;
 	}
 
 	EVP_MD_CTX_destroy(ctx);

--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -1694,7 +1694,7 @@ bool p3LinkMgrIMPL::retryConnectTCP(const RsPeerId &id)
 bool p3LinkMgrIMPL::locked_CheckPotentialAddr(
         const sockaddr_storage& addr, rstime_t /*age*/ )
 {
-	Dbg1() << __PRETTY_FUNCTION__ << " addr: " << addr << std::endl;
+	Dbg3() << __PRETTY_FUNCTION__ << " addr: " << addr << std::endl;
 
 	if(!sockaddr_storage_isValidNet(addr))
 	{/* if invalid - quick rejection */

--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -39,7 +39,7 @@
 #include "util/rsprint.h"
 #include "util/rsdebug.h"
 #include "util/rsstring.h"
-
+#include "util/rsrandom.h"
 #include "rsitems/rsconfigitems.h"
 
 #include "retroshare/rsiface.h"
@@ -2025,7 +2025,8 @@ bool p3LinkMgrIMPL::locked_ConnectAttempt_Complete(peerConnectState* peer)
 {
 	/* flag as last attempt to prevent loop */
 	//add a random perturbation between 0 and 2 sec.
-	peer->lastattempt = time(nullptr) + rand() % MAX_RANDOM_ATTEMPT_OFFSET;
+	peer->lastattempt = time(nullptr) +
+	        RsRandom::random_u32() % MAX_RANDOM_ATTEMPT_OFFSET;
 
 	if (peer->inConnAttempt) 
 	{

--- a/libretroshare/src/pqi/p3linkmgr.cc
+++ b/libretroshare/src/pqi/p3linkmgr.cc
@@ -1457,7 +1457,14 @@ void p3LinkMgrIMPL::peerConnectRequest(
 /*******************************************************************/
        /*************** External Control ****************/
 bool p3LinkMgrIMPL::retryConnect(const RsPeerId &id)
-{ return retryConnectTCP(id); }
+{
+// P3CONNMGR_NO_TCP_CONNECTIONS defined when debugging with UDP connections only
+#ifndef P3CONNMGR_NO_TCP_CONNECTIONS
+	return retryConnectTCP(id);
+#else // def P3CONNMGR_NO_TCP_CONNECTIONS
+	return false;
+#endif // def P3CONNMGR_NO_TCP_CONNECTIONS
+}
 
 
 

--- a/libretroshare/src/pqi/p3linkmgr.h
+++ b/libretroshare/src/pqi/p3linkmgr.h
@@ -19,8 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef MRK_PQI_LINK_MANAGER_HEADER
-#define MRK_PQI_LINK_MANAGER_HEADER
+#pragma once
 
 #include "pqi/pqimonitor.h"
 #include "pqi/pqiipset.h"
@@ -30,6 +29,11 @@
 #include "pqi/p3cfgmgr.h"
 
 #include "util/rsthreads.h"
+#include "util/rsdebug.h"
+
+#ifndef RS_DEBUG_LINKMGR
+#	define RS_DEBUG_LINKMGR 1
+#endif
 
 class ExtAddrFinder ;
 class DNSResolver ;
@@ -146,11 +150,7 @@ std::string textPeerConnectState(peerConnectState &state);
 
 class p3LinkMgr: public pqiConnectCb
 {
-	public:
-
-        p3LinkMgr() { return; }
-virtual ~p3LinkMgr() { return; }
-
+public:
 
 virtual const 	RsPeerId& getOwnId() = 0;
 virtual bool  	isOnline(const RsPeerId &ssl_id) = 0;
@@ -177,27 +177,40 @@ virtual void 	notifyDeniedConnection(const RsPgpId& gpgid,const RsPeerId& sslid,
 virtual bool 	setLocalAddress(const struct sockaddr_storage &addr) = 0;
 virtual bool 	getLocalAddress(struct sockaddr_storage &addr) = 0;
 
-	/************* DEPRECIATED FUNCTIONS (TO REMOVE) ********/
+	/************* DEPRECATED FUNCTIONS (TO REMOVE) ********/
+	RS_DEPRECATED
+	virtual void getFriendList(std::list<RsPeerId> &ssl_peers) = 0; // ONLY used by p3peers.cc USE p3PeerMgr instead.
 
-virtual void	getFriendList(std::list<RsPeerId> &ssl_peers) = 0; // ONLY used by p3peers.cc USE p3PeerMgr instead.
-virtual bool	getFriendNetStatus(const RsPeerId &id, peerConnectState &state) = 0; // ONLY used by p3peers.cc
+	RS_DEPRECATED
+	virtual bool getFriendNetStatus(const RsPeerId &id, peerConnectState &state) = 0; // ONLY used by p3peers.cc
 
-virtual bool 	checkPotentialAddr(const struct sockaddr_storage &addr, rstime_t age)=0;
+	RS_DEPRECATED
+	virtual bool checkPotentialAddr(const struct sockaddr_storage &addr, rstime_t age)=0;
 
-	/************* DEPRECIATED FUNCTIONS (TO REMOVE) ********/
-virtual int 	addFriend(const RsPeerId &ssl_id, bool isVisible) = 0;
-	/******* overloaded from pqiConnectCb *************/
-// THESE MUSTn't BE specfied HERE - as overloaded from pqiConnectCb.
-//virtual void    peerStatus(std::string id, const pqiIpAddrSet &addrs, 
-//                        uint32_t type, uint32_t flags, uint32_t source) = 0;
-//virtual void    peerConnectRequest(std::string id, const struct sockaddr_storage &raddr,
-//                        const struct sockaddr_storage &proxyaddr,  const struct sockaddr_storage &srcaddr,
-//                        uint32_t source, uint32_t flags, uint32_t delay, uint32_t bandwidth) = 0;
+	RS_DEPRECATED
+	virtual int addFriend(const RsPeerId &ssl_id, bool isVisible) = 0;
 
-/****************************************************************************/
-/****************************************************************************/
-/****************************************************************************/
+	virtual ~p3LinkMgr();
 
+protected:
+
+#if defined(RS_DEBUG_LINKMGR) && RS_DEBUG_LINKMGR == 1
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_LINKMGR) && RS_DEBUG_LINKMGR == 2
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_LINKMGR) && RS_DEBUG_LINKMGR >= 3
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsDbg;
+#else // RS_DEBUG_LINKMGR
+	using Dbg1 = RsNoDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#endif // RS_DEBUG_LINKMGR
 };
 
 
@@ -338,5 +351,3 @@ private:
 	/* relatively static list of banned ip addresses */
 	std::list<struct sockaddr_storage> mBannedIpList;
 };
-
-#endif // MRK_PQI_LINK_MANAGER_HEADER

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -19,8 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef MRK_PQI_PEER_MANAGER_HEADER
-#define MRK_PQI_PEER_MANAGER_HEADER
+#pragma once
 
 #include <retroshare/rspeers.h>
 #include "pqi/pqimonitor.h"
@@ -68,13 +67,16 @@ const uint32_t RS_NET_FLAGS_TRUSTS_ME 		= 0x0020;
 const rstime_t RS_PEER_OFFLINE_DELETE  = (90 * 24 * 3600);
 const rstime_t RS_PEER_OFFLINE_NO_DISC = (30 * 24 * 3600);
 
-class peerState
+struct peerState
 {
-	public:
-	peerState(); /* init */
+	peerState();
 
 	RsPeerId id;
 	RsPgpId gpg_id;
+
+	/** We should start using full PGP fingerprint instead of short PGP id to
+	 * identify peers */
+	PGPFingerprintType mPgpFingerprint;
 
 	uint32_t netMode; /* EXT / UPNP / UDP / HIDDEN / INVALID */
 	/* visState */
@@ -127,7 +129,13 @@ public:
 	                        rstime_t lastContact = 0,
 	                        ServicePermissionFlags = ServicePermissionFlags(RS_NODE_PERM_DEFAULT) ) = 0;
 
+	/// @see p3Peers
+	virtual bool addFriendPendingPgp(
+	        const RsPeerId& sslId,
+	        const RsPeerDetails& dt = RsPeerDetails() ) = 0;
+
 	virtual bool removeFriend(const RsPeerId &ssl_id, bool removePgpId) = 0;
+
 	virtual bool isFriend(const RsPeerId& ssl_id) = 0;
 
 virtual bool 	getAssociatedPeers(const RsPgpId &gpg_id, std::list<RsPeerId> &ids) = 0;
@@ -244,6 +252,11 @@ public:
                               rstime_t lastContact = 0,ServicePermissionFlags = ServicePermissionFlags(RS_NODE_PERM_DEFAULT));
     virtual bool	removeFriend(const RsPeerId &ssl_id, bool removePgpId);
     virtual bool	removeFriend(const RsPgpId &pgp_id);
+
+	/// @see p3PeerMgr
+	virtual bool addFriendPendingPgp(
+	        const RsPeerId& sslId,
+	        const RsPeerDetails& dt = RsPeerDetails() );
 
     virtual bool	isFriend(const RsPeerId &ssl_id);
 
@@ -394,7 +407,7 @@ private:
 
     peerState mOwnState;
 
-    std::map<RsPeerId, peerState> mFriendList;	// <SSLid , peerState>
+	std::map<RsPeerId, peerState> mFriendList;
     std::map<RsPeerId, peerState> mOthersList;
 
     std::map<RsPeerId,sockaddr_storage> mReportedOwnAddresses ;
@@ -413,5 +426,3 @@ private:
     uint32_t mProxyServerStatusI2P ;
 
 };
-
-#endif // MRK_PQI_PEER_MANAGER_HEADER

--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -21,14 +21,17 @@
  *******************************************************************************/
 #pragma once
 
-#include <retroshare/rspeers.h>
+#include "retroshare/rspeers.h"
 #include "pqi/pqimonitor.h"
 #include "pqi/pqiipset.h"
 #include "pqi/pqiassist.h"
-
 #include "pqi/p3cfgmgr.h"
-
+#include "util/rsdebug.h"
 #include "util/rsthreads.h"
+
+#ifndef RS_DEBUG_P3PEERMGR
+#	define RS_DEBUG_P3PEERMGR 1
+#endif
 
 /* RS_VIS_STATE -> specified in rspeers.h
  */
@@ -235,7 +238,24 @@ virtual bool   locked_computeCurrentBestOwnExtAddressCandidate(sockaddr_storage 
 /*************************************************************************************************/
 /*************************************************************************************************/
 
-
+protected:
+#if defined(RS_DEBUG_P3PEERMGR) && RS_DEBUG_P3PEERMGR == 1
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_P3PEERMGR) && RS_DEBUG_P3PEERMGR == 2
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_P3PEERMGR) && RS_DEBUG_P3PEERMGR >= 3
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsDbg;
+#else // RS_DEBUG_P3DISCOVERY
+	using Dbg1 = RsNoDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#endif // RS_DEBUG_P3DISCOVERY
 };
 
 

--- a/libretroshare/src/pqi/pqiperson.cc
+++ b/libretroshare/src/pqi/pqiperson.cc
@@ -35,9 +35,9 @@ static struct RsLog::logInfo pqipersonzoneInfo = {RsLog::Default, "pqiperson"};
  ****/
 
 pqiperson::pqiperson(const RsPeerId& id, pqipersongrp *pg) :
-	PQInterface(id), mNotifyMtx("pqiperson-notify"), mPersonMtx("pqiperson"),
-	active(false), activepqi(NULL), inConnectAttempt(false),// waittimes(0),
-	pqipg(pg) {} // TODO: must check id!
+    PQInterface(id), mNotifyMtx("pqiperson-notify"), mPersonMtx("pqiperson"),
+    active(false), activepqi(nullptr), inConnectAttempt(false), pqipg(pg)
+{} // TODO: must check id!
 
 pqiperson::~pqiperson()
 {
@@ -488,53 +488,37 @@ int pqiperson::stoplistening()
 	return 1;
 }
 
-int	pqiperson::connect(uint32_t type, const sockaddr_storage &raddr,
+int pqiperson::connect(uint32_t type, const sockaddr_storage& raddr,
 					   const sockaddr_storage &proxyaddr,
 					   const sockaddr_storage &srcaddr,
 					   uint32_t delay, uint32_t period, uint32_t timeout,
 					   uint32_t flags, uint32_t bandwidth,
 					   const std::string &domain_addr, uint16_t domain_port)
 {
-#ifdef PERSON_DEBUG
-	std::cerr << "pqiperson::connect() Id: " << PeerId().toStdString()
-			  << " type: " << type << " addr: "
-			  << sockaddr_storage_tostring(raddr) << " proxyaddr: "
-			  << sockaddr_storage_tostring(proxyaddr) << " srcaddr: "
-			  << sockaddr_storage_tostring(srcaddr) << " delay: " << delay
-			  << " period: " << period << " timeout: " << timeout << " flags: "
-			  << flags << " bandwidth: " << bandwidth << std::endl;
-#endif
+	Dbg1() << __PRETTY_FUNCTION__ << " id: " << PeerId() << " type: " << type
+	       << " raddr: " << raddr << " proxyaddr: " << proxyaddr
+	       << " srcaddr: " << srcaddr << " delay: " << delay
+	       << " period: " << period << " timeout: " << timeout
+	       << " flags: " << flags << " bandwidth: " << bandwidth << std::endl;
 
 	RS_STACK_MUTEX(mPersonMtx);
 
 	std::map<uint32_t, pqiconnect *>::iterator it;
-	
 	it = kids.find(type);
 	if (it == kids.end())
 	{
-		/* notify of fail! */
+		RsErr() << __PRETTY_FUNCTION__ << " unhandled type: "
+		        << type << std::endl;
+
 		pqipg->notifyConnect(PeerId(), type, false, false, raddr);
 		return 0;
 	}
 
-	pqiconnect *pqi = it->second;
-
-#ifdef PERSON_DEBUG
-	std::cerr << "pqiperson::connect() resetting for new connection attempt" << std::endl;
-#endif
-
-	/* set the parameters */
+	pqiconnect* pqi = it->second;
 	pqi->reset();
 
-#ifdef PERSON_DEBUG
-	std::cerr << "pqiperson::connect() clearing rate cap" << std::endl;
-#endif
 	setRateCap_locked(0,0);
 
-#ifdef PERSON_DEBUG
-	std::cerr << "pqiperson::connect() setting connect_parameters" << std::endl;
-#endif
-	
 	// These two are universal.
 	pqi->connect_parameter(NET_PARAM_CONNECT_DELAY, delay);
 	pqi->connect_parameter(NET_PARAM_CONNECT_TIMEOUT, timeout);

--- a/libretroshare/src/pqi/pqiperson.cc
+++ b/libretroshare/src/pqi/pqiperson.cc
@@ -495,7 +495,7 @@ int pqiperson::connect(uint32_t type, const sockaddr_storage& raddr,
 					   uint32_t flags, uint32_t bandwidth,
 					   const std::string &domain_addr, uint16_t domain_port)
 {
-	Dbg1() << __PRETTY_FUNCTION__ << " id: " << PeerId() << " type: " << type
+	Dbg2() << __PRETTY_FUNCTION__ << " id: " << PeerId() << " type: " << type
 	       << " raddr: " << raddr << " proxyaddr: " << proxyaddr
 	       << " srcaddr: " << srcaddr << " delay: " << delay
 	       << " period: " << period << " timeout: " << timeout

--- a/libretroshare/src/pqi/pqiperson.h
+++ b/libretroshare/src/pqi/pqiperson.h
@@ -19,15 +19,22 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef MRK_PQI_PERSON_HEADER
-#define MRK_PQI_PERSON_HEADER
+#pragma once
 
-
-#include <string>
 #include "pqi/pqi.h"
 #include "util/rsnet.h"
+#include "util/rsdebug.h"
 
 #include <list>
+#include <string>
+
+#ifndef RS_DEBUG_PQIPERSON
+#	define RS_DEBUG_PQIPERSON 1
+#endif
+
+#ifndef RS_DEBUG_PQICONNECT
+#	define RS_DEBUG_PQICONNECT 1
+#endif
 
 class pqiperson;
 struct RsPeerCryptoParams;
@@ -55,7 +62,9 @@ public:
 	virtual bool getCryptoParams(RsPeerCryptoParams& params);
 
 	// presents a virtual NetInterface -> passes to ni.
-	virtual int	connect(const struct sockaddr_storage &raddr) { return ni->connect(raddr); }
+	virtual int connect(const sockaddr_storage& raddr)
+	{ return ni->connect(raddr); }
+
 	virtual int	listen() { return ni->listen(); }
 	virtual int	stoplistening() { return ni->stoplistening(); }
     	virtual int 	reset() { pqistreamer::reset(); return ni->reset(); }
@@ -73,23 +82,38 @@ public:
 
 protected:
 	NetBinInterface *ni;
+
+#if defined(RS_DEBUG_PQICONNECT) && RS_DEBUG_PQICONNECT == 1
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQICONNECT) && RS_DEBUG_PQICONNECT == 2
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQICONNECT) && RS_DEBUG_PQICONNECT >= 3
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsDbg;
+#else // RS_DEBUG_PQICONNECT
+	using Dbg1 = RsNoDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#endif // RS_DEBUG_PQICONNECT
 };
 
 
 class pqipersongrp;
 
-class NotifyData
+struct NotifyData
 {
-public:
-	NotifyData() : mNi(NULL), mState(0)
-	{
-		sockaddr_storage_clear(mAddr);
-	}
+	NotifyData() : mNi(nullptr), mState(0)
+	{ sockaddr_storage_clear(mAddr); }
 
 	NotifyData(NetInterface *ni, int state, const sockaddr_storage &addr) :
-		mNi(ni), mState(state), mAddr(addr) {}
+	    mNi(ni), mState(state), mAddr(addr) {}
 
-	NetInterface *mNi;
+	NetInterface* mNi;
 	int mState;
 	sockaddr_storage mAddr;
 };
@@ -106,7 +130,7 @@ public:
 	int listen();
 	int stoplistening();
 	
-	int	connect(uint32_t type, const sockaddr_storage &raddr,
+	int connect(uint32_t type, const sockaddr_storage &raddr,
 				const sockaddr_storage &proxyaddr, const sockaddr_storage &srcaddr,
 				uint32_t delay, uint32_t period, uint32_t timeout, uint32_t flags,
 				uint32_t bandwidth, const std::string &domain_addr, uint16_t domain_port);
@@ -170,6 +194,22 @@ private:
 	//int waittimes;
 	rstime_t lastHeartbeatReceived; // use to track connection failure
 	pqipersongrp *pqipg; /* parent for callback */
-};
 
-#endif
+#if defined(RS_DEBUG_PQIPERSON) && RS_DEBUG_PQIPERSON == 1
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQIPERSON) && RS_DEBUG_PQIPERSON == 2
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQIPERSON) && RS_DEBUG_PQIPERSON >= 3
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsDbg;
+#else // RS_DEBUG_PQIPERSON
+	using Dbg1 = RsNoDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#endif // RS_DEBUG_PQIPERSON
+};

--- a/libretroshare/src/pqi/pqipersongrp.h
+++ b/libretroshare/src/pqi/pqipersongrp.h
@@ -42,10 +42,12 @@ const unsigned long PQIPERSON_NO_LISTENER = 	0x0001;
 const unsigned long PQIPERSON_ALL_BW_LIMITED =  0x0010;
 struct RsPeerCryptoParams;
 
-class pqipersongrp: public pqihandler, public pqiMonitor, public p3ServiceServer, public pqiNetListener
+class pqipersongrp:
+        public pqihandler, public pqiMonitor, public p3ServiceServer,
+        public pqiNetListener
 {
-	public:
-    pqipersongrp(p3ServiceControl *ctrl, unsigned long flags);
+public:
+	pqipersongrp(p3ServiceControl* ctrl, unsigned long flags);
 
 	/*************************** Setup *************************/
 	/* pqilistener */

--- a/libretroshare/src/pqi/pqissl.h
+++ b/libretroshare/src/pqi/pqissl.h
@@ -184,21 +184,21 @@ bool  	CheckConnectionTimeout();
 	// addition for udp (tcp version == ACTIVE).
 	int sslmode;     
 
-	SSL *ssl_connection;
+	SSL* ssl_connection;
 	int sockfd;
 
-	struct sockaddr_storage remote_addr;
+	sockaddr_storage remote_addr;
 
 	void *readpkt;
 	int pktlen;
 	int total_len ; // saves the reading state accross successive calls.
 
-	int attempt_ts;
+	rstime_t attempt_ts;
 
 	int n_read_zero; /* a counter to determine if the connection is really dead */
 	rstime_t mReadZeroTS; /* timestamp of first READ_ZERO occurance */
 
-	int ssl_connect_timeout; /* timeout to ensure that we don't get stuck (can happen on udp!) */
+	rstime_t ssl_connect_timeout; /* timeout to ensure that we don't get stuck (can happen on udp!) */
 
 	uint32_t mConnectDelay;
 	rstime_t   mConnectTS;

--- a/libretroshare/src/pqi/pqissl.h
+++ b/libretroshare/src/pqi/pqissl.h
@@ -3,8 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2004-2006 by Robert Fernie <retroshare@lunamutt.com>              *
- * Copyright (C) 2015-2018  Gioacchino Mazzurco <gio@eigenlab.org>             *
+ * Copyright (C) 2004-2006  Robert Fernie <retroshare@lunamutt.com>            *
+ * Copyright (C) 2015-2019  Gioacchino Mazzurco <gio@eigenlab.org>             *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -20,8 +20,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef MRK_PQI_SSL_HEADER
-#define MRK_PQI_SSL_HEADER
+#pragma once
 
 // operating system specific network header.
 #include "pqi/pqinetwork.h"
@@ -31,6 +30,11 @@
 
 #include "pqi/pqi_base.h"
 #include "pqi/authssl.h"
+#include "util/rsdebug.h"
+
+#ifndef RS_DEBUG_PQISSL
+#	define RS_DEBUG_PQISSL 1
+#endif
 
 #define WAITING_NOT            0
 #define WAITING_DELAY	       1
@@ -119,7 +123,6 @@ int accept(SSL *ssl, int fd, const struct sockaddr_storage &foreign_addr);
 void getCryptoParams(RsPeerCryptoParams& params) ;
 bool actAsServer();
 
-
 protected:
 
 
@@ -158,8 +161,6 @@ virtual int Basic_Connection_Complete();
 int Initiate_SSL_Connection();
 int SSL_Connection_Complete();
 int Authorise_SSL_Connection();
-
-int Extract_Failed_SSL_Certificate(); // try to get cert anyway.
 
 	// check connection timeout.
 bool  	CheckConnectionTimeout();
@@ -207,9 +208,23 @@ bool  	CheckConnectionTimeout();
 private:
 	// ssl only fns.
 	int connectInterface(const struct sockaddr_storage &addr);
+
+protected:
+#if defined(RS_DEBUG_PQISSL) && RS_DEBUG_PQISSL == 1
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQISSL) && RS_DEBUG_PQISSL == 2
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQISSL) && RS_DEBUG_PQISSL >= 3
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsDbg;
+#else // RS_DEBUG_PQISSL
+	using Dbg1 = RsNoDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#endif // RS_DEBUG_PQISSL
 };
-
-
-
-
-#endif // MRK_PQI_SSL_HEADER

--- a/libretroshare/src/pqi/pqissllistener.h
+++ b/libretroshare/src/pqi/pqissllistener.h
@@ -19,8 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef MRK_PQI_SSL_LISTEN_HEADER
-#define MRK_PQI_SSL_LISTEN_HEADER
+#pragma once
 
 #include <openssl/ssl.h>
 
@@ -34,6 +33,10 @@
 #include "pqi/pqilistener.h"
 
 #include "pqi/authssl.h"
+
+#ifndef RS_DEBUG_PQISSLLISTENER
+#	define RS_DEBUG_PQISSLLISTENER 1
+#endif
 
 /***************************** pqi Net SSL Interface *********************************
  */
@@ -98,10 +101,39 @@ protected:
 	p3PeerMgr *mPeerMgr;
 
 private:
+	/**
+	 * @deprecated When this function get called the information is usually not
+	 * available anymore because the authentication is completely handled by
+	 * OpenSSL through @see AuthSSL::VerifyX509Callback, so debug messages and
+	 * notifications generated from this functions are most of the time
+	 * misleading saying that the certificate wasn't provided by the peer, while
+	 * it have been provided but already deleted by OpenSSL.
+	 */
+	RS_DEPRECATED
 	int Extract_Failed_SSL_Certificate(const IncomingSSLInfo&);
+
 	bool active;
 	int lsock;
-	std::list<IncomingSSLInfo> incoming_ssl ;
+	std::list<IncomingSSLInfo> incoming_ssl;
+
+protected:
+#if defined(RS_DEBUG_PQISSLLISTENER) && RS_DEBUG_PQISSLLISTENER == 1
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQISSLLISTENER) && RS_DEBUG_PQISSLLISTENER == 2
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_PQISSLLISTENER) && RS_DEBUG_PQISSLLISTENER >= 3
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsDbg;
+#else // RS_DEBUG_PQISSLLISTENER
+	using Dbg1 = RsNoDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#endif // RS_DEBUG_PQISSLLISTENER
 };
 
 
@@ -123,6 +155,3 @@ public:
 private:
 	std::map<RsPeerId, pqissl*> listenaddr;
 };
-
-
-#endif // MRK_PQI_SSL_LISTEN_HEADER

--- a/libretroshare/src/pqi/sslfns.cc
+++ b/libretroshare/src/pqi/sslfns.cc
@@ -502,7 +502,7 @@ X509 *loadX509FromPEM(std::string pem)
 
 	BIO *bp = BIO_new_mem_buf(certstr, -1);
 
-	X509 *pc = PEM_read_bio_X509(bp, NULL, NULL, NULL);
+	X509* pc = PEM_read_bio_X509(bp, nullptr, nullptr, nullptr);
 
 	BIO_free(bp);
 	free(certstr);
@@ -589,7 +589,7 @@ bool getX509id(X509 *x509, RsPeerId& xid)
 #endif
 
 	xid.clear() ;
-	if (x509 == NULL)
+	if (x509 == nullptr)
 	{
 #ifdef AUTHSSL_DEBUG
 		std::cerr << "AuthSSL::getX509id() NULL pointer";
@@ -675,13 +675,6 @@ int pem_passwd_cb(char *buf, int size, int rwflag, void *password)
 	return(strlen(buf));
 }
 
-/* XXX FIX */
-bool CheckX509Certificate(X509 */*x509*/)
-{
-
-	return true;
-}
-
 uint64_t getX509SerialNumber(X509 *cert)
 {
 	ASN1_INTEGER *serial = X509_get_serialNumber(cert);
@@ -730,19 +723,12 @@ int	LoadCheckX509(const char *cert_file, RsPgpId& issuerName, std::string &locat
 	}
 
 	// get xPGP certificate.
-	X509 *x509 = PEM_read_X509(tmpfp, NULL, NULL, NULL);
+	X509 *x509 = PEM_read_X509(tmpfp, nullptr, nullptr, nullptr);
 	fclose(tmpfp);
 
 	// check the certificate.
 	bool valid = false;
-	if (x509)
-	{
-                valid = CheckX509Certificate(x509);
-		if (valid)
-		{
-                	valid = getX509id(x509, userId);
-		}
-	}
+	if(x509) valid = getX509id(x509, userId);
 
 	if (valid)
 	{

--- a/libretroshare/src/pqi/sslfns.h
+++ b/libretroshare/src/pqi/sslfns.h
@@ -113,7 +113,6 @@ bool getX509id(X509 *x509, RsPeerId &xid);
 
 int pem_passwd_cb(char *buf, int size, int rwflag, void *password);
 
-bool CheckX509Certificate(X509 *x509);
 // Not dependent on sslroot. load, and detroys the X509 memory.
 int	LoadCheckX509(const char *cert_file, RsPgpId& issuer, std::string &location, RsPeerId& userId);
 

--- a/libretroshare/src/retroshare/rsdisc.h
+++ b/libretroshare/src/retroshare/rsdisc.h
@@ -29,6 +29,7 @@
 
 #include "retroshare/rstypes.h"
 #include "retroshare/rsevents.h"
+#include "util/rsmemory.h"
 
 /* The Main Interface Class - for information about your Peers */
 class RsDisc;
@@ -47,20 +48,19 @@ extern RsDisc* rsDisc;
 /**
  * @brief Emitted when a pending PGP certificate is received
  */
-struct RsDiscPendingPgpReceivedEvent : RsEvent
+struct RsGossipDiscoveryPendingPgpFriendInviteReceivedEvent : RsEvent
 {
-	RsDiscPendingPgpReceivedEvent(const RsPgpId& pgpId, std::string pgpCert);
+	RsGossipDiscoveryPendingPgpFriendInviteReceivedEvent(
+	        const std::string& invite );
 
-	RsPgpId mPgpId;
-	std::string mPgpCert;
+	std::string mInvite;
 
 	/// @see RsSerializable
-	virtual void serial_process(RsGenericSerializer::SerializeJob j,
-	                            RsGenericSerializer::SerializeContext& ctx)
+	virtual void serial_process( RsGenericSerializer::SerializeJob j,
+	                             RsGenericSerializer::SerializeContext& ctx )
 	{
 		RsEvent::serial_process(j,ctx);
-		RS_SERIAL_PROCESS(mPgpId);
-		RS_SERIAL_PROCESS(mPgpCert);
+		RS_SERIAL_PROCESS(mInvite);
 	}
 };
 
@@ -104,22 +104,32 @@ public:
 	virtual bool getWaitingDiscCount(size_t &sendCount, size_t &recvCount) = 0;
 
 	/**
-	 * @brief Send PGP certificate to given peer
+	 * @brief Send RetroShare invite to given peer
 	 * @jsonapi{development}
-	 * @param[in] pgpId id of the PGP certificate to send
-	 * @param[in] toSslId ssl id of the destination
+	 * @param[in] inviteId id of peer of which send the invite
+	 * @param[in] toSslId ssl id of the destination peer
+	 * @param[out] errorMessage Optional storage for the error message,
+	 *	meaningful only on failure.
+	 * @return true on success false otherwise
 	 */
-	virtual void sendPGPCertificate(
-	        const RsPgpId& pgpId, const RsPeerId& toSslId ) = 0;
+	virtual bool sendInvite(
+	        const RsPeerId& inviteId, const RsPeerId& toSslId,
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) = 0;
 
 	/**
-	 * @brief Request PGP certificate to given peer
+	 * @brief Request RetroShare certificate to given peer
 	 * @jsonapi{development}
-	 * @param[in] pgpId id of the PGP certificate to request
+	 * @param[in] inviteId id of the peer of which request the invite
 	 * @param[in] toSslId id of the destination of the request
+	 * @param[out] errorMessage Optional storage for the error message,
+	 *	meaningful only on failure.
+	 * @return true on success false otherwise
 	 */
-	virtual void requestPGPCertificate(
-	        const RsPgpId& pgpId, const RsPeerId& toSslId ) = 0;
+	virtual bool requestInvite(
+	        const RsPeerId& inviteId, const RsPeerId& toSslId,
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) = 0;
 
 	virtual ~RsDisc();
 };

--- a/libretroshare/src/retroshare/rsevents.h
+++ b/libretroshare/src/retroshare/rsevents.h
@@ -57,6 +57,9 @@ enum class RsEventType : uint32_t
 	/// @see AuthSSL
 	AUTHSSL_CONNECTION_AUTENTICATION                        = 3,
 
+	/// @see pqissl
+	REMOTE_PEER_REFUSED_CONNECTION                          = 4,
+
 	MAX       /// Used to detect invalid event type passed
 };
 

--- a/libretroshare/src/retroshare/rsevents.h
+++ b/libretroshare/src/retroshare/rsevents.h
@@ -48,7 +48,14 @@ enum class RsEventType : uint32_t
 {
 	NONE = 0, /// Used to detect uninitialized event
 
-	BROADCAST_DISCOVERY_PEER_FOUND = 1, /// @see RsBroadcastDiscovery
+	/// @see RsBroadcastDiscovery
+	BROADCAST_DISCOVERY_PEER_FOUND                          = 1,
+
+	/// @see RsDiscPendingPgpReceivedEvent
+	GOSSIP_DISCOVERY_PENDIG_PGP_CERT_RECEIVED               = 2,
+
+	/// @see AuthSSL
+	AUTHSSL_CONNECTION_AUTENTICATION                        = 3,
 
 	MAX       /// Used to detect invalid event type passed
 };
@@ -74,8 +81,8 @@ public:
 	 * of serial_process
 	 * @see RsSerializable
 	 */
-	virtual void serial_process(RsGenericSerializer::SerializeJob j,
-	                            RsGenericSerializer::SerializeContext& ctx)
+	void serial_process( RsGenericSerializer::SerializeJob j,
+	                     RsGenericSerializer::SerializeContext& ctx) override
 	{
 		RS_SERIAL_PROCESS(mType);
 
@@ -84,7 +91,7 @@ public:
 		mTimePoint = std::chrono::system_clock::from_time_t(mTime);
 	}
 
-	virtual ~RsEvent();
+	virtual ~RsEvent() override;
 };
 
 typedef uint32_t RsEventsHandlerId_t;

--- a/libretroshare/src/retroshare/rsgxsifacetypes.h
+++ b/libretroshare/src/retroshare/rsgxsifacetypes.h
@@ -34,10 +34,7 @@
 #include "serialiser/rstypeserializer.h"
 #include "util/rstime.h"
 
-typedef GXSGroupId   RsGxsGroupId;
 typedef Sha1CheckSum RsGxsMessageId;
-typedef GXSId        RsGxsId;
-typedef GXSCircleId  RsGxsCircleId;
 
 typedef std::map<RsGxsGroupId, std::set<RsGxsMessageId> > GxsMsgIdResult;
 typedef std::pair<RsGxsGroupId, RsGxsMessageId> RsGxsGrpMsgIdPair;

--- a/libretroshare/src/retroshare/rsgxstunnel.h
+++ b/libretroshare/src/retroshare/rsgxstunnel.h
@@ -29,8 +29,6 @@
 class RsGxsTunnelService
 {
 public:
-    typedef GXSTunnelId RsGxsTunnelId ;
-    
     enum {
 	RS_GXS_TUNNEL_ERROR_NO_ERROR          = 0x0000,
 	RS_GXS_TUNNEL_ERROR_UNKNOWN_GXS_ID    = 0x0001  

--- a/libretroshare/src/retroshare/rsids.h
+++ b/libretroshare/src/retroshare/rsids.h
@@ -3,7 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2013 by Cyril Soler <csoler@users.sourceforge.net>                *
+ * Copyright (C) 2013  Cyril Soler <csoler@users.sourceforge.net>              *
+ * Copyright (C) 2019  Gioacchino Mazzurco <gio@eigenlab.org>                  *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -19,35 +20,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-
-// This class aims at defining a generic ID type that is a list of bytes. It
-// can be converted into a hexadecial string for printing, mainly) or for
-// compatibility with old methods.
-//
-// To use this class, derive your own ID type from it. Examples include:
-//
-// 	class RsPgpId: public t_RsGenericIdType<8> 
-// 	{
-// 		[..]
-// 	};
-//
-// 	class PGPFingerprintType: public t_RsGenericIdType<20> 
-// 	{
-// 		[..]
-// 	};
-//
-// With this, there is no implicit conversion between subtypes, and therefore ID mixup 
-// is impossible.
-//
-// A simpler way to make ID types is to 
-// 	typedef t_RsGenericIdType<MySize> MyType ;
-//
-// ID Types with different lengths will be incompatible on compilation.
-//
-// Warning: never store references to a t_RsGenericIdType accross threads, since the 
-// 			cached string convertion is not thread safe.
-//
-
 #pragma once
 
 #include <stdexcept>
@@ -55,125 +27,212 @@
 #include <iostream>
 #include <ostream>
 #include <string.h>
-#include <stdint.h>
-#include <util/rsrandom.h>
+#include <cstdint>
 #include <vector>
 #include <list>
 #include <set>
+#include <memory>
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER> class t_RsGenericIdType
+#include "util/rsdebug.h"
+#include "util/rsrandom.h"
+#include "util/stacktrace.h"
+
+/**
+ * RsGenericIdType values might be random, but must be different, in order to
+ * make the various IDs incompatible with each other.
+ */
+enum class RsGenericIdType
 {
-	public:
-
-		typedef std::list<t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> > std_list;
-		typedef std::vector<t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> > std_vector;
-		typedef std::set<t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> > std_set;
-
-		t_RsGenericIdType() 
-		{ 
-			memset(bytes,0,ID_SIZE_IN_BYTES) ; 	// by default, ids are set to null()
-		}
-		virtual ~t_RsGenericIdType() {}
-
-		// Explicit constructor from a hexadecimal string
-		//
-		explicit t_RsGenericIdType(const std::string& hex_string) ;
-
-		// Explicit constructor from a byte array. The array should have size at least ID_SIZE_IN_BYTES
-		//
-		explicit t_RsGenericIdType(const unsigned char bytes[]) ;
-
-		// Explicit constructor from a different type, checking that the sizes are compatible.
-		// This is used for conversions such as 
-		//
-		// 		GroupId -> CircleId
-		// 		GroupId -> GxsId
-		//
-		template<bool UPPER_CASE2,uint32_t UNIQUE_IDENTIFIER2>
-		explicit t_RsGenericIdType(const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE2,UNIQUE_IDENTIFIER2>& id)
-		{
-			memcpy(bytes,id.toByteArray(),ID_SIZE_IN_BYTES) ;
-		}
-
-        // Random initialization. Can be useful for testing and to generate new ids.
-		//
-		static t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> random() 
-		{
-			t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> id ;
-
-            RSRandom::random_bytes(id.bytes,ID_SIZE_IN_BYTES) ;
-
-			return id ;
-		}
-
-		inline void clear() { memset(bytes,0,SIZE_IN_BYTES) ; }
-
-		// Converts to a std::string using cached value. 
-		//
-		const unsigned char *toByteArray() const { return &bytes[0] ; }
-		static const uint32_t SIZE_IN_BYTES = ID_SIZE_IN_BYTES ;
-
-		inline bool operator==(const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& fp) const { return !memcmp(bytes,fp.bytes,ID_SIZE_IN_BYTES) ; }
-		inline bool operator!=(const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& fp) const { return !!memcmp(bytes,fp.bytes,ID_SIZE_IN_BYTES); }
-		inline bool operator< (const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& fp) const { return (memcmp(bytes,fp.bytes,ID_SIZE_IN_BYTES) < 0) ; }
-		inline t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>
-		operator~ () const
-		{
-			t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> ret;
-			for(uint32_t i=0; i < ID_SIZE_IN_BYTES; ++i)
-				ret.bytes[i] = ~bytes[i];
-			return ret;
-		}
-		inline t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>
-		operator| (const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& fp) const
-		{
-			t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> ret;
-			for(uint32_t i=0; i < ID_SIZE_IN_BYTES; ++i)
-				ret.bytes[i] = bytes[i] | fp.bytes[i];
-			return ret;
-		}
-
-		inline bool isNull() const 
-		{ 
-			for(uint32_t i=0;i<SIZE_IN_BYTES;++i) 
-				if(bytes[i] != 0)
-					return false ;
-			return true ;
-		} 
-
-		friend std::ostream& operator<<(std::ostream& out,const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& id)
-		{
-			return out << id.toStdString(UPPER_CASE) ;
-		}
-
-		inline std::string toStdString() const { return toStdString(UPPER_CASE) ; }
-
-        inline static uint32_t serial_size() { return SIZE_IN_BYTES ; }
-        bool serialise(void *data,uint32_t pktsize,uint32_t& offset) const
-		{
-			if(offset + SIZE_IN_BYTES > pktsize)
-				return false ;
-
-			memcpy(&((uint8_t*)data)[offset],bytes,SIZE_IN_BYTES) ;
-			offset += SIZE_IN_BYTES ;
-			return true ;
-		}
-		bool deserialise(const void *data,uint32_t pktsize,uint32_t& offset)
-		{
-			if(offset + SIZE_IN_BYTES > pktsize)
-				return false ;
-
-			memcpy(bytes,&((uint8_t*)data)[offset],SIZE_IN_BYTES) ;
-			offset += SIZE_IN_BYTES ;
-			return true ;
-		}
-	private:
-		std::string toStdString(bool upper_case) const ;
-
-		unsigned char bytes[ID_SIZE_IN_BYTES] ;
+	SSL,
+	PGP_ID,
+	SHA1,
+	PGP_FINGERPRINT,
+	GXS_GROUP,
+	GXS_ID,
+	GXS_MSG,
+	GXS_CIRCLE,
+	GROUTER,
+	GXS_TUNNEL,
+	DISTANT_CHAT,
+	NODE_GROUP,
+	SHA256,
+	BIAS_20_BYTES
 };
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER> std::string t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>::toStdString(bool upper_case) const
+/**
+ * This class aims at defining a generic ID type that is a list of bytes. It
+ * can be converted into a hexadecial string for printing, mainly) or for
+ * compatibility with old methods.
+ *
+ * To use this class, derive your own ID type from it.
+ * @see RsPpgFingerprint as an example.
+ *
+ * Take care to define and use a different @see RsGenericIdType for each ne type
+ * of ID you create, to avoid implicit conversion between subtypes, and
+ * therefore accidental ID mixup is impossible.
+ *
+ * ID Types with different lengths are not convertible even using explicit
+ * constructor and compilation would fail if that is attempted.
+ *
+ * Warning: never store references to a t_RsGenericIdType accross threads, since
+ * the cached string convertion is not thread safe.
+ */
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
+struct t_RsGenericIdType
+{
+	using Id_t = t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>;
+	using std_list   = std::list<Id_t>;
+	using std_vector = std::vector<Id_t>;
+	using std_set    = std::set<Id_t>;
+
+	/// by default, ids are set to null()
+	t_RsGenericIdType() { memset(bytes, 0, ID_SIZE_IN_BYTES); }
+
+	/// Explicit constructor from a hexadecimal string
+	explicit t_RsGenericIdType(const std::string& hex_string);
+
+	/**
+	 * @brief Construct from a buffer of at least the size of ID_SIZE_IN_BYTES
+	 * @param[in] buff pointer to the buffer
+	 * @param[in] buffSize buffer size
+	 * @return nullptr on failure pointer to the costructed ID otherwise
+	 */
+	static std::unique_ptr<Id_t> fromBuffer(
+	        const uint8_t* buff, uint32_t buffSize )
+	{
+		if(!buff || buffSize < ID_SIZE_IN_BYTES)
+		{
+			RsErr() << __PRETTY_FUNCTION__ << " invalid paramethers buff: "
+			        << buff << " buffSize: " << buffSize
+			        << " ID_SIZE_IN_BYTES: " << ID_SIZE_IN_BYTES << std::endl;
+			print_stacktrace();
+			return nullptr;
+		}
+
+		std::unique_ptr<Id_t> ret(new Id_t);
+		memmove(ret->bytes, buff, ID_SIZE_IN_BYTES);
+		return ret; // Implicit move semantic
+	}
+
+	/**
+	 * Explicit constructor from a different type but with same size.
+	 *
+	 * This is used for conversions such as
+	 * 	GroupId -> CircleId
+	 * 	GroupId -> GxsId
+	 */
+	template<bool UPPER_CASE2, RsGenericIdType UNIQUE_IDENTIFIER2>
+	explicit t_RsGenericIdType(
+	        const t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE2, UNIQUE_IDENTIFIER2>&
+	        id )
+	{ memmove(bytes, id.toByteArray(), ID_SIZE_IN_BYTES); }
+
+	/// Random initialization. Can be useful for testing and to generate new ids.
+	static Id_t random()
+	{
+		Id_t id;
+		RSRandom::random_bytes(id.bytes, ID_SIZE_IN_BYTES);
+		return id;
+	}
+
+	inline void clear() { memset(bytes, 0, SIZE_IN_BYTES); }
+
+	/// Converts to a std::string using cached value.
+	const uint8_t* toByteArray() const { return &bytes[0]; }
+
+	static constexpr uint32_t SIZE_IN_BYTES = ID_SIZE_IN_BYTES;
+
+	inline bool operator==(const Id_t& fp) const
+	{ return !memcmp(bytes, fp.bytes, ID_SIZE_IN_BYTES); }
+
+	inline bool operator!=(const Id_t& fp) const
+	{ return !!memcmp(bytes, fp.bytes, ID_SIZE_IN_BYTES); }
+
+	inline bool operator< (const Id_t& fp) const
+	{ return (memcmp(bytes, fp.bytes, ID_SIZE_IN_BYTES) < 0); }
+
+	inline Id_t operator~ () const
+	{
+		Id_t ret;
+		for(uint32_t i=0; i < ID_SIZE_IN_BYTES; ++i)
+			ret.bytes[i] = ~bytes[i];
+		return ret;
+	}
+
+	inline Id_t operator| (const Id_t& fp) const
+	{
+		Id_t ret;
+		for(uint32_t i=0; i < ID_SIZE_IN_BYTES; ++i)
+			ret.bytes[i] = bytes[i] | fp.bytes[i];
+		return ret;
+	}
+
+	inline bool isNull() const
+	{
+		for(uint32_t i=0; i < SIZE_IN_BYTES; ++i)
+		if(bytes[i] != 0) return false;
+		return true;
+	}
+
+	friend std::ostream& operator<<(std::ostream& out, const Id_t& id)
+	{
+		switch (UNIQUE_IDENTIFIER)
+		{
+		case RsGenericIdType::PGP_FINGERPRINT:
+		{
+			uint8_t index = 0;
+			for(char c : id.toStdString())
+			{
+				out << c;
+				if(++index % 4 == 0 && index < id.SIZE_IN_BYTES*2) out << ' ';
+			}
+		}
+		break;
+		default: out << id.toStdString(UPPER_CASE); break;
+		}
+
+		return out;
+	}
+
+	inline std::string toStdString() const { return toStdString(UPPER_CASE); }
+
+	inline static uint32_t serial_size() { return SIZE_IN_BYTES; }
+
+	bool serialise(void* data,uint32_t pktsize,uint32_t& offset) const
+	{
+		if(offset + SIZE_IN_BYTES > pktsize) return false;
+		memmove( &(reinterpret_cast<uint8_t*>(data))[offset],
+		         bytes, SIZE_IN_BYTES );
+		offset += SIZE_IN_BYTES;
+		return true;
+	}
+
+	bool deserialise(const void* data, uint32_t pktsize, uint32_t& offset)
+	{
+		if(offset + SIZE_IN_BYTES > pktsize) return false;
+		memmove( bytes,
+		         &(reinterpret_cast<const uint8_t*>(data))[offset],
+		         SIZE_IN_BYTES );
+		offset += SIZE_IN_BYTES;
+		return true;
+	}
+
+	/** Explicit constructor from a byte array. The array must have size at
+	 * least ID_SIZE_IN_BYTES
+	 * @deprecated This is too dangerous!
+	 * Nothing prevent a buffer of wrong size being passed at runtime!
+	 */
+	RS_DEPRECATED_FOR("t_RsGenericIdType::fromBuffer(...)")
+	explicit t_RsGenericIdType(const uint8_t bytes[]);
+
+private:
+	std::string toStdString(bool upper_case) const;
+	uint8_t bytes[ID_SIZE_IN_BYTES];
+};
+
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
+std::string t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>
+::toStdString(bool upper_case) const
 {
 	static const char outh[16] = { '0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F' } ;
 	static const char outl[16] = { '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' } ;
@@ -195,14 +254,20 @@ template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER> s
 	return res ;
 }
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER> t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>::t_RsGenericIdType(const std::string& s) 
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
+t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>
+::t_RsGenericIdType(const std::string& s)
 {
-	int n=0;
+	std::string::size_type n = 0;
 	if(s.length() != ID_SIZE_IN_BYTES*2)
 	{
 		if(!s.empty())
-			std::cerr << "t_RsGenericIdType<>::t_RsGenericIdType(std::string&): supplied string in constructor has wrong size. Expected ID size=" << ID_SIZE_IN_BYTES*2 << " String=\"" << s << "\" = " << s.length() << std::endl;
-
+		{
+			RsErr() << __PRETTY_FUNCTION__ << " supplied string in constructor "
+			        << "has wrong size. Expected ID size=" << ID_SIZE_IN_BYTES*2
+			        << " String=\"" << s << "\" = " << s.length() << std::endl;
+			print_stacktrace();
+		}
 		clear();
 		return;
 	}
@@ -221,58 +286,52 @@ template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER> t
 				bytes[i] += (b-'a'+10) << 4*(1-k) ;
 			else if(b >= '0' && b <= '9')
 				bytes[i] += (b-'0') << 4*(1-k) ;
-			else {
-                std::cerr << "t_RsGenericIdType<>::t_RsGenericIdType(std::string&): supplied string is not purely hexadecimal: s=\"" << s << "\"" << std::endl;
-                clear();
+			else
+			{
+				RsErr() << __PRETTY_FUNCTION__ << "supplied string is not "
+				        << "purely hexadecimal: s=\"" << s << "\"" << std::endl;
+				clear();
 				return;
 			}
 		}
 	}
 }
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER> t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>::t_RsGenericIdType(const unsigned char *mem) 
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
+RS_DEPRECATED_FOR("t_RsGenericIdType::fromBuffer(...)")
+t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>::
+t_RsGenericIdType(const uint8_t mem[]) /// @deprecated Too dangerous!
 {
-	if(mem == NULL)
-		memset(bytes,0,ID_SIZE_IN_BYTES) ;
-	else
-		memcpy(bytes,mem,ID_SIZE_IN_BYTES) ;
+	if(mem == nullptr) memset(bytes, 0, ID_SIZE_IN_BYTES);
+	else memcpy(bytes, mem, ID_SIZE_IN_BYTES);
 }
 
-static const int SSL_ID_SIZE              = 16 ;	// = CERTSIGNLEN
-static const int CERT_SIGN_LEN            = 16 ;	// = CERTSIGNLEN
-static const int PGP_KEY_ID_SIZE          =  8 ;
-static const int PGP_KEY_FINGERPRINT_SIZE = 20 ;
-static const int SHA1_SIZE                = 20 ;
-static const int SHA256_SIZE              = 32 ;
+/**
+ * This constants are meant to be used only inside this file.
+ * Use @see t_RsGenericIdType::SIZE_IN_BYTES in other places.
+ */
+namespace _RsIdSize
+{
+constexpr uint32_t SSL_ID          = 16;   // = CERT_SIGN
+constexpr uint32_t CERT_SIGN       = 16;   // = SSL_ID
+constexpr uint32_t PGP_ID          =  8;
+constexpr uint32_t PGP_FINGERPRINT = 20;
+constexpr uint32_t SHA1            = 20;
+constexpr uint32_t SHA256          = 32;
+}
 
-// These constants are random, but should be different, in order to make the various IDs incompatible with each other.
-//
-static const uint32_t RS_GENERIC_ID_SSL_ID_TYPE              = 0x0001 ;
-static const uint32_t RS_GENERIC_ID_PGP_ID_TYPE              = 0x0002 ;
-static const uint32_t RS_GENERIC_ID_SHA1_ID_TYPE             = 0x0003 ;
-static const uint32_t RS_GENERIC_ID_PGP_FINGERPRINT_TYPE     = 0x0004 ;
-static const uint32_t RS_GENERIC_ID_GXS_GROUP_ID_TYPE        = 0x0005 ;
-static const uint32_t RS_GENERIC_ID_GXS_ID_TYPE              = 0x0006 ;
-static const uint32_t RS_GENERIC_ID_GXS_MSG_ID_TYPE          = 0x0007 ;
-static const uint32_t RS_GENERIC_ID_GXS_CIRCLE_ID_TYPE       = 0x0008 ;
-static const uint32_t RS_GENERIC_ID_GROUTER_ID_TYPE          = 0x0009 ;
-static const uint32_t RS_GENERIC_ID_GXS_TUNNEL_ID_TYPE       = 0x0010 ;
-static const uint32_t RS_GENERIC_ID_GXS_DISTANT_CHAT_ID_TYPE = 0x0011 ;
-static const uint32_t RS_GENERIC_ID_NODE_GROUP_ID_TYPE       = 0x0012 ;
-static const uint32_t RS_GENERIC_ID_SHA256_ID_TYPE           = 0x0013 ;
-static const uint32_t RS_GENERIC_ID_20_BYTES_UNTYPED         = 0x0014 ;
+using RsPeerId          = t_RsGenericIdType<_RsIdSize::SSL_ID         , false, RsGenericIdType::SSL            >;
+using RsPgpId           = t_RsGenericIdType<_RsIdSize::PGP_ID         , true,  RsGenericIdType::PGP_ID         >;
+using Sha1CheckSum      = t_RsGenericIdType<_RsIdSize::SHA1           , false, RsGenericIdType::SHA1           >;
+using Sha256CheckSum    = t_RsGenericIdType<_RsIdSize::SHA256         , false, RsGenericIdType::SHA256         >;
+using RsPpgFingerprint  = t_RsGenericIdType<_RsIdSize::PGP_FINGERPRINT, true,  RsGenericIdType::PGP_FINGERPRINT>;
+using Bias20Bytes       = t_RsGenericIdType<_RsIdSize::SHA1           , true,  RsGenericIdType::BIAS_20_BYTES  >;
+using RsGxsGroupId      = t_RsGenericIdType<_RsIdSize::CERT_SIGN      , false, RsGenericIdType::GXS_GROUP      >;
+using RsGxsId           = t_RsGenericIdType<_RsIdSize::CERT_SIGN      , false, RsGenericIdType::GXS_ID         >;
+using RsGxsCircleId     = t_RsGenericIdType<_RsIdSize::CERT_SIGN      , false, RsGenericIdType::GXS_CIRCLE     >;
+using RsGxsTunnelId     = t_RsGenericIdType<_RsIdSize::SSL_ID         , false, RsGenericIdType::GXS_TUNNEL     >;
+using DistantChatPeerId = t_RsGenericIdType<_RsIdSize::SSL_ID         , false, RsGenericIdType::DISTANT_CHAT   >;
+using RsNodeGroupId     = t_RsGenericIdType<_RsIdSize::CERT_SIGN      , false, RsGenericIdType::NODE_GROUP     >;
 
-typedef t_RsGenericIdType<  SSL_ID_SIZE             , false, RS_GENERIC_ID_SSL_ID_TYPE>          SSLIdType ;
-typedef t_RsGenericIdType<  PGP_KEY_ID_SIZE         , true,  RS_GENERIC_ID_PGP_ID_TYPE>          PGPIdType ;
-typedef t_RsGenericIdType<  SHA1_SIZE               , false, RS_GENERIC_ID_SHA1_ID_TYPE>         Sha1CheckSum ;
-typedef t_RsGenericIdType<  SHA256_SIZE             , false, RS_GENERIC_ID_SHA256_ID_TYPE>       Sha256CheckSum ;
-typedef t_RsGenericIdType<  PGP_KEY_FINGERPRINT_SIZE, true,  RS_GENERIC_ID_PGP_FINGERPRINT_TYPE> PGPFingerprintType ;
-typedef t_RsGenericIdType<  SHA1_SIZE               , true,  RS_GENERIC_ID_20_BYTES_UNTYPED>     Bias20Bytes ;
-
-typedef t_RsGenericIdType<  CERT_SIGN_LEN           , false, RS_GENERIC_ID_GXS_GROUP_ID_TYPE   > GXSGroupId ;
-typedef t_RsGenericIdType<  CERT_SIGN_LEN           , false, RS_GENERIC_ID_GXS_ID_TYPE         > GXSId ;
-typedef t_RsGenericIdType<  CERT_SIGN_LEN           , false, RS_GENERIC_ID_GXS_CIRCLE_ID_TYPE  > GXSCircleId ;
-typedef t_RsGenericIdType<  SSL_ID_SIZE             , false, RS_GENERIC_ID_GXS_TUNNEL_ID_TYPE  > GXSTunnelId ;
-typedef t_RsGenericIdType<  SSL_ID_SIZE             , false, RS_GENERIC_ID_GXS_DISTANT_CHAT_ID_TYPE  > DistantChatPeerId ;
-typedef t_RsGenericIdType<  CERT_SIGN_LEN           , false, RS_GENERIC_ID_NODE_GROUP_ID_TYPE  > RsNodeGroupId ;
-
+/// @deprecated Ugly name kept temporarly only because it is used in many places
+using PGPFingerprintType RS_DEPRECATED_FOR(RsPpgFingerprint) = RsPpgFingerprint;

--- a/libretroshare/src/retroshare/rstypes.h
+++ b/libretroshare/src/retroshare/rstypes.h
@@ -37,15 +37,6 @@
 
 #define USE_NEW_CHUNK_CHECKING_CODE
 
-// This adds a level of indirection to types, so we can easily change them if needed
-//
-//typedef std::string   RsCertId;	// unused
-//typedef std::string   RsChanId;
-//typedef std::string   RsMsgId;
-//typedef std::string   RsAuthId;
-
-typedef SSLIdType     RsPeerId ;
-typedef PGPIdType     RsPgpId ;
 typedef Sha1CheckSum  RsFileHash ;
 typedef Sha1CheckSum  RsMessageId ;
 

--- a/libretroshare/src/rsitems/rsdiscovery2items.cc
+++ b/libretroshare/src/rsitems/rsdiscovery2items.cc
@@ -43,22 +43,21 @@
 
 RsItem *RsDiscSerialiser::create_item(uint16_t service,uint8_t item_subtype) const
 {
-    if(service != RS_SERVICE_TYPE_DISC)
-        return NULL ;
+	if(service != RS_SERVICE_TYPE_DISC) return nullptr;
 
-    switch(item_subtype)
-    {
+	switch(item_subtype)
+	{
 	case RS_PKT_SUBTYPE_DISC_PGP_LIST           : return new RsDiscPgpListItem() ; //= 0x01;
 	case RS_PKT_SUBTYPE_DISC_PGP_CERT           : return new RsDiscPgpCertItem() ;      //= 0x02;
-	case RS_PKT_SUBTYPE_DISC_CONTACT_deprecated : return NULL ;                         //= 0x03;
-#if 0
-	case RS_PKT_SUBTYPE_DISC_SERVICES           : return new RsDiscServicesItem();      //= 0x04;
-#endif
+	case RS_PKT_SUBTYPE_DISC_CONTACT_deprecated : return nullptr;                         //= 0x03;
 	case RS_PKT_SUBTYPE_DISC_CONTACT            : return new RsDiscContactItem();       //= 0x05;
 	case RS_PKT_SUBTYPE_DISC_IDENTITY_LIST      : return new RsDiscIdentityListItem();  //= 0x06;
-    default:
-    return NULL ;
-    }
+	case static_cast<uint8_t>(RsGossipDiscoveryItemType::INVITE):
+		return new RsGossipDiscoveryInviteItem();
+	case static_cast<uint8_t>(RsGossipDiscoveryItemType::INVITE_REQUEST):
+		return  new RsGossipDiscoveryInviteRequestItem();
+	default: return nullptr;
+	}
 }
 
 /*************************************************************************/
@@ -156,3 +155,11 @@ void RsDiscIdentityListItem::serial_process(RsGenericSerializer::SerializeJob j,
     RS_SERIAL_PROCESS(ownIdentityList);
 }
 
+
+RsGossipDiscoveryInviteItem::RsGossipDiscoveryInviteItem() :
+    RsDiscItem(static_cast<uint8_t>(RsGossipDiscoveryItemType::INVITE))
+{ setPriorityLevel(QOS_PRIORITY_RS_DISC_ASK_INFO); }
+
+RsGossipDiscoveryInviteRequestItem::RsGossipDiscoveryInviteRequestItem() :
+    RsDiscItem(static_cast<uint8_t>(RsGossipDiscoveryItemType::INVITE_REQUEST))
+{ setPriorityLevel(QOS_PRIORITY_RS_DISC_REPLY); }

--- a/libretroshare/src/rsitems/rsdiscovery2items.h
+++ b/libretroshare/src/rsitems/rsdiscovery2items.h
@@ -31,17 +31,24 @@
 
 #include "serialiser/rsserializer.h"
 
+// TODO: port to RsGossipDiscoveryItemType
 const uint8_t RS_PKT_SUBTYPE_DISC_PGP_LIST           = 0x01;
 const uint8_t RS_PKT_SUBTYPE_DISC_PGP_CERT           = 0x02;
 const uint8_t RS_PKT_SUBTYPE_DISC_CONTACT_deprecated = 0x03;
-const uint8_t RS_PKT_SUBTYPE_DISC_SERVICES           = 0x04;
 const uint8_t RS_PKT_SUBTYPE_DISC_CONTACT            = 0x05;
 const uint8_t RS_PKT_SUBTYPE_DISC_IDENTITY_LIST      = 0x06;
 
+enum class RsGossipDiscoveryItemType : uint8_t
+{
+	INVITE = 7,
+	INVITE_REQUEST = 8
+};
+
 class RsDiscItem: public RsItem
 {
-	protected:
-		RsDiscItem(uint8_t subtype) :RsItem(RS_PKT_VERSION_SERVICE, RS_SERVICE_TYPE_DISC, subtype) {}
+protected:
+	RsDiscItem(uint8_t subtype) :
+	    RsItem(RS_PKT_VERSION_SERVICE, RS_SERVICE_TYPE_DISC, subtype) {}
 };
 
 
@@ -68,8 +75,6 @@ public:
 	RsTlvPgpIdSet pgpIdSet;
 };
 
-
-
 class RsDiscPgpCertItem: public RsDiscItem
 {
 public:
@@ -88,7 +93,6 @@ public:
 	RsPgpId pgpId;
 	std::string pgpCert;
 };
-
 
 class RsDiscContactItem: public RsDiscItem
 {
@@ -156,38 +160,38 @@ public:
 
     std::list<RsGxsId> ownIdentityList ;
 };
-#if 0
-class RsDiscServicesItem: public RsDiscItem
+
+struct RsGossipDiscoveryInviteItem : RsDiscItem
 {
-	public:
+	RsGossipDiscoveryInviteItem();
 
-	RsDiscServicesItem()
-        :RsDiscItem(RS_PKT_SUBTYPE_DISC_SERVICES)
-	{ 
-		setPriorityLevel(QOS_PRIORITY_RS_DISC_SERVICES); 
-	}
+	void serial_process( RsGenericSerializer::SerializeJob j,
+	                     RsGenericSerializer::SerializeContext& ctx ) override
+	{ RS_SERIAL_PROCESS(mInvite); }
+	void clear() override { mInvite.clear(); }
 
-virtual ~RsDiscServicesItem();
-
-virtual  void clear();
-virtual std::ostream &print(std::ostream &out, uint16_t indent = 0);
-
-
-	std::string version;
-	RsTlvServiceIdMap mServiceIdMap;
+	std::string mInvite;
 };
 
-#endif
+struct RsGossipDiscoveryInviteRequestItem : RsDiscItem
+{
+	RsGossipDiscoveryInviteRequestItem();
 
+	void serial_process( RsGenericSerializer::SerializeJob j,
+	                     RsGenericSerializer::SerializeContext& ctx ) override
+	{ RS_SERIAL_PROCESS(mInviteId); }
+	void clear() override { mInviteId.clear(); }
+
+	RsPeerId mInviteId;
+};
 
 class RsDiscSerialiser: public RsServiceSerializer
 {
-        public:
-        RsDiscSerialiser() :RsServiceSerializer(RS_SERVICE_TYPE_DISC) {}
+public:
+	RsDiscSerialiser() :RsServiceSerializer(RS_SERVICE_TYPE_DISC) {}
+	virtual ~RsDiscSerialiser() {}
 
-		virtual     ~RsDiscSerialiser() {}
-
-        RsItem *create_item(uint16_t service,uint8_t item_subtype) const ;
+	RsItem* create_item(uint16_t service, uint8_t item_subtype) const;
 };
 
 

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -1317,9 +1317,7 @@ std::string p3Peers::GetRetroshareInvite(
 
 	//add the sslid, location, ip local and external address after the signature
 	RsPeerDetails detail;
-	std::string invite;
-
-	if (getPeerDetails(ssl_id, detail))
+	if(getPeerDetails(ssl_id, detail))
 	{
 		if(!includeExtraLocators) detail.ipAddressList.clear();
 
@@ -1327,12 +1325,12 @@ std::string p3Peers::GetRetroshareInvite(
 		size_t mem_block_size = 0;
 
 		if(!AuthGPG::getAuthGPG()->exportPublicKey(
-		            RsPgpId(detail.gpg_id), mem_block, mem_block_size, false,
+		            detail.gpg_id, mem_block, mem_block_size, false,
 		            include_signatures ))
 		{
-			std::cerr << "Cannot output certificate for id \"" << detail.gpg_id
-			          << "\". Sorry." << std::endl;
-			return "";
+			RsErr() << __PRETTY_FUNCTION__ << " Cannot output certificate for "
+			        << "PGP id: " << detail.gpg_id << std::endl;
+			return std::string();
 		}
 
 		RsCertificate cert(detail, mem_block, mem_block_size);
@@ -1341,10 +1339,10 @@ std::string p3Peers::GetRetroshareInvite(
 		return cert.toStdString();
 	}
 
-#ifdef P3PEERS_DEBUG
-	std::cerr << __PRETTY_FUNCTION__ << " returns : \n" << invite << std::endl;
-#endif
-	return invite;
+	RsErr() << __PRETTY_FUNCTION__ << " peer: " << ssl_id
+	        << " not found! Returning empty!" << std::endl;
+
+	return std::string();
 }
 
 //===========================================================================

--- a/libretroshare/src/rsserver/p3peers.h
+++ b/libretroshare/src/rsserver/p3peers.h
@@ -65,7 +65,12 @@ public:
 	virtual bool getPeerCount (unsigned int *friendCount, unsigned int *onlineCount, bool ssl);
 
 	virtual bool isOnline(const RsPeerId &id);
+
 	virtual bool isFriend(const RsPeerId &id);
+
+	/// @see RsPeers
+	bool isFriendPendingPgp(const RsPeerId& sslId) override;
+
 	virtual bool isPgpFriend(const RsPgpId& pgpId);
 
 	RS_DEPRECATED_FOR(isPgpFriend)
@@ -91,6 +96,11 @@ public:
 	virtual	bool addFriend(const RsPeerId &ssl_id, const RsPgpId &gpg_id,ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT);
 	virtual	bool removeFriend(const RsPgpId& gpgid);
 	virtual bool removeFriendLocation(const RsPeerId& sslId);
+
+	/// @see RsPeers
+	bool addFriendPendingPgp(
+	        const RsPeerId& sslId,
+	        const RsPeerDetails& dt = RsPeerDetails() ) override;
 
 	/* keyring management */
 	virtual bool removeKeysFromPGPKeyring(const std::set<RsPgpId> &pgp_ids,std::string& backup_file,uint32_t& error_code);
@@ -123,12 +133,23 @@ public:
 	virtual	std::string GetRetroshareInvite(
 	        const RsPeerId& ssl_id = RsPeerId(),
 	        bool include_signatures = false, bool includeExtraLocators = true );
-	virtual	std::string getPGPKey(const RsPgpId& pgp_id,bool include_signatures);
+
+	virtual std::string getPGPKey(const RsPgpId& pgp_id,bool include_signatures);
+
+	/// @see RsPeers
+	bool getShortInvite(
+	        std::string& invite, const RsPeerId& sslId = RsPeerId(),
+	        bool formatRadix = false, bool includeFingerprint = false,
+	        bool bareBones = false ) override;
 
 	virtual bool GetPGPBase64StringAndCheckSum(const RsPgpId& gpg_id,std::string& gpg_base64_string,std::string& gpg_base64_checksum);
 
 	/// @see RsPeers::acceptInvite
 	virtual bool acceptInvite(
+	        const std::string& invite,
+	        ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT );
+
+	virtual bool acceptLongInvite(
 	        const std::string& invite,
 	        ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT );
 

--- a/libretroshare/src/serialiser/rstypeserializer.h
+++ b/libretroshare/src/serialiser/rstypeserializer.h
@@ -844,36 +844,36 @@ protected:
 // t_RsGenericId<...> declarations                                            //
 //============================================================================//
 
-	template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+	template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 	static bool serialize(
 	        uint8_t data[], uint32_t size, uint32_t &offset,
-	        const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member );
+	        const t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member );
 
-	template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+	template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 	static bool deserialize(
 	        const uint8_t data[], uint32_t size, uint32_t &offset,
-	        t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member );
+	        t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member );
 
-	template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+	template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 	static uint32_t serial_size(
 	        const t_RsGenericIdType<
-	        ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member );
+	        ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member );
 
-	template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+	template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 	static void print_data(
 	        const std::string& name,
 	        const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member );
 
-	template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+	template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 	static bool to_JSON(
 	        const std::string& membername,
-	        const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member,
+	        const t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member,
 	        RsJson& jVal );
 
-	template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+	template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 	static bool from_JSON(
 	        const std::string& memberName,
-	        t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member,
+	        t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member,
 	        RsJson& jDoc );
 
 //============================================================================//
@@ -914,41 +914,43 @@ protected:
 //                            t_RsGenericId<...>                              //
 //============================================================================//
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 bool RsTypeSerializer::serialize (
         uint8_t data[], uint32_t size, uint32_t &offset,
         const t_RsGenericIdType<
-        ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member )
+        ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member )
 {
 	return (*const_cast<const t_RsGenericIdType<
-	      ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER> *>(&member)
-	      ).serialise(data,size,offset);
+	      ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER> *>(&member)
+	      ).serialise(data, size, offset);
 }
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 bool RsTypeSerializer::deserialize(
         const uint8_t data[], uint32_t size, uint32_t &offset,
-        t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member )
-{ return member.deserialise(data,size,offset); }
+        t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member )
+{ return member.deserialise(data, size, offset); }
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 uint32_t RsTypeSerializer::serial_size(
-        const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member )
+        const t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member )
 { return member.serial_size(); }
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
 void RsTypeSerializer::print_data(
         const std::string& /*name*/,
-        const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member )
+        const t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member )
 {
-	std::cerr << "  [RsGenericId<" << std::hex << UNIQUE_IDENTIFIER << ">] : "
+	std::cerr << "  [RsGenericId<" << std::hex
+	          << static_cast<uint32_t>(UNIQUE_IDENTIFIER) << ">] : "
 	          << member << std::endl;
 }
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
-bool RsTypeSerializer::to_JSON( const std::string& memberName,
-                                const t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member,
-                                RsJson& jDoc )
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
+bool RsTypeSerializer::to_JSON(
+        const std::string& memberName,
+        const t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member,
+        RsJson& jDoc )
 {
 	rapidjson::Document::AllocatorType& allocator = jDoc.GetAllocator();
 
@@ -964,10 +966,11 @@ bool RsTypeSerializer::to_JSON( const std::string& memberName,
 	return true;
 }
 
-template<uint32_t ID_SIZE_IN_BYTES,bool UPPER_CASE,uint32_t UNIQUE_IDENTIFIER>
-bool RsTypeSerializer::from_JSON( const std::string& membername,
-                                  t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>& member,
-                                  RsJson& jVal )
+template<uint32_t ID_SIZE_IN_BYTES, bool UPPER_CASE, RsGenericIdType UNIQUE_IDENTIFIER>
+bool RsTypeSerializer::from_JSON(
+        const std::string& membername,
+        t_RsGenericIdType<ID_SIZE_IN_BYTES, UPPER_CASE, UNIQUE_IDENTIFIER>& member,
+        RsJson& jVal )
 {
 	const char* mName = membername.c_str();
 	bool ret = jVal.HasMember(mName);
@@ -975,7 +978,9 @@ bool RsTypeSerializer::from_JSON( const std::string& membername,
 	{
 		rapidjson::Value& v = jVal[mName];
 		ret = ret && v.IsString();
-		if(ret) member = t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>(std::string(v.GetString()));
+		if(ret) member =
+		        t_RsGenericIdType<ID_SIZE_IN_BYTES,UPPER_CASE,UNIQUE_IDENTIFIER>(
+		            std::string(v.GetString()) );
 	}
 	return ret;
 }

--- a/libretroshare/src/services/p3discovery2.cc
+++ b/libretroshare/src/services/p3discovery2.cc
@@ -103,7 +103,7 @@ p3discovery2::p3discovery2(
     p3Service(), mPeerMgr(peerMgr), mLinkMgr(linkMgr), mNetMgr(netMgr),
     mServiceCtrl(sc), mGixs(gixs), mDiscMtx("p3discovery2"), mLastPgpUpdate(0)
 {
-	Dbg2() << __PRETTY_FUNCTION__ << std::endl;
+	Dbg3() << __PRETTY_FUNCTION__ << std::endl;
 
 	RS_STACK_MUTEX(mDiscMtx);
 	addSerialType(new RsDiscSerialiser());
@@ -1264,13 +1264,14 @@ void p3discovery2::rsEventsHandler(const RsEvent& event)
 	{
 	case RsEventType::AUTHSSL_CONNECTION_AUTENTICATION:
 	{
-		Dbg1() << __PRETTY_FUNCTION__ << " AUTHSSL_CONNECTION_AUTENTICATION "
-		       << "event: " << event << std::endl;
-
 		using Evt_t = RsAuthSslConnectionAutenticationEvent;
 		const Evt_t& evt = static_cast<const Evt_t&>(event);
 		if(evt.mIsPendingPpg)
 		{
+			Dbg1() << __PRETTY_FUNCTION__
+			       << " AUTHSSL_CONNECTION_AUTENTICATION event: " << event
+			       << std::endl;
+
 			const RsPeerId& sslId = evt.mSslId;
 			RsThread::async([sslId]()
 			{ /* Make sure the connection is ready before requesting invite. */

--- a/libretroshare/src/services/p3discovery2.cc
+++ b/libretroshare/src/services/p3discovery2.cc
@@ -1283,7 +1283,7 @@ void p3discovery2::rsEventsHandler(const RsEvent& event)
 					if(rsPeers->isOnline(sslId))
 					{
 						// Need to wait a bit more even if online
-						std::this_thread::sleep_for(std::chrono::seconds(2));
+						//std::this_thread::sleep_for(std::chrono::seconds(2));
 						if(rsDisc && rsDisc->requestInvite(sslId, sslId))
 							return; // RsThread::async
 					}

--- a/libretroshare/src/services/p3discovery2.h
+++ b/libretroshare/src/services/p3discovery2.h
@@ -119,7 +119,10 @@ virtual void setGPGOperation(AuthGPGOperation *operation);
 	void processContactInfo(const SSLID &fromId, const RsDiscContactItem *info);
 
 	void requestPGPCertificate(const PGPID &aboutId, const SSLID &toId);
-	void recvPGPCertificateRequest(const SSLID &fromId, const RsDiscPgpListItem *item);
+
+	void recvPGPCertificateRequest(
+	        const RsPeerId& fromId, const RsDiscPgpListItem* item );
+
 	void sendPGPCertificate(const PGPID &aboutId, const SSLID &toId);
 	void recvPGPCertificate(const SSLID &fromId, RsDiscPgpCertItem *item);
 	void recvIdentityList(const RsPeerId& pid,const std::list<RsGxsId>& ids);

--- a/libretroshare/src/services/p3discovery2.h
+++ b/libretroshare/src/services/p3discovery2.h
@@ -3,7 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2004-2013 Robert Fernie <retroshare@lunamutt.com>                 *
+ * Copyright (C) 2004-2013  Robert Fernie <retroshare@lunamutt.com>            *
+ * Copyright (C) 2019  Gioacchino Mazzurco <gio@eigenlab.org>                  *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -19,10 +20,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef MRK_SERVICES_DISCOVERY2_H
-#define MRK_SERVICES_DISCOVERY2_H
+#pragma once
 
 // Discovery2: Improved discovery service.
+
+#include <memory>
 
 #include "retroshare/rsdisc.h"
 
@@ -36,48 +38,47 @@
 #include "pqi/authgpg.h"
 #include "gxs/rsgixs.h"
 
-class p3ServiceControl;
+#ifndef RS_DEBUG_P3DISCOVERY
+#	define RS_DEBUG_P3DISCOVERY 4
+#endif
 
+class p3ServiceControl;
 
 typedef RsPgpId PGPID;
 typedef RsPeerId SSLID;
 
-class DiscSslInfo
+struct DiscSslInfo
 {
-	public:
-	DiscSslInfo() { mDiscStatus = 0; }
+	DiscSslInfo() : mDiscStatus(0) {}
 	uint16_t mDiscStatus;
 };
 
-class DiscPeerInfo
+struct DiscPeerInfo
 {
-	public:
 	DiscPeerInfo() {}
 
 	std::string mVersion;
-	//uint32_t mStatus;
 };
 
-class DiscPgpInfo
+struct DiscPgpInfo
 {
-	public:
 	DiscPgpInfo() {}
 
-void    mergeFriendList(const std::set<PGPID> &friends);
+	void mergeFriendList(const std::set<PGPID> &friends);
 
-	//PGPID mPgpId;
 	std::set<PGPID> mFriendSet;
 	std::map<SSLID, DiscSslInfo> mSslIds;
 };
 
 
-
-class p3discovery2: public RsDisc, public p3Service, public pqiServiceMonitor, public AuthGPGService
+class p3discovery2 : public RsDisc, public p3Service, public pqiServiceMonitor,
+        public AuthGPGService
 {
-	public:
+public:
 
-	p3discovery2(p3PeerMgr *peerMgr, p3LinkMgr *linkMgr, p3NetMgr *netMgr, p3ServiceControl *sc,RsGixs *gixs);
-virtual ~p3discovery2();
+	p3discovery2( p3PeerMgr* peerMgr, p3LinkMgr* linkMgr, p3NetMgr* netMgr,
+	              p3ServiceControl* sc, RsGixs* gixs );
+	virtual ~p3discovery2();
 
 virtual RsServiceInfo getServiceInfo();
 
@@ -92,12 +93,25 @@ virtual RsServiceInfo getServiceInfo();
 	bool getDiscPgpFriends(const RsPgpId &pgpid, std::list<RsPgpId> &gpg_friends);
 	bool getPeerVersion(const RsPeerId &id, std::string &version);
 	bool getWaitingDiscCount(size_t &sendCount, size_t &recvCount);
+
+	/// @see RsDisc
+	bool sendInvite(
+	        const RsPeerId& inviteId, const RsPeerId& toSslId,
+	        std::string& errorMsg = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) override;
+
+	/// @see RsDisc
+	bool requestInvite(
+	        const RsPeerId& inviteId, const RsPeerId& toSslId,
+	        std::string& errorMsg = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) override;
+
         /************* from AuthGPService ****************/
 virtual AuthGPGOperation *getGPGOperation();
 virtual void setGPGOperation(AuthGPGOperation *operation);
 
 
-	private:
+private:
 
 	PGPID getPGPId(const SSLID &id);
 
@@ -129,7 +143,11 @@ virtual void setGPGOperation(AuthGPGOperation *operation);
 
 	bool setPeerVersion(const SSLID &peerId, const std::string &version);
 
-	private:
+	void recvInvite(std::unique_ptr<RsGossipDiscoveryInviteItem> inviteItem);
+
+	void rsEventsHandler(const RsEvent& event);
+	RsEventsHandlerId_t mRsEventsHandle;
+
 
 	p3PeerMgr *mPeerMgr;
 	p3LinkMgr *mLinkMgr;
@@ -150,7 +168,23 @@ virtual void setGPGOperation(AuthGPGOperation *operation);
 
 	std::list<RsDiscPgpCertItem *> mPendingDiscPgpCertInList;
 	std::list<RsDiscPgpCertItem *> mPendingDiscPgpCertOutList;
+
+protected:
+#if defined(RS_DEBUG_P3DISCOVERY) && RS_DEBUG_P3DISCOVERY == 1
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_P3DISCOVERY) && RS_DEBUG_P3DISCOVERY == 2
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsNoDbg;
+#elif defined(RS_DEBUG_P3DISCOVERY) && RS_DEBUG_P3DISCOVERY >= 3
+	using Dbg1 = RsDbg;
+	using Dbg2 = RsDbg;
+	using Dbg3 = RsDbg;
+#else // RS_DEBUG_P3DISCOVERY
+	using Dbg1 = RsNoDbg;
+	using Dbg2 = RsNoDbg;
+	using Dbg3 = RsNoDbg;
+#endif // RS_DEBUG_P3DISCOVERY
 };
-
-
-#endif // MRK_SERVICES_DISCOVERY2_H

--- a/libretroshare/src/util/rsdebug.h
+++ b/libretroshare/src/util/rsdebug.h
@@ -22,6 +22,7 @@
 
 #include <ostream>
 #include <iostream>
+#include <ctime>
 
 #include "util/rsdeprecate.h"
 

--- a/libretroshare/src/util/rsnet.cc
+++ b/libretroshare/src/util/rsnet.cc
@@ -162,6 +162,9 @@ std::ostream &operator<<(std::ostream &out, const struct sockaddr_in &addr)
 	return out;
 }
 
+std::ostream& operator<<(std::ostream& o, const sockaddr_storage& addr)
+{ return o << sockaddr_storage_tostring(addr); }
+
 /* thread-safe version of inet_ntoa */
 
 std::string rs_inet_ntoa(struct in_addr in)

--- a/libretroshare/src/util/rsnet.h
+++ b/libretroshare/src/util/rsnet.h
@@ -84,7 +84,8 @@ bool isExternalNet(const struct in_addr *addr);
 // uses a re-entrant version of gethostbyname
 bool rsGetHostByName(const std::string& hostname, in_addr& returned_addr) ;
 
-std::ostream& operator<<(std::ostream& o,const struct sockaddr_in&) ;
+std::ostream& operator<<(std::ostream& o, const sockaddr_in&);
+std::ostream& operator<<(std::ostream& o, const sockaddr_storage&);
 
 /* thread-safe version of inet_ntoa */
 std::string rs_inet_ntoa(struct in_addr in);
@@ -143,10 +144,6 @@ std::string sockaddr_storage_familytostring(const struct sockaddr_storage &addr)
 std::string sockaddr_storage_iptostring(const struct sockaddr_storage &addr);
 std::string sockaddr_storage_porttostring(const struct sockaddr_storage &addr);
 void sockaddr_storage_dump(const sockaddr_storage & addr, std::string * outputString = NULL);
-
-// output
-//void sockaddr_storage_output(const struct sockaddr_storage &addr, std::ostream &out);
-//void sockaddr_storage_ipoutput(const struct sockaddr_storage &addr, std::ostream &out);
 
 // net checks.
 bool sockaddr_storage_isnull(const struct sockaddr_storage &addr);

--- a/libretroshare/src/util/rsrandom.h
+++ b/libretroshare/src/util/rsrandom.h
@@ -21,15 +21,20 @@
  *******************************************************************************/
 #pragma once
 
-// RSRandom contains a random number generator that is
-// - thread safe
-// - system independant
-// - fast
-// - CRYPTOGRAPHICALLY SAFE, because it is based on openssl random number generator
-
 #include <vector>
 #include <util/rsthreads.h>
 
+/**
+ * RsRandom provide a random number generator that is
+ * - thread safe
+ * - system independant
+ * - fast
+ * - CRYPTOGRAPHICALLY SAFE, because it is based on openssl random number
+ *   generator
+ *
+ * Use the RsRandom alias instead of RSRandom name to be consistent with the
+ * RetroShare class naming
+ */
 class RSRandom
 {
 	public:
@@ -52,3 +57,5 @@ class RSRandom
 		static uint32_t index ;
 		static std::vector<uint32_t> MT ;
 };
+
+using RsRandom = RSRandom;

--- a/libretroshare/src/util/rsurl.cc
+++ b/libretroshare/src/util/rsurl.cc
@@ -201,6 +201,13 @@ RsUrl& RsUrl::delQueryK(const std::string& key)
 	mQuery.erase(key);
 	return *this;
 }
+bool RsUrl::hasQueryK(const std::string& key)
+{ return (mQuery.find(key) != mQuery.end()); }
+const std::string* RsUrl::getQueryV(const std::string& key)
+{
+	if(hasQueryK(key)) return &(mQuery.find(key)->second);
+	return nullptr;
+}
 
 const std::string& RsUrl::fragment() const { return mFragment; }
 RsUrl& RsUrl::setFragment(const std::string& fragment)

--- a/libretroshare/src/util/rsurl.h
+++ b/libretroshare/src/util/rsurl.h
@@ -59,6 +59,8 @@ struct RsUrl : RsSerializable
 	RsUrl& setQuery(const std::map<std::string, std::string>& query);
 	RsUrl& setQueryKV(const std::string& key, const std::string& value);
 	RsUrl& delQueryK(const std::string& key);
+	bool hasQueryK(const std::string& key);
+	const std::string* getQueryV(const std::string& key);
 
 	const std::string& fragment() const;
 	RsUrl& setFragment(const std::string& fragment);

--- a/retroshare-gui/src/gui/NetworkDialog/pgpid_item_model.cpp
+++ b/retroshare-gui/src/gui/NetworkDialog/pgpid_item_model.cpp
@@ -148,9 +148,7 @@ QVariant pgpid_item_model::data(const QModelIndex &index, int role) const
     {
         switch(index.column())
         {
-        case COLUMN_LAST_USED:
-            return detail.lastUsed;
-            break;
+		case COLUMN_LAST_USED: return static_cast<long long>(detail.lastUsed);
         case COLUMN_I_AUTH_PEER:
         {
             if (detail.ownsign)


### PR DESCRIPTION
With this PR it is possible to add a friend based on her SSL id only so a short invite looks like rs://89a4101580dd61c119e4b3cf2dbe53f7?extAddr=192.0.2.28&extPort=7992&name=Test%2004

This make it possible to fit a  retroshare invite in low size mediums like a QR code or a broadcast UDP packet.

I have successfully tested the functionalities introduced by this pull request through JSON API.