### PR TITLE
Gossip discovery refinement

### DIFF
--- a/libretroshare/src/gossipdiscovery/gossipdiscoveryitems.h
+++ b/libretroshare/src/gossipdiscovery/gossipdiscoveryitems.h
@@ -33,12 +33,12 @@
 
 enum class RsGossipDiscoveryItemType : uint8_t
 {
-	PGP_LIST           = 1,
-	PGP_CERT           = 2,
-	CONTACT            = 5,
-	IDENTITY_LIST      = 6,
-	INVITE             = 7,
-	INVITE_REQUEST     = 8
+	PGP_LIST           = 0x1,
+	PGP_CERT           = 0x2,
+	CONTACT            = 0x5,
+	IDENTITY_LIST      = 0x6,
+	INVITE             = 0x7,
+	INVITE_REQUEST     = 0x8
 };
 
 class RsDiscItem: public RsItem
@@ -51,12 +51,17 @@ public:
 	virtual ~RsDiscItem();
 };
 
-/// uint32_t overkill just for retro-compatibility
+/**
+ * This enum is underlined by uint32_t for historical reasons.
+ * We are conscious that uint32_t is an overkill for so few possible values but,
+ * changing here it at this point would break binary serialized item
+ * retro-compatibility.
+ */
 enum class RsGossipDiscoveryPgpListMode : uint32_t
 {
-	NONE    = 0,
-	FRIENDS = 1,
-	GETCERT = 2
+	NONE    = 0x0,
+	FRIENDS = 0x1,
+	GETCERT = 0x2
 };
 
 class RsDiscPgpListItem: public RsDiscItem

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -134,6 +134,7 @@ SOURCES +=	tcponudp/udppeer.cc \
 
 
 PUBLIC_HEADERS =	retroshare/rsdisc.h \
+    retroshare/rsgossipdiscovery \
     retroshare/rsevents.h \
 					retroshare/rsexpr.h \
 					retroshare/rsfiles.h \
@@ -452,7 +453,7 @@ HEADERS +=	rsitems/rsitem.h \
 			serialiser/rstlvbanlist.h \
 			rsitems/rsbanlistitems.h \
 			rsitems/rsbwctrlitems.h \
-			rsitems/rsdiscovery2items.h \
+    gossipdiscovery/gossipdiscoveryitems.h \
 			rsitems/rsheartbeatitems.h \
 			rsitems/rsrttitems.h \
 			rsitems/rsgxsrecognitems.h \
@@ -466,8 +467,8 @@ HEADERS +=  services/autoproxy/p3i2pbob.h \
 			services/p3service.h \
 			services/p3statusservice.h \
 			services/p3banlist.h \
-			services/p3bwctrl.h \
-			services/p3discovery2.h \
+    services/p3bwctrl.h \
+    gossipdiscovery/p3gossipdiscovery.h \
 			services/p3heartbeat.h \
 			services/p3rtt.h \
 			services/p3serviceinfo.h  \
@@ -603,7 +604,7 @@ SOURCES +=	serialiser/rsbaseserial.cc \
 			serialiser/rstlvbanlist.cc \
 			rsitems/rsbanlistitems.cc \
 			rsitems/rsbwctrlitems.cc \
-			rsitems/rsdiscovery2items.cc \
+    gossipdiscovery/gossipdiscoveryitems.cc \
 			rsitems/rsrttitems.cc \
 			rsitems/rsgxsrecognitems.cc \
 			rsitems/rsgxsupdateitems.cc \
@@ -618,7 +619,7 @@ SOURCES +=  services/autoproxy/rsautoproxymonitor.cc \
 			services/p3statusservice.cc \
 			services/p3banlist.cc \
 			services/p3bwctrl.cc \
-			services/p3discovery2.cc \
+    gossipdiscovery/p3gossipdiscovery.cc \
 			services/p3heartbeat.cc \
 			services/p3rtt.cc \
 			services/p3serviceinfo.cc \

--- a/libretroshare/src/retroshare/rsdisc.h
+++ b/libretroshare/src/retroshare/rsdisc.h
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * libretroshare/src/retroshare: rsdht.h                                       *
+ * RetroShare gossip discovery - discovery2 retro-compatibility include        *
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2008-2008 by Robert Fernie <retroshare@lunamutt.com>              *
+ * Copyright (C) 2019  Gioacchino Mazzurco <gio@eigenlab.org>                  *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -19,66 +19,14 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef RETROSHARE_DISC_GUI_INTERFACE_H
-#define RETROSHARE_DISC_GUI_INTERFACE_H
+#pragma once
 
-#include <inttypes.h>
-#include <string>
-#include <list>
-#include <map>
-#include <retroshare/rstypes.h>
+#include "retroshare/rsgossipdiscovery.h"
+#include "util/rsdeprecate.h"
 
-/* The Main Interface Class - for information about your Peers */
-class RsDisc;
+#warning "Including retroshare/rsdisc.h is deprecated, \
+use retroshare/rsgossipdiscovery.h instead"
 
-/**
- * Pointer to global instance of RsDisc service implementation
- * @jsonapi{development}
- */
-extern RsDisc   *rsDisc;
+using RsDisc RS_DEPRECATED_FOR("RsGossipDiscovery") = RsGossipDiscovery;
 
-class RsDisc
-{
-	public:
-
-	RsDisc() {}
-	virtual ~RsDisc() {}
-
-	/**
-	 * @brief getDiscFriends get a list with all friends (ssl id) to a given friend (ssl id)
-	 * @jsonapi{development}
-	 * @param[in] id peer to get the friends of
-	 * @param[out] friends list of friends (ssl id)
-	 * @return true on success false otherwise
-	 */
-	virtual bool	getDiscFriends(const RsPeerId &id, std::list<RsPeerId>& friends) = 0;
-
-	/**
-	 * @brief getDiscPgpFriends get a list with all friends (pgp id) to a given friend (pgp id)
-	 * @jsonapi{development}
-	 * @param[in] pgpid peer to get the friends of
-	 * @param[out] gpg_friends list of friends (gpg id)
-	 * @return true on success false otherwise
-	 */
-	virtual bool	getDiscPgpFriends(const RsPgpId &pgpid, std::list<RsPgpId>& gpg_friends) = 0;
-
-	/**
-	 * @brief getPeerVersion get the version string of a peer.
-	 * @jsonapi{development}
-	 * @param[in] id peer to get the version string of
-	 * @param[out] versions version string sent by the peer
-	 * @return true on success false otherwise
-	 */
-	virtual bool 	getPeerVersion(const RsPeerId &id, std::string &versions) = 0;
-
-	/**
-	 * @brief getWaitingDiscCount get the number of queued discovery packets.
-	 * @jsonapi{development}
-	 * @param[out] sendCount number of queued outgoing packets
-	 * @param[out] recvCount number of queued incoming packets
-	 * @return true on success false otherwise
-	 */
-	virtual bool 	getWaitingDiscCount(size_t &sendCount, size_t &recvCount) = 0;
-};
-
-#endif
+#define rsDisc rsGossipDiscovery.get()

--- a/libretroshare/src/retroshare/rsevents.h
+++ b/libretroshare/src/retroshare/rsevents.h
@@ -52,7 +52,7 @@ enum class RsEventType : uint32_t
 	BROADCAST_DISCOVERY_PEER_FOUND                          = 1,
 
 	/// @see RsDiscPendingPgpReceivedEvent
-	GOSSIP_DISCOVERY_PENDIG_PGP_CERT_RECEIVED               = 2,
+	GOSSIP_DISCOVERY_INVITE_RECEIVED                        = 2,
 
 	/// @see AuthSSL
 	AUTHSSL_CONNECTION_AUTENTICATION                        = 3,

--- a/libretroshare/src/retroshare/rsgossipdiscovery.h
+++ b/libretroshare/src/retroshare/rsgossipdiscovery.h
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * RetroShare remote peers gossip discovery                                    *
+ *                                                                             *
+ * libretroshare: retroshare core library                                      *
+ *                                                                             *
+ * Copyright (C) 2008  Robert Fernie <retroshare@lunamutt.com>                 *
+ * Copyright (C) 2019  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <list>
+#include <map>
+
+#include "retroshare/rstypes.h"
+#include "retroshare/rsevents.h"
+#include "util/rsmemory.h"
+
+class RsGossipDiscovery;
+
+/**
+ * Pointer to global instance of RsGossipDiscovery service implementation
+ * @jsonapi{development}
+ *
+ * TODO: this should become std::weak_ptr once we have a reasonable services
+ * management.
+ */
+extern std::shared_ptr<RsGossipDiscovery> rsGossipDiscovery;
+
+/**
+ * @brief Emitted when a pending PGP certificate is received
+ */
+struct RsGossipDiscoveryFriendInviteReceivedEvent : RsEvent
+{
+	RsGossipDiscoveryFriendInviteReceivedEvent(
+	        const std::string& invite );
+
+	std::string mInvite;
+
+	/// @see RsSerializable
+	virtual void serial_process( RsGenericSerializer::SerializeJob j,
+	                             RsGenericSerializer::SerializeContext& ctx )
+	{
+		RsEvent::serial_process(j,ctx);
+		RS_SERIAL_PROCESS(mInvite);
+	}
+};
+
+class RsGossipDiscovery
+{
+public:
+	/**
+	 * @brief getDiscFriends get a list of all friends of a given friend
+	 * @jsonapi{development}
+	 * @param[in] id peer to get the friends of
+	 * @param[out] friends list of friends (ssl id)
+	 * @return true on success false otherwise
+	 */
+	virtual bool getDiscFriends( const RsPeerId& id,
+	                             std::list<RsPeerId>& friends ) = 0;
+
+	/**
+	 * @brief getDiscPgpFriends get a list of all friends of a given friend
+	 * @jsonapi{development}
+	 * @param[in] pgpid peer to get the friends of
+	 * @param[out] gpg_friends list of friends (gpg id)
+	 * @return true on success false otherwise
+	 */
+	virtual bool getDiscPgpFriends(
+	        const RsPgpId& pgpid, std::list<RsPgpId>& gpg_friends ) = 0;
+
+	/**
+	 * @brief getPeerVersion get the version string of a peer.
+	 * @jsonapi{development}
+	 * @param[in] id peer to get the version string of
+	 * @param[out] version version string sent by the peer
+	 * @return true on success false otherwise
+	 */
+	virtual bool getPeerVersion(const RsPeerId& id, std::string& version) = 0;
+
+	/**
+	 * @brief getWaitingDiscCount get the number of queued discovery packets.
+	 * @jsonapi{development}
+	 * @param[out] sendCount number of queued outgoing packets
+	 * @param[out] recvCount number of queued incoming packets
+	 * @return true on success false otherwise
+	 */
+	virtual bool getWaitingDiscCount(size_t& sendCount, size_t& recvCount) = 0;
+
+	/**
+	 * @brief Send RetroShare invite to given peer
+	 * @jsonapi{development}
+	 * @param[in] inviteId id of peer of which send the invite
+	 * @param[in] toSslId ssl id of the destination peer
+	 * @param[out] errorMessage Optional storage for the error message,
+	 *	meaningful only on failure.
+	 * @return true on success false otherwise
+	 */
+	virtual bool sendInvite(
+	        const RsPeerId& inviteId, const RsPeerId& toSslId,
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) = 0;
+
+	/**
+	 * @brief Request RetroShare certificate to given peer
+	 * @jsonapi{development}
+	 * @param[in] inviteId id of the peer of which request the invite
+	 * @param[in] toSslId id of the destination of the request
+	 * @param[out] errorMessage Optional storage for the error message,
+	 *	meaningful only on failure.
+	 * @return true on success false otherwise
+	 */
+	virtual bool requestInvite(
+	        const RsPeerId& inviteId, const RsPeerId& toSslId,
+	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
+	        ) = 0;
+
+	virtual ~RsGossipDiscovery();
+};

--- a/libretroshare/src/retroshare/rsplugin.h
+++ b/libretroshare/src/retroshare/rsplugin.h
@@ -30,6 +30,7 @@
 #include "retroshare/rsfiles.h"
 #include "retroshare/rsversion.h"
 #include "util/rsinitedptr.h"
+#include "retroshare/rsdisc.h"
 
 class RsPluginHandler ;
 extern RsPluginHandler *rsPlugins ;
@@ -40,7 +41,6 @@ class RsReputations ;
 class RsTurtle ;
 class RsGxsTunnelService ;
 class RsDht ;
-class RsDisc ;
 class RsMsgs ;
 class RsGxsForums;
 class RsGxsChannels;

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -745,7 +745,7 @@ RsGRouter *rsGRouter = NULL ;
 #include "services/p3gxsreputation.h"
 #include "services/p3serviceinfo.h"
 #include "services/p3heartbeat.h"
-#include "services/p3discovery2.h"
+#include "gossipdiscovery/p3gossipdiscovery.h"
 #include "services/p3msgservice.h"
 #include "services/p3statusservice.h"
 
@@ -1484,7 +1484,7 @@ int RsServer::StartupRetroShare()
 
 	mGxsNetTunnel->connectToTurtleRouter(tr) ;
 
-	rsDisc  = mDisc;
+	rsGossipDiscovery.reset(mDisc);
 	rsMsgs  = new p3Msgs(msgSrv, chatSrv);
 
 	// connect components to turtle router.


### PR DESCRIPTION
Rename from RsDisc to more descriptive RsGossipDiscovery
Keep full retro-compatibility suggesting usage of RsGossipDiscovery
Add capability to send and receive full RetroShare invitation
Emit event when receiving a full invitation
Start using new debug utilities
Use enum class instead of defines and constant where appropriate