### PR TITLE
p3LinkMgr remove address age check in wrong place

### DIFF
--- a/libretroshare/src/pqi/p3linkmgr.h
+++ b/libretroshare/src/pqi/p3linkmgr.h
@@ -182,7 +182,7 @@ virtual bool 	getLocalAddress(struct sockaddr_storage &addr) = 0;
 virtual void	getFriendList(std::list<RsPeerId> &ssl_peers) = 0; // ONLY used by p3peers.cc USE p3PeerMgr instead.
 virtual bool	getFriendNetStatus(const RsPeerId &id, peerConnectState &state) = 0; // ONLY used by p3peers.cc
 
-virtual bool 	checkPotentialAddr(const struct sockaddr_storage &addr, rstime_t age)=0;
+	virtual bool checkPotentialAddr(const sockaddr_storage& addr) = 0;
 
 	/************* DEPRECIATED FUNCTIONS (TO REMOVE) ********/
 virtual int 	addFriend(const RsPeerId &ssl_id, bool isVisible) = 0;
@@ -269,7 +269,8 @@ int 	removeFriend(const RsPeerId &ssl_id);
 
 void 	printPeerLists(std::ostream &out);
 
-virtual bool checkPotentialAddr(const struct sockaddr_storage &addr, rstime_t age);
+    virtual bool checkPotentialAddr(const sockaddr_storage& addr);
+
 protected:
 	/* THESE CAN PROBABLY BE REMOVED */
 //bool	shutdown(); /* blocking shutdown call */
@@ -302,7 +303,8 @@ void  	locked_ConnectAttempt_ProxyAddress(peerConnectState *peer, const uint32_t
 
 bool  	locked_ConnectAttempt_Complete(peerConnectState *peer);
 
-bool  	locked_CheckPotentialAddr(const struct sockaddr_storage &addr, rstime_t age);
+    bool locked_CheckPotentialAddr(const sockaddr_storage& addr);
+
 bool 	addAddressIfUnique(std::list<peerConnectAddress> &addrList, peerConnectAddress &pca, bool pushFront);
 
 

--- a/libretroshare/src/pqi/p3peermgr.cc
+++ b/libretroshare/src/pqi/p3peermgr.cc
@@ -1729,7 +1729,7 @@ static bool cleanIpList(std::list<pqiIpAddress>& lst,const RsPeerId& pid,p3LinkM
     /* remove unused parameter warnings */
     (void) pid;
 #endif
-      if(!link_mgr->checkPotentialAddr( (*it2).mAddr,now - (*it2).mSeenTime))
+		if(!link_mgr->checkPotentialAddr((*it2).mAddr))
       {
 #ifdef PEER_DEBUG
         std::cerr << "  (SS) Removing Banned/old IP address " << sockaddr_storage_iptostring( (*it2).mAddr) << " from peer " << pid << ", age = " << now - (*it2).mSeenTime << std::endl;


### PR DESCRIPTION
The age check was causing some address were ignored during connect attempt, this was disastrous especially for sporadic users which completely lost capability to connect to any node, even if the IPs neve changes!

Old addresses triaging is handled elsewhere so ignoring them in connect attempt only generate very counter-intuitive situations for the user, as addressed still listed in potential address list were never attempted.