### PR TITLE
Short invites support for libretroshare

### DIFF
--- a/libretroshare/src/pqi/p3peermgr.h
+++ b/libretroshare/src/pqi/p3peermgr.h
@@ -127,6 +127,10 @@ public:
 	                        rstime_t lastContact = 0,
 	                        ServicePermissionFlags = ServicePermissionFlags(RS_NODE_PERM_DEFAULT) ) = 0;
 
+	virtual bool addSslOnlyFriend(
+	        const RsPeerId& sslId,
+	        const RsPeerDetails& details = RsPeerDetails() ) = 0;
+
 	virtual bool removeFriend(const RsPeerId &ssl_id, bool removePgpId) = 0;
 	virtual bool isFriend(const RsPeerId& ssl_id) = 0;
 
@@ -242,6 +246,11 @@ public:
     virtual bool addFriend(const RsPeerId&ssl_id, const RsPgpId&gpg_id, uint32_t netMode = RS_NET_MODE_UDP,
                               uint16_t vsDisc = RS_VS_DISC_FULL, uint16_t vsDht = RS_VS_DHT_FULL,
                               rstime_t lastContact = 0,ServicePermissionFlags = ServicePermissionFlags(RS_NODE_PERM_DEFAULT));
+
+	bool addSslOnlyFriend(
+	            const RsPeerId& sslId,
+	            const RsPeerDetails& details = RsPeerDetails() ) override;
+
     virtual bool	removeFriend(const RsPeerId &ssl_id, bool removePgpId);
     virtual bool	removeFriend(const RsPgpId &pgp_id);
 

--- a/libretroshare/src/pqi/p3servicecontrol.cc
+++ b/libretroshare/src/pqi/p3servicecontrol.cc
@@ -28,6 +28,8 @@
 #include "rsitems/rsnxsitems.h"
 #include "pqi/p3cfgmgr.h"
 #include "pqi/pqiservice.h"
+#include "retroshare/rspeers.h"
+#include "retroshare/rsevents.h"
 
 /*******************************/
 // #define SERVICECONTROL_DEBUG	1
@@ -756,6 +758,12 @@ bool	p3ServiceControl::updateFilterByPeer_locked(const RsPeerId &peerId)
 		mPeerFilterMap[peerId] = peerFilter;
 	}
 	recordFilterChanges_locked(peerId, originalFilter, peerFilter);
+
+	using Evt_t = RsPeerStateChangedEvent;
+	std::shared_ptr<RsEvents> lockedRsEvents = rsEvents;
+	if(lockedRsEvents)
+		lockedRsEvents->postEvent(std::unique_ptr<Evt_t>(new Evt_t(peerId)));
+
 	return true;
 }
 

--- a/libretroshare/src/retroshare/rsevents.h
+++ b/libretroshare/src/retroshare/rsevents.h
@@ -63,6 +63,9 @@ enum class RsEventType : uint32_t
 	/// @see RsGxsChanges
 	GXS_CHANGES                                             = 5,
 
+	/// Emitted when a peer state changes, @see RsPeers
+	PEER_STATE_CHANGED                                      = 6,
+
 	MAX       /// Used to detect invalid event type passed
 };
 

--- a/libretroshare/src/rsserver/p3peers.cc
+++ b/libretroshare/src/rsserver/p3peers.cc
@@ -1274,14 +1274,16 @@ bool p3Peers::parseShortInvite(
 
 		case RsShortInviteFieldType::EXT4_LOCATOR:
 		{
-			sockaddr_in tExtAddr;
-			RS_SERIAL_PROCESS(tExtAddr.sin_addr.s_addr);
+			uint32_t t4Addr = 0;
+			RS_SERIAL_PROCESS(t4Addr);
 			if(!ctx.mOk)
 			{
 				RsWarn() << __PRETTY_FUNCTION__ << " failed to parse IPv4"
 				         << std::endl;
 				break;
 			}
+			sockaddr_in tExtAddr;
+			tExtAddr.sin_addr.s_addr = t4Addr;
 			details.extAddr = rs_inet_ntoa(tExtAddr.sin_addr);
 
 			RS_SERIAL_PROCESS(details.extPort);

--- a/libretroshare/src/rsserver/p3peers.h
+++ b/libretroshare/src/rsserver/p3peers.h
@@ -69,6 +69,9 @@ public:
 	virtual bool isFriend(const RsPeerId &id);
 	virtual bool isPgpFriend(const RsPgpId& pgpId);
 
+	/// @see RsPeers
+	bool isSslOnlyFriend(const RsPeerId& sslId) override;
+
 	RS_DEPRECATED_FOR(isPgpFriend)
 	virtual bool isGPGAccepted(const RsPgpId &gpg_id_is_friend);
 
@@ -90,6 +93,12 @@ public:
 
 	/* Add/Remove Friends */
 	virtual	bool addFriend(const RsPeerId &ssl_id, const RsPgpId &gpg_id,ServicePermissionFlags flags = RS_NODE_PERM_DEFAULT);
+
+	/// @see RsPeers
+	bool addSslOnlyFriend(
+	            const RsPeerId& sslId,
+	            const RsPeerDetails& details = RsPeerDetails() ) override;
+
 	virtual	bool removeFriend(const RsPgpId& gpgid);
 	virtual bool removeFriendLocation(const RsPeerId& sslId);
 
@@ -127,6 +136,16 @@ public:
 	virtual	std::string getPGPKey(const RsPgpId& pgp_id,bool include_signatures);
 
 	virtual bool GetPGPBase64StringAndCheckSum(const RsPgpId& gpg_id,std::string& gpg_base64_string,std::string& gpg_base64_checksum);
+
+	/// @see RsPeers
+	bool getShortInvite(
+	        std::string& invite, const RsPeerId& sslId = RsPeerId(),
+	        bool formatRadix = false, bool bareBones = false,
+	        const std::string& baseUrl = "https://retroshare.me/" ) override;
+
+	/// @see RsPeers
+	bool parseShortInvite(
+	            const std::string& invite, RsPeerDetails& details ) override;
 
 	/// @see RsPeers::acceptInvite
 	virtual bool acceptInvite(


### PR DESCRIPTION
With this PR it is possible to add a friend based on her SSL id only so the following are all valid equivalents short invites:

AImkEBWA3WHBGeSzzy2+U/cBAAAAB1Rlc3QgMDSSHDs7XB84
https://retroshare.me?rsInvite=AImkEBWA3WHBGeSzzy2%2BU%2FcBAAAAB1Rlc3QgMDSSHDs7XB84
retroshare:///?rsInvite=AImkEBWA3WHBGeSzzy2%2BU%2FcBAAAAB1Rlc3QgMDSSHDs7XB84
rs:///?rsInvite=AImkEBWA3WHBGeSzzy2%2BU%2FcBAAAAB1Rlc3QgMDSSHDs7XB84
https://elrepo.io/?rsInvite=AImkEBWA3WHBGeSzzy2%2BU%2FcBAAAAB1Rlc3QgMDSSHDs7XB84
http://whadeverdomain.tld/whatewerpath/?rsInvite=AImkEBWA3WHBGeSzzy2%2BU%2FcBAAAAB1Rlc3QgMDSSHDs7XB84

Those invites contains SSL id + PGP name + external IP, hidden locations and dyndns are supported too, passing `bareBones == true` the link would contain only  SSL id + PGP name so the link is even shorter but only incoming connections are possible. 

This make it possible to fit a retroshare invite in low size mediums like a QR code or a broadcast UDP packet, or to sneak it as an common looking link into other Apps messages etc, also this way it is more flexible to register retroshare invites handling across platforms.

I have successfully tested the functionalities introduced by this pull request through JSON API.