### PR TITLE
Rise public chat message size

### DIFF
--- a/libretroshare/src/chat/p3chatservice.cc
+++ b/libretroshare/src/chat/p3chatservice.cc
@@ -47,7 +47,7 @@
  * #define CHAT_DEBUG 1
  ****/
 
-static const uint32_t MAX_MESSAGE_SECURITY_SIZE         = 6000 ; // Max message size to forward other friends
+static const uint32_t MAX_MESSAGE_SECURITY_SIZE         = 31000 ; // Max message size to forward other friends
 static const uint32_t MAX_AVATAR_JPEG_SIZE              = 32767; // Maximum size in bytes for an avatar. Too large packets 
                                                                  // don't transfer correctly and can kill the system.
 																					  // Images are 96x96, which makes approx. 27000 bytes uncompressed.

--- a/retroshare-gui/src/util/imageutil.cpp
+++ b/retroshare-gui/src/util/imageutil.cpp
@@ -99,9 +99,9 @@ bool ImageUtil::optimizeSize(QString &html, const QImage& original, QImage &opti
 	}
 
 	//Use binary search to find a suitable image size + linear regression to guess the file size
-	double maxsize = (double)checkSize(html, optimized = original.scaledToWidth(maxwidth, Qt::SmoothTransformation).convertToFormat(QImage::Format_Indexed8, ct), maxBytes);
+	double maxsize = (double)checkSize(html, optimized = original.scaledToWidth(maxwidth, Qt::SmoothTransformation).convertToFormat(QImage::Format_Indexed8, ct, Qt::ThresholdDither), maxBytes);
 	if(maxsize <= maxBytes) return true;	//success
-	double minsize = (double)checkSize(html, optimized = original.scaledToWidth(minwidth, Qt::SmoothTransformation).convertToFormat(QImage::Format_Indexed8, ct), maxBytes);
+	double minsize = (double)checkSize(html, optimized = original.scaledToWidth(minwidth, Qt::SmoothTransformation).convertToFormat(QImage::Format_Indexed8, ct, Qt::ThresholdDither), maxBytes);
 	if(minsize > maxBytes) return false; //impossible
 
 //	std::cout << "maxS: " << maxsize << " minS: " << minsize << std::endl;
@@ -114,7 +114,7 @@ bool ImageUtil::optimizeSize(QString &html, const QImage& original, QImage &opti
 		double b = maxsize - m * ((double)maxwidth * (double)maxwidth / whratio);
 		double a = ((double)(maxBytes - region/2) - b) / m; //maxBytes - region/2 target the center of the accepted region
 		int nextwidth = (int)sqrt(a * whratio);
-		int nextsize = checkSize(html, optimized = original.scaledToWidth(nextwidth, Qt::SmoothTransformation).convertToFormat(QImage::Format_Indexed8, ct), maxBytes);
+		int nextsize = checkSize(html, optimized = original.scaledToWidth(nextwidth, Qt::SmoothTransformation).convertToFormat(QImage::Format_Indexed8, ct, Qt::ThresholdDither), maxBytes);
 		if(nextsize <= maxBytes) {
 			minsize = nextsize;
 			minwidth = nextwidth;
@@ -188,7 +188,7 @@ bool blueLessThan(const QRgb &c1, const QRgb &c2)
 //median cut algoritmh
 void ImageUtil::quantization(const QImage &img, QVector<QRgb> &palette)
 {
-	int bits = 4;	// bits/pixel
+	int bits = 8;	// bits/pixel
 	int samplesize = 100000;	//only take this many color samples
 
 	rstime::RsScopeTimer st("Quantization");


### PR DESCRIPTION
Rises the chat lobby message size to the maximum currently possible.
This way at least the stickers doesn't get compressed.

This branch should be merged right before new release, to minimise compatibility issues. Old clients drop oversized messages.
The sticker branch (https://github.com/RetroShare/RetroShare/pull/1589) can be merged at anytime, it works without this patch.

- Rise max public chat message size to 31000 bytes
- Rise color palette size from 16 to 256 colors

Note: Max chat item size is 32000 without splitting the message.
31000 = 32000 - some place left for other fields

At long term we should re-enable message splitting, and make the limit configurable per lobby basis.