### PR TITLE
Workaround JSON API opacity of RsTlv*Set in RsGxsForumGroup

### DIFF
--- a/libretroshare/src/retroshare/rsgxsforums.h
+++ b/libretroshare/src/retroshare/rsgxsforums.h
@@ -59,25 +59,17 @@ struct RsGxsForumGroup : RsSerializable
 	RsGroupMetaData mMeta;
 	std::string mDescription;
 
-	/* What's below is optional, and handled by the serialiser
-	 * TODO: run away from TLV old serializables as those types are opaque to
-	 *	JSON API! */
+	/* TODO: run away from TLV old serializables as those types are opaque to
+	 * JSON API! */
 	RsTlvGxsIdSet mAdminList;
 	RsTlvGxsMsgIdSet mPinnedPosts;
 
 	/// @see RsSerializable
 	virtual void serial_process( RsGenericSerializer::SerializeJob j,
-	                             RsGenericSerializer::SerializeContext& ctx )
-	{
-		RS_SERIAL_PROCESS(mMeta);
-		RS_SERIAL_PROCESS(mDescription);
-		RS_SERIAL_PROCESS(mAdminList);
-		RS_SERIAL_PROCESS(mPinnedPosts);
-	}
+	                             RsGenericSerializer::SerializeContext& ctx );
 
-    // utility functions
-
-    bool canEditPosts(const RsGxsId& id) const { return mAdminList.ids.find(id) != mAdminList.ids.end() || id == mMeta.mAuthorId; }
+	/// utility functions
+	bool canEditPosts(const RsGxsId& id) const;
 };
 
 struct RsGxsForumMsg : RsSerializable
@@ -203,4 +195,3 @@ public:
 	RS_DEPRECATED_FOR(editForum)
 	virtual bool updateGroup(uint32_t &token, RsGxsForumGroup &group) = 0;
 };
-

--- a/libretroshare/src/services/p3gxsforums.cc
+++ b/libretroshare/src/services/p3gxsforums.cc
@@ -813,3 +813,34 @@ void p3GxsForums::handle_event(uint32_t event_type, const std::string &/*elabel*
 			break;
 	}
 }
+
+void RsGxsForumGroup::serial_process(
+        RsGenericSerializer::SerializeJob j,
+        RsGenericSerializer::SerializeContext& ctx )
+{
+	RS_SERIAL_PROCESS(mMeta);
+	RS_SERIAL_PROCESS(mDescription);
+
+	/* Work around to have usable JSON API, without breaking binary
+	 * serialization retrocompatibility */
+	switch (j)
+	{
+	case RsGenericSerializer::TO_JSON: // fallthrough
+	case RsGenericSerializer::FROM_JSON:
+		RsTypeSerializer::serial_process( j, ctx,
+		                                  mAdminList.ids, "mAdminList" );
+		RsTypeSerializer::serial_process( j, ctx,
+		                                  mPinnedPosts.ids, "mPinnedPosts" );
+		break;
+	default:
+		RS_SERIAL_PROCESS(mAdminList);
+		RS_SERIAL_PROCESS(mPinnedPosts);
+	}
+}
+
+bool RsGxsForumGroup::canEditPosts(const RsGxsId& id) const
+{
+	return mAdminList.ids.find(id) != mAdminList.ids.end() ||
+	        id == mMeta.mAuthorId;
+}
+


### PR DESCRIPTION
JSON API user would get an unusable base64 blob due to RsTlv opaque JSON
  serialization, this instead way the content of the set is serialized plainly
  so it is usable through JSON API, without breaking binary
  serialization compatibility.

Anyway we must stop using those RsTlv derived items.