### PR TITLE
Replace deprecated class name

### DIFF
--- a/libretroshare/src/retroshare/rspeers.h
+++ b/libretroshare/src/retroshare/rspeers.h
@@ -220,7 +220,7 @@ struct RsPeerDetails : RsSerializable
 	
 	RsPgpId issuer;
 
-	PGPFingerprintType fpr; /* pgp fingerprint */
+	RsPgpFingerprint fpr; /* pgp fingerprint */
 	std::string authcode; 	// TODO: 2015/12/31 (cyril) what is this used for ?????
 	std::list<RsPgpId> gpgSigners;
 


### PR DESCRIPTION
The name `PGPFingerprintType` is deprecated in favour of `RsPgpFingerprint`