### PR TITLE
Fix sporadic crash in JSON API async calls

### DIFF
--- a/jsonapi-generator/src/async-method-wrapper-template.cpp.tmpl
+++ b/jsonapi-generator/src/async-method-wrapper-template.cpp.tmpl
@@ -19,7 +19,7 @@
  *******************************************************************************/
 
 registerHandler("$%apiPath%$",
-		[$%captureVars%$](const std::shared_ptr<rb::Session> session)
+		[this, $%captureVars%$](const std::shared_ptr<rb::Session> session)
 {
 	const std::multimap<std::string, std::string> headers
 	{
@@ -29,7 +29,7 @@ registerHandler("$%apiPath%$",
 	session->yield(rb::OK, headers);
 
 	size_t reqSize = session->get_request()->get_header("Content-Length", 0);
-	session->fetch( reqSize, [$%captureVars%$](
+	session->fetch( reqSize, [this, $%captureVars%$](
 					const std::shared_ptr<rb::Session> session,
 					const rb::Bytes& body )
 	{
@@ -44,17 +44,24 @@ $%paramsDeclaration%$
 $%inputParamsDeserialization%$
 
 		const std::weak_ptr<rb::Session> weakSession(session);
-		$%callbackName%$ = [weakSession]($%callbackParams%$)
+		$%callbackName%$ = [this, weakSession]($%callbackParams%$)
 		{
 			auto session = weakSession.lock();
 			if(!session || session->is_closed()) return;
 
 $%callbackParamsSerialization%$
 
-			std::stringstream message;
-			message << "data: " << compactJSON << ctx.mJson << "\n\n";
-			session->yield(message.str());
-			$%sessionEarlyClose%$
+			std::stringstream sStream;
+			sStream << "data: " << compactJSON << ctx.mJson << "\n\n";
+			const std::string message = sStream.str();
+
+			mService.schedule( [weakSession, message]()
+			{
+				auto session = weakSession.lock();
+				if(!session || session->is_closed()) return;
+				session->yield(message);
+				$%sessionEarlyClose%$
+			} );
 		};
 
 $%functionCall%$

--- a/libretroshare/src/retroshare/rsevents.h
+++ b/libretroshare/src/retroshare/rsevents.h
@@ -37,7 +37,7 @@ class RsEvents;
  * TODO: this should become std::weak_ptr once we have a reasonable services
  * management.
  */
-extern std::shared_ptr<RsEvents> rsEvents;
+extern RsEvents* rsEvents;
 
 /**
  * @brief Events types.
@@ -113,21 +113,20 @@ public:
 	 * @return False on error, true otherwise.
 	 */
 	virtual bool postEvent(
-	        std::unique_ptr<RsEvent> event,
+	        std::shared_ptr<const RsEvent> event,
 	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
 	        ) = 0;
 
 	/**
 	 * @brief Send event directly to handlers. Blocking API
-	 * The handlers get exectuded on the caller thread, ensuring the function
-	 * returns only after the event has been handled.
+	 * The handlers get exectuded on the caller thread.
 	 * @param[in] event
 	 * @param[out] errorMessage Optional storage for error messsage, meaningful
 	 *                          only on failure.
 	 * @return False on error, true otherwise.
 	 */
 	virtual bool sendEvent(
-	        const RsEvent& event,
+	        std::shared_ptr<const RsEvent> event,
 	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
 	        ) = 0;
 
@@ -152,7 +151,7 @@ public:
 	 * @return False on error, true otherwise.
 	 */
 	virtual bool registerEventsHandler(
-	        std::function<void(const RsEvent&)> multiCallback,
+	        std::function<void(std::shared_ptr<const RsEvent>)> multiCallback,
 	        RsEventsHandlerId_t& hId = RS_DEFAULT_STORAGE_PARAM(RsEventsHandlerId_t, 0)
 	        ) = 0;
 

--- a/libretroshare/src/rsserver/p3face-server.cc
+++ b/libretroshare/src/rsserver/p3face-server.cc
@@ -35,8 +35,6 @@
 #include "pqi/p3linkmgr.h"
 #include "pqi/p3netmgr.h"
 
-int rsserverzone = 101;
-
 #include "util/rsdebug.h"
 
 #include "retroshare/rsevents.h"
@@ -86,7 +84,7 @@ RsServer::RsServer() :
 {
 	{
 		RsEventsService* tmpRsEvtPtr = new RsEventsService();
-		rsEvents.reset(tmpRsEvtPtr);
+		rsEvents = tmpRsEvtPtr;
 		startServiceThread(tmpRsEvtPtr, "RsEventsService");
 	}
 
@@ -271,8 +269,6 @@ void 	RsServer::data_tick()
         std::string out;
         rs_sprintf(out, "RsServer::run() WARNING Excessively Long Cycle Time: %g secs => Please DEBUG", cycleTime);
         std::cerr << out << std::endl;
-
-        rslog(RSL_ALERT, rsserverzone, out);
     }
 #endif
 }

--- a/libretroshare/src/services/broadcastdiscoveryservice.cc
+++ b/libretroshare/src/services/broadcastdiscoveryservice.cc
@@ -171,12 +171,9 @@ void BroadcastDiscoveryService::data_tick()
 				else if(!isFriend)
 				{
 					typedef RsBroadcastDiscoveryPeerFoundEvent Evt_t;
-
-					// Ensure rsEvents is not deleted while we use it
-					std::shared_ptr<RsEvents> lockedRsEvents = rsEvents;
-					if(lockedRsEvents)
-						lockedRsEvents->postEvent(
-						            std::unique_ptr<Evt_t>(new Evt_t(rbdr)) );
+					if(rsEvents)
+						rsEvents->postEvent(
+						            std::shared_ptr<Evt_t>(new Evt_t(rbdr)) );
 				}
 			}
 		}

--- a/libretroshare/src/services/rseventsservice.h
+++ b/libretroshare/src/services/rseventsservice.h
@@ -27,6 +27,7 @@
 
 #include "retroshare/rsevents.h"
 #include "util/rsthreads.h"
+#include "util/rsdebug.h"
 
 class RsEventsService :
         public RsEvents, public RsTickingThread
@@ -38,13 +39,13 @@ public:
 
 	/// @see RsEvents
 	bool postEvent(
-	        std::unique_ptr<RsEvent> event,
+	        std::shared_ptr<const RsEvent> event,
 	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
 	        ) override;
 
 	/// @see RsEvents
 	bool sendEvent(
-	        const RsEvent& event,
+	        std::shared_ptr<const RsEvent> event,
 	        std::string& errorMessage = RS_DEFAULT_STORAGE_PARAM(std::string)
 	        ) override;
 
@@ -53,7 +54,7 @@ public:
 
 	/// @see RsEvents
 	bool registerEventsHandler(
-	        std::function<void(const RsEvent&)> multiCallback,
+	        std::function<void(std::shared_ptr<const RsEvent>)> multiCallback,
 	        RsEventsHandlerId_t& hId = RS_DEFAULT_STORAGE_PARAM(RsEventsHandlerId_t, 0)
 	        ) override;
 
@@ -63,15 +64,18 @@ public:
 protected:
 	RsMutex mHandlerMapMtx;
 	RsEventsHandlerId_t mLastHandlerId;
-	std::map< RsEventsHandlerId_t, std::function<void(const RsEvent&)> >
-	mHandlerMap;
+	std::map<
+	    RsEventsHandlerId_t,
+	    std::function<void(std::shared_ptr<const RsEvent>)> > mHandlerMap;
 
 	RsMutex mEventQueueMtx;
-	std::deque< std::unique_ptr<RsEvent> > mEventQueue;
+	std::deque< std::shared_ptr<const RsEvent> > mEventQueue;
 
 	/// @see RsTickingThread
 	void data_tick() override;
 
-	void handleEvent(const RsEvent& event);
+	void handleEvent(std::shared_ptr<const RsEvent> event);
 	RsEventsHandlerId_t generateUniqueHandlerId_unlocked();
+
+	RS_SET_CONTEXT_DEBUG_LEVEL(3)
 };


### PR DESCRIPTION
In Restbed one is not supposed to call session->yield outside the
  threads controlled by Restbed. RetroShare JSON API async call were
  calling session->yield from threads controlled by RetroShare all the
  times, this caused crashes in some cases, like when the JSON API
  socket timed out concurrently with the session->yield call .
  To solve this problem session->yield from async
  calls are now wrapped into mService->schedule to ensure they are
  executed on the right thread (aka one of the threads controlled by
  Restbed).
While solving this issue I realized also that passing RsEvents as const
  references around was quite limiting in cases where the event need to
  be finally handled in another thread, in that case passing by const
  reference the RsEvent needed to be copied by value into the thread
  that process it, in this copy by value process the information of
  which was the original specific type is lost, and then only the data
  and methods from general RsEvents are available, unless the handler
  does tricky stuff with type coercion etc. To solve this limitation
  pass the events as std::shared_ptr<const RsEvent> seems the safer and
  more elegant solution.