### PR TITLE
Protect p3BanList::isAddressAccepted with mutex

### DIFF
--- a/libretroshare/src/services/p3banlist.cc
+++ b/libretroshare/src/services/p3banlist.cc
@@ -306,17 +306,22 @@ bool p3BanList::acceptedBanRanges_locked(const BanListPeer& blp)
     }
     return false ;
 }
+
 bool p3BanList::isAddressAccepted(
         const sockaddr_storage& dAddr, uint32_t checking_flags,
         uint32_t& check_result )
 {
 	check_result = RSBANLIST_CHECK_RESULT_NOCHECK;
-	if(!mIPFilteringEnabled) return true;
 
 	sockaddr_storage addr; sockaddr_storage_copy(dAddr, addr);
 
 	if(!sockaddr_storage_ipv6_to_ipv4(addr)) return true;
 	if(sockaddr_storage_isLoopbackNet(addr)) return true;
+
+
+	RS_STACK_MUTEX(mBanMtx);
+
+	if(!mIPFilteringEnabled) return true;
 
 #ifdef DEBUG_BANLIST
     std::cerr << "isAddressAccepted(): tested addr=" << sockaddr_storage_iptostring(addr) << ", checking flags=" << checking_flags ;
@@ -409,6 +414,7 @@ bool p3BanList::isAddressAccepted(
         check_result = RSBANLIST_CHECK_RESULT_ACCEPTED;
     return true ;
 }
+
 void p3BanList::getWhiteListedIps(std::list<BanListPeer> &lst)
 {
     RS_STACK_MUTEX(mBanMtx) ;
@@ -580,11 +586,6 @@ int p3BanList::tick()
 #endif
 
     return 0;
-}
-
-int	p3BanList::status()
-{
-	return 1;
 }
 
 void p3BanList::getDhtInfo()

--- a/libretroshare/src/services/p3banlist.h
+++ b/libretroshare/src/services/p3banlist.h
@@ -105,7 +105,6 @@ public:
 
      */
     virtual int   tick();
-    virtual int   status();
 
     int     sendPackets();
     bool 	processIncoming();


### PR DESCRIPTION
This method is called from other threads and apparently caused a sporadic crash caught on Android.
See retroshare://forum?name=Got%20crash%20on%20Android%20with%20GDB%20backtrace&id=95de1451952d8c38cb1cdfdb85eed986&msgid=ac8c9d41f2cd0c9e8e290433c7f296fecb2d62b3