### PR TITLE
added destructor in RsTickingThread calling for fullstop, which preve…

### DIFF
--- a/libretroshare/src/util/rsthreads.cc
+++ b/libretroshare/src/util/rsthreads.cc
@@ -236,6 +236,10 @@ RsTickingThread::RsTickingThread()
 #endif
 }
 
+RsTickingThread::~RsTickingThread()
+{
+    fullstop();
+}
 void RsSingleJobThread::runloop()
 {
     run() ;

--- a/libretroshare/src/util/rsthreads.h
+++ b/libretroshare/src/util/rsthreads.h
@@ -287,6 +287,7 @@ class RsTickingThread: public RsThread
 {
 public:
     RsTickingThread();
+    virtual ~RsTickingThread();
 
     void shutdown();
     void fullstop();


### PR DESCRIPTION
…nts the crash due to threads being killed when still running