### PR TITLE
Improve SQLCipher/SQLite support

### DIFF
--- a/build_scripts/Android/prepare-toolchain-clang.sh
+++ b/build_scripts/Android/prepare-toolchain-clang.sh
@@ -325,13 +325,6 @@ build_sqlcipher()
 ################################################################################
 "
 
-	case "${ANDROID_NDK_ARCH}" in
-	"arm64")
-		echo sqlcipher not supported for arm64
-		return 0
-	;;
-	esac
-
 	B_dir="sqlcipher-${SQLCIPHER_SOURCE_VERSION}"
 	rm -rf $B_dir
 
@@ -342,6 +335,14 @@ build_sqlcipher()
 
 	tar -xf $T_file
 	cd $B_dir
+	case "${ANDROID_NDK_ARCH}" in
+	"arm64")
+	# SQLCipher config.sub is outdated and doesn't recognize newer architectures
+		rm config.sub
+		autoreconf --verbose --install --force
+		automake --add-missing --copy --force-missing
+	;;
+	esac
 	./configure --with-pic --build=$(sh ./config.guess) \
 		--host=${cArch}-linux \
 		--prefix="${PREFIX}" --with-sysroot="${SYSROOT}" \

--- a/libretroshare/src/util/retrodb.h
+++ b/libretroshare/src/util/retrodb.h
@@ -19,8 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef RSSQLITE_H
-#define RSSQLITE_H
+#pragma once
 
 #ifdef NO_SQLCIPHER
 #include <sqlite3.h>
@@ -32,9 +31,10 @@
 #include <set>
 #include <list>
 #include <map>
-#include "rsdbbind.h"
 
-#include "contentvalue.h"
+#include "util/rsdebug.h"
+#include "util/rsdbbind.h"
+#include "util/contentvalue.h"
 
 class RetroCursor;
 
@@ -202,6 +202,8 @@ private:
 
     sqlite3* mDb;
     const std::string mKey;
+
+	RS_SET_CONTEXT_DEBUG_LEVEL(3)
 };
 
 /*!
@@ -318,5 +320,3 @@ public:
 private:
     sqlite3_stmt* mStmt;
 };
-
-#endif // RSSQLITE_H


### PR DESCRIPTION
When compiled with SQLCipher it is now capable of handling databases  created by SQLite-only versions
Add support for SQLCipher on Android arm64