### PR TITLE
Fix implicitly-declared operator= warnings

### DIFF
--- a/libretroshare/src/gxs/rsgds.h
+++ b/libretroshare/src/gxs/rsgds.h
@@ -48,13 +48,12 @@ public:
  * This allows modification of local
  * meta data items of a message
  */
-class MsgLocMetaData {
+struct MsgLocMetaData {
+	MsgLocMetaData() = default;
+	MsgLocMetaData(const MsgLocMetaData& meta): msgId(meta.msgId), val(meta.val) {}
 
-public:
-    MsgLocMetaData(const MsgLocMetaData& meta){ msgId = meta.msgId; val = meta.val;}
-    MsgLocMetaData() {}
-    RsGxsGrpMsgIdPair msgId;
-    ContentValue val;
+	RsGxsGrpMsgIdPair msgId;
+	ContentValue val;
 };
 
 typedef std::map<RsGxsGroupId,RsGxsGrpMetaData*> RsGxsGrpMetaTemporaryMap;
@@ -63,14 +62,12 @@ typedef std::map<RsGxsGroupId,RsGxsGrpMetaData*> RsGxsGrpMetaTemporaryMap;
  * This allows modification of local
  * meta data items of a group
  */
-class GrpLocMetaData {
+struct GrpLocMetaData {
+	GrpLocMetaData() = default;
+	GrpLocMetaData(const GrpLocMetaData& meta): grpId(meta.grpId), val(meta.val) {}
 
-public:
-    GrpLocMetaData(const GrpLocMetaData& meta){ grpId = meta.grpId; val = meta.val;}
-    GrpLocMetaData(){}
-    RsGxsGroupId grpId;
-    ContentValue val;
-
+	RsGxsGroupId grpId;
+	ContentValue val;
 };
 
 /*!


### PR DESCRIPTION
/libretroshare/src/gxs/rsgds.h:54: warning: implicitly-declared
'ContentValue& ContentValue::operator=(const ContentValue&)' is
deprecated [-Wdeprecated-copy]
   54 |     MsgLocMetaData(const MsgLocMetaData& meta){ msgId =
meta.msgId; val = meta.val;}

/libretroshare/src/gxs/rsgds.h:69: warning: implicitly-declared
'ContentValue& ContentValue::operator=(const ContentValue&)' is
deprecated [-Wdeprecated-copy]
   69 |     GrpLocMetaData(const GrpLocMetaData& meta){ grpId =
meta.grpId; val = meta.val;}

From 248 to 146 warnings.