### PR TITLE
Fix implicitly-declared operator= warnings

### DIFF
--- a/retroshare-gui/src/TorControl/CryptoKey.cpp
+++ b/retroshare-gui/src/TorControl/CryptoKey.cpp
@@ -51,8 +51,13 @@ void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
 void base32_encode(char *dest, unsigned destlen, const char *src, unsigned srclen);
 bool base32_decode(char *dest, unsigned destlen, const char *src, unsigned srclen);
 
-CryptoKey::CryptoKey()
+CryptoKey& CryptoKey::operator = (const CryptoKey &t)
 {
+	// Check for self assignment
+	if(this != &t)
+		d = t.d;
+
+	return *this;
 }
 
 CryptoKey::~CryptoKey()

--- a/retroshare-gui/src/TorControl/CryptoKey.h
+++ b/retroshare-gui/src/TorControl/CryptoKey.h
@@ -50,15 +50,16 @@ public:
         DER
     };
 
-    CryptoKey();
+    CryptoKey() = default;
     CryptoKey(const CryptoKey &other) : d(other.d) { }
+    CryptoKey& operator = (const CryptoKey &t);
     ~CryptoKey();
 
     bool loadFromData(const QByteArray &data, KeyType type, KeyFormat format = PEM);
     bool loadFromFile(const QString &path, KeyType type, KeyFormat format = PEM);
     void clear();
 
-    bool isLoaded() const { return d.data() && d->key != 0; }
+    bool isLoaded() const { return d.data() && d->key != nullptr; }
     bool isPrivate() const;
 
     QByteArray publicKeyDigest() const;
@@ -83,7 +84,7 @@ private:
         typedef struct rsa_st RSA;
         RSA *key;
 
-        Data(RSA *k = 0) : key(k) { }
+        Data(RSA *k = nullptr) : key(k) { }
         ~Data();
     };
 


### PR DESCRIPTION
/retroshare-gui/src/TorControl/HiddenService.cpp:105: warning:
implicitly-declared 'CryptoKey& CryptoKey::operator=(const CryptoKey&)'
is deprecated [-Wdeprecated-copy]