### PR TITLE
Implement TOFU authentication for RetroShare

### DIFF
--- a/libretroshare/src/pqi/authssl.h
+++ b/libretroshare/src/pqi/authssl.h
@@ -162,6 +162,11 @@ public:
 	 */
 	virtual int VerifyX509Callback(int preverify_ok, X509_STORE_CTX* ctx) = 0;
 
+#ifdef RS_TOFU_AUTHENTICATION
+	/// Same as VerifyX509Callback but with TOFU authentication policy
+	virtual int tofuVerifyX509Cb(int preverify_ok, X509_STORE_CTX* ctx) = 0;
+#endif // RS_TOFU_AUTHENTICATION
+
 	/// SSL specific functions used in pqissl/pqissllistener
 	virtual SSL_CTX* getCTX() = 0;
 
@@ -239,6 +244,11 @@ public:
 
 	/// @see AuthSSL
 	int VerifyX509Callback(int preverify_ok, X509_STORE_CTX *ctx) override;
+
+#ifdef RS_TOFU_AUTHENTICATION
+	/// @see AuthSSL
+	int tofuVerifyX509Cb(int preverify_ok, X509_STORE_CTX* ctx) override;
+#endif // RS_TOFU_AUTHENTICATION
 
 	/// @see AuthSSL
 	bool parseX509DetailsFromFile(

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -195,6 +195,15 @@ rs_service_webui_terminal_password:CONFIG -= no_rs_service_webui_terminal_passwo
 CONFIG *= no_rs_service_terminal_login
 rs_service_terminal_login:CONFIG -= no_rs_service_terminal_login
 
+# To enable TOFU authentication append the following assignation to qmake
+# command line "CONFIG+=rs_tofu_authentication". This is not intended for end
+# users as it radically changes RetroShare security model, making it much more
+# insecure. Still it might be useful in specific corner cases such as
+# chat-servers, where accepting everyone at first connection attempt is the
+# normal behaviour.
+CONFIG *= no_rs_tofu_authentication
+rs_tofu_authentication:CONFIG -= no_rs_tofu_authentication
+
 # Specify host precompiled jsonapi-generator path, appending the following
 # assignation to qmake command line
 # 'JSONAPI_GENERATOR_EXE=/myBuildDir/jsonapi-generator'. Required for JSON API
@@ -453,6 +462,7 @@ rs_gxs_send_all:DEFINES *= RS_GXS_SEND_ALL
 rs_webui:DEFINES *= RS_WEBUI
 rs_service_webui_terminal_password:DEFINES *= RS_SERVICE_TERMINAL_WEBUI_PASSWORD
 rs_service_terminal_login:DEFINES *= RS_SERVICE_TERMINAL_LOGIN
+rs_tofu_authentication:DEFINES *= RS_TOFU_AUTHENTICATION
 
 sqlcipher {
     DEFINES -= NO_SQLCIPHER


### PR DESCRIPTION
This might be extremely dangerous in common RetroShare use case, but it
is extremely useful for chat-servers.
Of course it is disabled by default and one have to explicitly enable
it at compile time to have TOFU enabled RetroShare version.