### PR TITLE
Multiple improvements to global router

### DIFF
--- a/libretroshare/src/grouter/grouteritems.cc
+++ b/libretroshare/src/grouter/grouteritems.cc
@@ -108,7 +108,7 @@ void RsGRouterGenericDataItem::serial_process(RsGenericSerializer::SerializeJob 
 
     RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,signature,"signature") ;
     RsTypeSerializer::serial_process<uint32_t>(j,ctx,duplication_factor,"duplication_factor") ;
-    RsTypeSerializer::serial_process<uint32_t>(j,ctx,flags,"flags") ;
+	RS_SERIAL_PROCESS(flags);
 
     if(j == RsGenericSerializer::DESERIALIZE) // make sure the duplication factor is not altered by friends. In the worst case, the item will duplicate a bit more.
     {
@@ -128,7 +128,7 @@ void RsGRouterGenericDataItem::serial_process(RsGenericSerializer::SerializeJob 
 void RsGRouterSignedReceiptItem::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
 {
     RsTypeSerializer::serial_process<uint64_t> (j,ctx,routing_id,"routing_id") ;
-    RsTypeSerializer::serial_process<uint32_t> (j,ctx,flags,"flags") ;
+    RS_SERIAL_PROCESS(flags);
     RsTypeSerializer::serial_process           (j,ctx,destination_key,"destination_key") ;
     RsTypeSerializer::serial_process<uint32_t> (j,ctx,service_id,"service_id") ;
     RsTypeSerializer::serial_process           (j,ctx,data_hash,"data_hash") ;

--- a/libretroshare/src/grouter/grouteritems.cc
+++ b/libretroshare/src/grouter/grouteritems.cc
@@ -269,3 +269,4 @@ RsGRouterSignedReceiptItem *RsGRouterSignedReceiptItem::duplicate() const
     return item ;
 }
 
+RsGRouterAbstractMsgItem::~RsGRouterAbstractMsgItem() = default;

--- a/libretroshare/src/grouter/grouteritems.h
+++ b/libretroshare/src/grouter/grouteritems.h
@@ -103,11 +103,14 @@ struct RsGRouterAbstractMsgItem: RsGRouterItem
 
 	/// packet was delivered, not delivered, bounced, etc
 	RsGrouterItemFlags flags;
+
+	~RsGRouterAbstractMsgItem();
 };
 
-struct RsGRouterGenericDataItem:
-        RsGRouterAbstractMsgItem, RsGRouterNonCopyableObject
+class RsGRouterGenericDataItem:
+        public RsGRouterAbstractMsgItem, public  RsGRouterNonCopyableObject
 {
+public:
 	RsGRouterGenericDataItem():
 	    RsGRouterAbstractMsgItem(RS_PKT_SUBTYPE_GROUTER_DATA),
 	    data_size(0), data_bytes(nullptr), duplication_factor(0)

--- a/libretroshare/src/grouter/groutertypes.h
+++ b/libretroshare/src/grouter/groutertypes.h
@@ -29,7 +29,7 @@
 #include "turtle/p3turtle.h"
 #include "retroshare/rsgrouter.h"
 
-struct RsGRouterGenericDataItem;
+class RsGRouterGenericDataItem;
 class RsGRouterSignedReceiptItem ;
 
 #ifndef V07_NON_BACKWARD_COMPATIBLE_CHANGE_GROUTER_SERVICE_ID

--- a/libretroshare/src/grouter/groutertypes.h
+++ b/libretroshare/src/grouter/groutertypes.h
@@ -21,14 +21,15 @@
  *******************************************************************************/
 #pragma once
 
-#include <stdint.h>
-#include "util/rstime.h"
+#include <cstdint>
 #include <list>
+
+#include "util/rstime.h"
 #include "pgp/rscertificate.h"
 #include "turtle/p3turtle.h"
 #include "retroshare/rsgrouter.h"
 
-class RsGRouterGenericDataItem ;
+struct RsGRouterGenericDataItem;
 class RsGRouterSignedReceiptItem ;
 
 static const uint16_t GROUTER_CLIENT_ID_MESSAGES     = 0x1001 ;

--- a/libretroshare/src/grouter/groutertypes.h
+++ b/libretroshare/src/grouter/groutertypes.h
@@ -32,7 +32,11 @@
 struct RsGRouterGenericDataItem;
 class RsGRouterSignedReceiptItem ;
 
-static const uint16_t GROUTER_CLIENT_ID_MESSAGES     = 0x1001 ;
+#ifndef V07_NON_BACKWARD_COMPATIBLE_CHANGE_GROUTER_SERVICE_ID
+/// Pay special attention fixing this, as may break retrocompatibility!
+RS_DEPRECATED_FOR(RsServiceType::MSG)
+static const uint16_t GROUTER_CLIENT_ID_MESSAGES     = 0x1001;
+#endif // V07_NON_BACKWARD_COMPATIBLE_CHANGE_GROUTER_SERVICE_ID
 
 static const uint32_t RS_GROUTER_MATRIX_MAX_HIT_ENTRIES       =        10 ; // max number of clues to store
 static const uint32_t RS_GROUTER_MATRIX_MIN_TIME_BETWEEN_HITS =        60 ; // can be set to up to half the publish time interval. Prevents flooding routes.

--- a/libretroshare/src/grouter/p3grouter.cc
+++ b/libretroshare/src/grouter/p3grouter.cc
@@ -1927,7 +1927,7 @@ bool p3GRouter::registerClientService(const GRouterServiceId& id,GRouterClientSe
 
 bool p3GRouter::encryptDataItem(RsGRouterGenericDataItem *item,const RsGxsId& destination_key)
 {
-	assert(!(item->flags & RsGrouterItemFlags::ENCRYPTED)) ;
+	assert(!(item->flags & RsGrouterItemFlags::ENCRYPTED));
 
 #ifdef GROUTER_DEBUG
     std::cerr << "  Encrypting data for key " << destination_key << std::endl;
@@ -1963,7 +1963,7 @@ return true ;
 }
 bool p3GRouter::decryptDataItem(RsGRouterGenericDataItem *item)
 {
-	assert(item->flags & RsGrouterItemFlags::ENCRYPTED);
+	assert(!!(item->flags & RsGrouterItemFlags::ENCRYPTED));
 
 #ifdef GROUTER_DEBUG
     std::cerr << "  decrypting data for key " << item->destination_key << std::endl;

--- a/libretroshare/src/grouter/p3grouter.h
+++ b/libretroshare/src/grouter/p3grouter.h
@@ -3,7 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2013 by Cyril Soler <csoler@users.sourceforge.net>                *
+ * Copyright (C) 2013  Cyril Soler <csoler@users.sourceforge.net>              *
+ * Copyright (C) 2019  Gioacchino Mazzurco <gio@eigenlab.org>                  *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -22,8 +23,8 @@
 #pragma once
 
 #include <map>
-#include <queue>
 #include <fstream>
+#include <list>
 
 #include "retroshare/rsgrouter.h"
 #include "retroshare/rstypes.h"
@@ -33,15 +34,13 @@
 #include "turtle/turtleclientservice.h"
 #include "services/p3service.h"
 #include "pqi/p3cfgmgr.h"
-
+#include "util/rsdebug.h"
 #include "groutertypes.h"
 #include "groutermatrix.h"
 #include "grouteritems.h"
 
 // To be put in pqi/p3cfgmgr.h
-//
 static const uint32_t CONFIG_TYPE_GROUTER = 0x0016 ;
-static const uint32_t RS_GROUTER_DATA_FLAGS_ENCRYPTED = 0x0001 ;
 
 class p3LinkMgr ;
 class p3turtle ;
@@ -352,4 +351,22 @@ private:
     rstime_t _last_config_changed ;
 
     uint64_t _random_salt ;
+
+	/** Temporarly store items that could not have been verified yet due to
+	 * missing author key, attempt to handle them once in a while.
+	 * The items are discarded if after mMissingKeyQueueEntryTimeout the key
+	 * hasn't been received yet, and are not saved on RetroShare stopping. */
+	std::list< std::pair<
+	    std::unique_ptr<RsGRouterGenericDataItem>, rstime_t > > mMissingKeyQueue;
+
+	/// @see mMissingKeyQueue
+	static constexpr rstime_t mMissingKeyQueueEntryTimeout = 600;
+
+	/// @see mMissingKeyQueue
+	static constexpr rstime_t mMissingKeyQueueCheckEvery = 30;
+
+	/// @see mMissingKeyQueue
+	rstime_t mMissingKeyQueueCheckLastCheck = 0;
+
+	RS_SET_CONTEXT_DEBUG_LEVEL(2)
 };

--- a/libretroshare/src/grouter/p3grouter.h
+++ b/libretroshare/src/grouter/p3grouter.h
@@ -358,6 +358,7 @@ private:
 	 * hasn't been received yet, and are not saved on RetroShare stopping. */
 	std::list< std::pair<
 	    std::unique_ptr<RsGRouterGenericDataItem>, rstime_t > > mMissingKeyQueue;
+	RsMutex mMissingKeyQueueMtx; /// protect mMissingKeyQueue
 
 	/// @see mMissingKeyQueue
 	static constexpr rstime_t mMissingKeyQueueEntryTimeout = 600;

--- a/libretroshare/src/pqi/p3servicecontrol.cc
+++ b/libretroshare/src/pqi/p3servicecontrol.cc
@@ -431,72 +431,45 @@ bool p3ServiceControl::updateServicePermissions(uint32_t serviceId, const RsServ
 // to the pqiStreamer, (when items have been sorted by peers already!).
 // but we will do this later.
 
-bool	p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId &peerId)
+bool p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId& peerId)
 {
-	RsStackMutex stack(mCtrlMtx); /***** LOCK STACK MUTEX ****/
+	Dbg4() << __PRETTY_FUNCTION__ << " serviceId: " << serviceId << " peerId: "
+	       << peerId << std::endl;
 
-#ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::checkFilter() ";
-	std::cerr << " ServiceId: " << serviceId;
-#endif
+	RS_STACK_MUTEX(mCtrlMtx);
 
 	std::map<uint32_t, RsServiceInfo>::iterator it;
 	it = mOwnServices.find(serviceId);
 	if (it != mOwnServices.end())
-	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << " ServiceName: " << it->second.mServiceName;
-#endif
-	}
+		Dbg3() << __PRETTY_FUNCTION__ << " serviceId: " << serviceId
+		       << " peerId: " << peerId<< " ServiceName: "
+		       << it->second.mServiceName << std::endl;
 	else
-	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << " ServiceName: Unknown! ";
-#endif
-	}
-
-#ifdef SERVICECONTROL_DEBUG
-	std::cerr << " PeerId: " << peerId.toStdString();
-	std::cerr << std::endl;
-#endif
+		Dbg2() << __PRETTY_FUNCTION__ << " serviceId: " << serviceId
+		       << " peerId: " << peerId << " ServiceName: Unknown!"
+		       << std::endl;
 
 	// must allow ServiceInfo through, or we have nothing!
-	if (serviceId == RsServiceInfo::RsServiceInfoUIn16ToFullServiceId(RS_SERVICE_TYPE_SERVICEINFO))
-	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Allowed SERVICEINFO";
-		std::cerr << std::endl;
-#endif
-		return true;
-	}
-
+	if(serviceId == RsServiceInfo::RsServiceInfoUIn16ToFullServiceId(
+	            RS_SERVICE_TYPE_SERVICEINFO )) return true;
 
 	std::map<RsPeerId, ServicePeerFilter>::const_iterator pit;
 	pit = mPeerFilterMap.find(peerId);
 	if (pit == mPeerFilterMap.end())
 	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Denied No PeerId";
-		std::cerr << std::endl;
-#endif
+		Dbg2() << __PRETTY_FUNCTION__ << " Denied No PeerId" << std::endl;
 		return false;
 	}
 
 	if (pit->second.mDenyAll)
 	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Denied Peer.DenyAll";
-		std::cerr << std::endl;
-#endif
+		Dbg2() << __PRETTY_FUNCTION__ << " Denied Peer.DenyAll" << std::endl;
 		return false;
 	}
 
 	if (pit->second.mAllowAll)
 	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Allowed Peer.AllowAll";
-		std::cerr << std::endl;
-#endif
+		Dbg3() << __PRETTY_FUNCTION__ << " Allowed Peer.AllowAll" << std::endl;
 		return true;
 	}
 
@@ -504,16 +477,14 @@ bool	p3ServiceControl::checkFilter(uint32_t serviceId, const RsPeerId &peerId)
 	sit = pit->second.mAllowedServices.find(serviceId);
 	if (sit == pit->second.mAllowedServices.end())
 	{
-#ifdef SERVICECONTROL_DEBUG
-		std::cerr << "p3ServiceControl::checkFilter() Denied !Peer.find(serviceId)";
-		std::cerr << std::endl;
-#endif
+		Dbg2() << __PRETTY_FUNCTION__ << " Denied !Peer.find(serviceId)"
+		       << std::endl;
 		return false;
 	}
-#ifdef SERVICECONTROL_DEBUG
-	std::cerr << "p3ServiceControl::checkFilter() Allowed Peer.find(serviceId)";
-	std::cerr << std::endl;
-#endif
+
+	Dbg3() << __PRETTY_FUNCTION__ << " Allowed Peer.find(serviceId)"
+	       << std::endl;
+
 	return true;
 }
 

--- a/libretroshare/src/pqi/p3servicecontrol.h
+++ b/libretroshare/src/pqi/p3servicecontrol.h
@@ -19,8 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef P3_SERVICE_CONTROL_HEADER
-#define P3_SERVICE_CONTROL_HEADER
+#pragma once
 
 #include <string>
 #include <map>
@@ -30,6 +29,7 @@
 #include "pqi/pqimonitor.h"
 #include "pqi/pqiservicemonitor.h"
 #include "pqi/p3linkmgr.h"
+#include "util/rsdebug.h"
 
 class p3ServiceServer ;
 
@@ -199,7 +199,6 @@ bool peerHasPermissionForService_locked(const RsPeerId &peerId, uint32_t service
     std::map<uint32_t, RsServicePermissions> mServicePermissionMap;
 
     p3ServiceServer *mServiceServer ;
+
+	RS_SET_CONTEXT_DEBUG_LEVEL(2)
 };
-
-
-#endif // P3_SERVICE_CONTROL_HEADER

--- a/libretroshare/src/retroshare/rsgrouter.h
+++ b/libretroshare/src/retroshare/rsgrouter.h
@@ -3,7 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2013 by Cyril Soler <retroshare.project@gmail.com>                *
+ * Copyright (C) 2013  Cyril Soler <retroshare.project@gmail.com>              *
+ * Copyright (C) 2019  Gioacchino Mazzurco <gio@eigenlab.org>                  *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -19,19 +20,28 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-
 #pragma once
 
 #include "util/rsdir.h"
+#include "util/rsdeprecate.h"
 #include "retroshare/rsids.h"
 #include "retroshare/rsgxsifacetypes.h"
 
-typedef RsGxsId  GRouterKeyId ;	// we use SSLIds, so that it's easier in the GUI to mix up peer ids with grouter ids.
-typedef uint32_t GRouterServiceId ;
-typedef uint64_t GRouterMsgPropagationId ;
+RS_DEPRECATED_FOR(RsGxsId)
+typedef RsGxsId GRouterKeyId;
+
+/**
+ * @note Some items use this type, when migrating to RsServiceType (2 bytes),
+ * special care should be taken to do it in a way which doesn't break
+ * retrocompatibility
+ */
+RS_DEPRECATED_FOR(RsServiceType)
+typedef uint32_t GRouterServiceId;
+
+typedef uint64_t GRouterMsgPropagationId;
 
 class GRouterClientService ;
-class RsGRouterGenericDataItem ;
+struct RsGRouterGenericDataItem;
 
 class RsGRouter
 {

--- a/libretroshare/src/retroshare/rsgrouter.h
+++ b/libretroshare/src/retroshare/rsgrouter.h
@@ -26,6 +26,7 @@
 #include "util/rsdeprecate.h"
 #include "retroshare/rsids.h"
 #include "retroshare/rsgxsifacetypes.h"
+#include "rsitems/rsserviceids.h"
 
 RS_DEPRECATED_FOR(RsGxsId)
 typedef RsGxsId GRouterKeyId;
@@ -64,12 +65,12 @@ public:
         Sha1CheckSum            item_hash ;
     };
 
-    struct GRouterPublishedKeyInfo
-    {
-        std::string  	description_string ;
-        RsGxsId 	authentication_key ;
-        uint32_t     	service_id ;
-    };
+	struct GRouterPublishedKeyInfo
+	{
+		std::string description_string;
+		RsGxsId authentication_key;
+		uint32_t service_id; // TODO: use RsServiceType instead
+	};
 
     struct GRouterRoutingMatrixInfo
     {
@@ -100,10 +101,16 @@ public:
     //         Communication to other services.          //
     //===================================================//
 
-    virtual bool sendData(const RsGxsId& destination, const GRouterServiceId& client_id, const uint8_t *data, uint32_t data_size, const RsGxsId& signing_id, GRouterMsgPropagationId& id) =0;
-    virtual bool cancel(GRouterMsgPropagationId mid) =0;
+	virtual bool sendData(
+	        const RsGxsId& destination, RsServiceType client_id,
+	        const uint8_t* data, uint32_t data_size, const RsGxsId& signing_id,
+	        GRouterMsgPropagationId& id ) = 0;
+	virtual bool cancel(GRouterMsgPropagationId mid) =0;
 
-    virtual bool registerKey(const RsGxsId& authentication_id, const GRouterServiceId& client_id,const std::string& description_string)=0 ;
+	virtual bool registerKey(
+	        const RsGxsId& authentication_id, RsServiceType client_id,
+	        const std::string& description_string ) = 0;
+	virtual bool unregisterKey(const RsGxsId& key_id, RsServiceType sid) = 0;
 
     //===================================================//
     //         Routage feedback from other services      //

--- a/libretroshare/src/retroshare/rsgrouter.h
+++ b/libretroshare/src/retroshare/rsgrouter.h
@@ -42,7 +42,7 @@ typedef uint32_t GRouterServiceId;
 typedef uint64_t GRouterMsgPropagationId;
 
 class GRouterClientService ;
-struct RsGRouterGenericDataItem;
+class RsGRouterGenericDataItem;
 
 class RsGRouter
 {

--- a/libretroshare/src/retroshare/rsidentity.h
+++ b/libretroshare/src/retroshare/rsidentity.h
@@ -524,9 +524,13 @@ struct RsIdentity : RsGxsIfaceHelper
 	 * @brief request details of a not yet known identity to the network
 	 * @jsonapi{development}
 	 * @param[in] id id of the identity to request
+	 * @param[in] peers optional list of the peers to ask for the key, if empty
+	 *	all online peers are asked.
 	 * @return false on error, true otherwise
 	 */
-	virtual bool requestIdentity(const RsGxsId& id) = 0;
+	virtual bool requestIdentity(
+	        const RsGxsId& id,
+	        const std::vector<RsPeerId>& peers = std::vector<RsPeerId>() ) = 0;
 
 
 	RS_DEPRECATED

--- a/libretroshare/src/rsitems/rsserviceids.h
+++ b/libretroshare/src/rsitems/rsserviceids.h
@@ -40,7 +40,6 @@ enum class RsServiceType : uint16_t
 	FILE_DATABASE              = 0x0019,
 	SERVICEINFO                = 0x0020,
 	BANDWIDTH_CONTROL          = 0x0021,
-	MAIL                       = 0x0022,
 	DIRECT_MAIL                = 0x0023,
 	DISTANT_MAIL               = 0x0024,
 	GWEMAIL_MAIL               = 0x0025,
@@ -98,8 +97,6 @@ RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_GROUTER        =
 RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_FILE_DATABASE  = 0x0019;
 RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_SERVICEINFO    = 0x0020;
 RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_BWCTRL         = 0x0021; /// Bandwidth Control
-/// New Mail Service (replace old Msg Service)
-RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_MAIL           = 0x0022;
 RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_DIRECT_MAIL    = 0x0023;
 RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_DISTANT_MAIL   = 0x0024;
 RS_DEPRECATED_FOR(RsServiceType) const uint16_t RS_SERVICE_TYPE_GWEMAIL_MAIL   = 0x0025;

--- a/libretroshare/src/services/p3gxscircles.cc
+++ b/libretroshare/src/services/p3gxscircles.cc
@@ -1118,7 +1118,7 @@ bool p3GxsCircles::cache_request_load(const RsGxsCircleId &id)
 		return true;
 	}
 
-	int32_t age = 0;
+	uint32_t age = 0;
 	if (RsTickEvent::prev_event_ago(CIRCLE_EVENT_CACHELOAD, age))
 	{
 		if (age < MIN_CIRCLE_LOAD_GAP)

--- a/libretroshare/src/services/p3idservice.cc
+++ b/libretroshare/src/services/p3idservice.cc
@@ -1168,97 +1168,97 @@ bool p3IdService::haveKey(const RsGxsId &id)
 
 bool p3IdService::havePrivateKey(const RsGxsId &id)
 {
-    if(! isOwnId(id))
-        return false ;
+	if(!isOwnId(id)) return false;
 
-    RsStackMutex stack(mIdMtx); /********** STACK LOCKED MTX ******/
-    return mKeyCache.is_cached(id) ;
+	RS_STACK_MUTEX(mIdMtx);
+	return mKeyCache.is_cached(id);
 }
 
-static void mergeIds(std::map<RsGxsId,std::list<RsPeerId> >& idmap,const RsGxsId& id,const std::list<RsPeerId>& peers)
+static void mergeIds(
+        std::map<RsGxsId, std::list<RsPeerId> >& idmap,
+        const RsGxsId& id, const std::list<RsPeerId>& peers )
 {
-    // merge the two lists (I use a std::set to make it more efficient)
-#ifdef DEBUG_IDS
-    std::cerr << "p3IdService::requestKey(): merging list with existing pending request." << std::endl;
-#endif
+	/* merge the two lists, use std::set to avoid duplicates efficiently */
 
-    std::list<RsPeerId>& old_peers(idmap[id]) ;	// create if necessary
-    std::set<RsPeerId> new_peers ;
+	std::set<RsPeerId> new_peers(std::begin(peers), std::end(peers));
 
-    for(std::list<RsPeerId>::const_iterator it(peers.begin());it!=peers.end();++it)
-        new_peers.insert(*it) ;
-
-    for(std::list<RsPeerId>::iterator it(old_peers.begin());it!=old_peers.end();++it)
-        new_peers.insert(*it) ;
-
-    old_peers.clear();
-
-    for(std::set<RsPeerId>::iterator it(new_peers.begin());it!=new_peers.end();++it)
-        old_peers.push_back(*it) ;
+	std::list<RsPeerId>& stored_peers(idmap[id]);
+	std::copy( std::begin(stored_peers), std::end(stored_peers),
+	           std::inserter(new_peers, std::begin(new_peers)) );
+	stored_peers.clear();
+	std::copy( std::begin(new_peers), std::end(new_peers),
+	           std::inserter(stored_peers, std::begin(stored_peers)) );
 }
 
-bool p3IdService::requestIdentity(const RsGxsId& id)
+bool p3IdService::requestIdentity(
+        const RsGxsId& id, const std::vector<RsPeerId>& peers )
 {
+	std::list<RsPeerId> askPeersList(peers.begin(), peers.end());
+
+	// Empty list passed? Ask to all online peers.
+	if(askPeersList.empty()) rsPeers->getOnlineList(askPeersList);
+
+	if(askPeersList.empty()) // Still empty? Fail!
+	{
+		RsErr() << __PRETTY_FUNCTION__ << " failure retrieving peers list"
+		        << std::endl;
+		return false;
+	}
+
 	RsIdentityUsage usageInfo( RsServiceType::GXSID,
 	                           RsIdentityUsage::IDENTITY_DATA_UPDATE );
-	std::list<RsPeerId> onlinePeers;
 
-	return rsPeers && rsPeers->getOnlineList(onlinePeers)
-	        && requestKey(id, onlinePeers, usageInfo);
+	return requestKey(id, askPeersList, usageInfo);
 }
 
-bool p3IdService::requestKey(const RsGxsId &id, const std::list<RsPeerId>& peers,const RsIdentityUsage& use_info)
+bool p3IdService::requestKey(
+        const RsGxsId& id, const std::list<RsPeerId>& peers,
+        const RsIdentityUsage& use_info )
 {
-    if(id.isNull())
-    {
-        std::cerr << "(EE) nul ID requested to p3IdService. This should not happen. Callstack:" << std::endl;
-        print_stacktrace();
-        return false ;
-    }
+	Dbg3() << __PRETTY_FUNCTION__ << " id: " <<  id << std::endl;
 
-    if (haveKey(id))
-        return true;
-    else
-    {
-        // Normally we should call getIdDetails(), but since the key is not known, we need to digg a possibly old information
-        // from the reputation system, which keeps its own list of banned keys. Of course, the owner ID is not known at this point.
+	if(id.isNull())
+	{
+		RsErr() << __PRETTY_FUNCTION__ << " cannot request null id"
+		        << std::endl;
+		return false;
+	}
 
-#ifdef DEBUG_IDS
-        std::cerr << "p3IdService::requesting key " << id <<std::endl;
-#endif
+	if(peers.empty())
+	{
+		RsErr() << __PRETTY_FUNCTION__ << " cannot request id: " << id
+		        << " to empty lists of peers" << std::endl;
+		return false;
+	}
 
-		RsReputationInfo info;
-        rsReputations->getReputationInfo(id,RsPgpId(),info) ;
+	if(isKnownId(id)) return true;
 
-		if( info.mOverallReputationLevel == RsReputationLevel::LOCALLY_NEGATIVE )
-        {
-            std::cerr << "(II) not requesting Key " << id << " because it has been banned." << std::endl;
+	/* Normally we should call getIdDetails(), but since the key is not known,
+	 * we need to dig a possibly old information from the reputation system,
+	 * which keeps its own list of banned keys.
+	 * Of course, the owner ID is not known at this point.c*/
 
-            {
-                RS_STACK_MUTEX(mIdMtx); /********** STACK LOCKED MTX ******/
-                mIdsNotPresent.erase(id) ;
-            }
-            return true;
-        }
+	RsReputationInfo info;
+	rsReputations->getReputationInfo(id, RsPgpId(), info);
 
-        RsStackMutex stack(mIdMtx); /********** STACK LOCKED MTX ******/
+	if( info.mOverallReputationLevel == RsReputationLevel::LOCALLY_NEGATIVE )
+	{
+		RsInfo() << __PRETTY_FUNCTION__ << " not requesting Key " << id
+		         << " because it has been banned." << std::endl;
 
-        std::map<RsGxsId,std::list<RsPeerId> >::iterator rit = mIdsNotPresent.find(id) ;
+		RS_STACK_MUTEX(mIdMtx);
+		mIdsNotPresent.erase(id);
 
-        if(rit != mIdsNotPresent.end())
-        {
-            if(!peers.empty())
-                mergeIds(mIdsNotPresent,id,peers) ;
+		return false;
+	}
 
-            return true ;
-        }
-    }
-    {
-		RS_STACK_MUTEX(mIdMtx); /********** STACK LOCKED MTX ******/
-		mKeysTS[id].usage_map[use_info] = time(NULL) ;
-    }
+	{
+		RS_STACK_MUTEX(mIdMtx);
+		mergeIds(mIdsNotPresent, id, peers);
+		mKeysTS[id].usage_map[use_info] = time(nullptr);
+	}
 
-    return cache_request_load(id, peers);
+	return cache_request_load(id, peers);
 }
 
 bool p3IdService::isPendingNetworkRequest(const RsGxsId& gxsId)
@@ -2778,36 +2778,34 @@ bool p3IdService::cache_store(const RsGxsIdGroupItem *item)
 
 #define MIN_CYCLE_GAP	2
 
-bool p3IdService::cache_request_load(const RsGxsId &id, const std::list<RsPeerId> &peers)
+bool p3IdService::cache_request_load(
+        const RsGxsId& id, const std::list<RsPeerId>& peers )
 {
-#ifdef DEBUG_IDS
-    std::cerr << "p3IdService::cache_request_load(" << id << ")" << std::endl;
-#endif // DEBUG_IDS
+	Dbg4() << __PRETTY_FUNCTION__ << " id: " << id << std::endl;
 
-    {
-        RsStackMutex stack(mIdMtx); /********** STACK LOCKED MTX ******/
+	{
+		RS_STACK_MUTEX(mIdMtx);
+		// merge, even if peers is empty
+		mergeIds(mCacheLoad_ToCache, id, peers);
+	}
 
-        mergeIds(mCacheLoad_ToCache,id,peers) ;	// merge, even if peers is empty
-    }
+	if(RsTickEvent::event_count(GXSID_EVENT_CACHELOAD) > 0)
+	{
+		Dbg3() << __PRETTY_FUNCTION__ << " cache reload already scheduled "
+		       << "skipping" << std::endl;
+		return true;
+	}
 
-    if (RsTickEvent::event_count(GXSID_EVENT_CACHELOAD) > 0)
-    {
-        /* its already scheduled */
-        return true;
-    }
+	uint32_t age = 0;
+	if( RsTickEvent::prev_event_ago(GXSID_EVENT_CACHELOAD, age) &&
+	        age < MIN_CYCLE_GAP )
+	{
+		RsTickEvent::schedule_in(GXSID_EVENT_CACHELOAD, MIN_CYCLE_GAP - age);
+		return true;
+	}
 
-    int32_t age = 0;
-    if (RsTickEvent::prev_event_ago(GXSID_EVENT_CACHELOAD, age))
-    {
-        if (age < MIN_CYCLE_GAP)
-        {
-            RsTickEvent::schedule_in(GXSID_EVENT_CACHELOAD, MIN_CYCLE_GAP - age);
-            return true;
-        }
-    }
-
-    RsTickEvent::schedule_now(GXSID_EVENT_CACHELOAD);
-    return true;
+	RsTickEvent::schedule_now(GXSID_EVENT_CACHELOAD);
+	return true;
 }
 
 
@@ -2931,71 +2929,88 @@ bool p3IdService::cache_load_for_token(uint32_t token)
 
 void p3IdService::requestIdsFromNet()
 {
-    RsStackMutex stack(mIdMtx);
+	RS_STACK_MUTEX(mIdMtx);
 
-    if(!mNes)
-    {
-        std::cerr << "(WW) cannot request missing GXS IDs because network service is not present." << std::endl;
-        return ;
-    }
+	if(!mNes)
+	{
+		RsErr() << __PRETTY_FUNCTION__ << " Cannot request missing GXS IDs "
+		        << "because network service is not present." << std::endl;
+		return;
+	}
 
-    std::map<RsGxsId, std::list<RsPeerId> >::iterator cit;
-    std::map<RsPeerId, std::list<RsGxsId> > requests;
+	std::map<RsGxsId, std::list<RsPeerId> >::iterator cit;
+	std::map<RsPeerId, std::list<RsGxsId> > requests;
 
-    // Transform to appropriate structure (<peer, std::list<RsGxsId> > map) to make request to nes per peer ID
-    // Only delete entries in mIdsNotPresent that can actually be performed.
+	/* Transform to appropriate structure (<RsPeerId, std::list<RsGxsId> > map)
+	 * to make request to nes per peer ID
+	 * Only delete entries in mIdsNotPresent that can actually be performed, or
+	 * that have empty peer list */
 
-    for(cit = mIdsNotPresent.begin(); cit != mIdsNotPresent.end();)
-    {
-#ifdef DEBUG_IDS
-        std::cerr << "p3IdService::requestIdsFromNet() Id not found, deferring for net request: " << cit->first << std::endl;
-#endif
+	for(cit = mIdsNotPresent.begin(); cit != mIdsNotPresent.end();)
+	{
+		Dbg2() << __PRETTY_FUNCTION__ << " Processing missing key RsGxsId: "
+		       << cit->first << std::endl;
 
-        const std::list<RsPeerId>& peers = cit->second;
-        std::list<RsPeerId>::const_iterator cit2;
+		const RsGxsId& gxsId = cit->first;
+		const std::list<RsPeerId>& peers = cit->second;
+		std::list<RsPeerId>::const_iterator cit2;
 
-        bool request_can_proceed = false ;
+		bool request_can_proceed = false;
 
-        for(cit2 = peers.begin(); cit2 != peers.end(); ++cit2)
-            if(rsPeers->isOnline(*cit2) || mNes->isDistantPeer(*cit2)) // make sure that the peer in online, so that we know that the request has some chance to succeed.
-            {
-                requests[*cit2].push_back(cit->first);
-                request_can_proceed = true ;
-#ifdef DEBUG_IDS
-                std::cerr << "       will ask ID " << cit->first << " to peer ID " << *cit2 << std::endl;
-#endif
-            }
+		for(cit2 = peers.begin(); cit2 != peers.end(); ++cit2)
+		{
+			const RsPeerId& peer = *cit2;
 
-        if(request_can_proceed || peers.empty())
-        {
-            std::map<RsGxsId, std::list<RsPeerId> >::iterator tmp(cit);
-            ++tmp ;
-            mIdsNotPresent.erase(cit) ;
-            cit = tmp ;
-        }
-        else
-        {
-#ifdef DEBUG_IDS
-            std::cerr << "(EE) no online peers among supply list in ID request for groupId " << cit->first << ". Keeping it until peers show up."<< std::endl;
-#endif
-            ++cit ;
-        }
-    }
+			if(rsPeers->isOnline(peer) || mNes->isDistantPeer(peer))
+			{
+				/* make sure that the peer in online, so that we know that the
+				 * request has some chance to succeed.*/
+				requests[peer].push_back(cit->first);
+				request_can_proceed = true ;
 
-    for(std::map<RsPeerId, std::list<RsGxsId> >::const_iterator cit2(requests.begin()); cit2 != requests.end(); ++cit2)
-    {
-        std::list<RsGxsId>::const_iterator gxs_id_it = cit2->second.begin();
-        std::list<RsGxsGroupId> grpIds;
-        for(; gxs_id_it != cit2->second.end(); ++gxs_id_it)
-        {
-#ifdef DEBUG_IDS
-            std::cerr << "  asking ID " << *gxs_id_it << " to peer ID " << cit2->first << std::endl;
-#endif
-            grpIds.push_back(RsGxsGroupId(*gxs_id_it));
-        }
+				Dbg2() << __PRETTY_FUNCTION__ << " Moving missing key RsGxsId:"
+				       << gxsId << " to peer: " << peer << " requests queue"
+				       << std::endl;
+			}
+		}
 
-        mNes->requestGrp(grpIds, cit2->first);
-    }
+		const bool noPeersFound = peers.empty();
+		if(noPeersFound)
+			RsWarn() << __PRETTY_FUNCTION__ << " No peers supplied to request "
+			         << "RsGxsId: " << gxsId << " dropping." << std::endl;
+
+		if(request_can_proceed || noPeersFound)
+		{
+			std::map<RsGxsId, std::list<RsPeerId> >::iterator tmp(cit);
+			++tmp;
+			mIdsNotPresent.erase(cit);
+			cit = tmp;
+		}
+		else
+		{
+			RsInfo() << __PRETTY_FUNCTION__ << " no online peers among supplied"
+			         << " list in request for RsGxsId: " << gxsId
+			         << ". Keeping it until peers show up."<< std::endl;
+			++cit;
+		}
+	}
+
+	for( std::map<RsPeerId, std::list<RsGxsId> >::const_iterator cit2(
+	         requests.begin() ); cit2 != requests.end(); ++cit2 )
+	{
+		const RsPeerId& peer = cit2->first;
+		std::list<RsGxsGroupId> grpIds;
+		for( std::list<RsGxsId>::const_iterator gxs_id_it = cit2->second.begin();
+		     gxs_id_it != cit2->second.end(); ++gxs_id_it )
+		{
+			Dbg2() << __PRETTY_FUNCTION__ << " passing RsGxsId: " << *gxs_id_it
+			       << " request for peer: " << peer
+			       << " to RsNetworkExchangeService " << std::endl;
+			grpIds.push_back(RsGxsGroupId(*gxs_id_it));
+		}
+
+		mNes->requestGrp(grpIds, peer);
+	}
 }
 
 bool p3IdService::cache_update_if_cached(const RsGxsId &id, std::string serviceString)
@@ -4004,7 +4019,7 @@ bool p3IdService::recogn_schedule()
 	std::cerr << std::endl;
 #endif
 
-	int32_t age = 0;
+	uint32_t age = 0;
 	int32_t next_event = 0;
 
 	if (RsTickEvent::event_count(GXSID_EVENT_RECOGN) > 0)
@@ -4706,14 +4721,12 @@ void p3IdService::handle_event(uint32_t event_type, const std::string &/*elabel*
 			break;
 		case GXSID_EVENT_REQUEST_IDS:
 			requestIdsFromNet();
-			break;
-
-
-		default:
-			/* error */
-			std::cerr << "p3IdService::handle_event() Unknown Event Type: " << event_type;
-			std::cerr << std::endl;
-			break;
+		    break;
+	default:
+		RsErr() << __PRETTY_FUNCTION__ << " Unknown Event Type: "
+		        << event_type << std::endl;
+		print_stacktrace();
+		break;
 	}
 }
 
@@ -4723,9 +4736,8 @@ void RsGxsIdGroup::serial_process(
 {
 	RS_SERIAL_PROCESS(mMeta);
 	RS_SERIAL_PROCESS(mPgpIdHash);
-	//RS_SERIAL_PROCESS(mPgpIdSign);
-	RS_SERIAL_PROCESS(mRecognTags);
-	//RS_SERIAL_PROCESS(mImage);
+	RS_SERIAL_PROCESS(mPgpIdSign);
+	RS_SERIAL_PROCESS(mImage);
 	RS_SERIAL_PROCESS(mLastUsageTS);
 	RS_SERIAL_PROCESS(mPgpKnown);
 	RS_SERIAL_PROCESS(mIsAContact);

--- a/libretroshare/src/services/p3idservice.h
+++ b/libretroshare/src/services/p3idservice.h
@@ -369,7 +369,10 @@ public:
 	                                           RsGxsId* id = nullptr);
 
 	/// @see RsIdentity
-	bool requestIdentity(const RsGxsId& id) override;
+	bool requestIdentity(
+	            const RsGxsId& id,
+	            const std::vector<RsPeerId>& peers = std::vector<RsPeerId>()
+	        ) override;
 
 	/**************** RsGixsReputation Implementation ****************/
 
@@ -482,7 +485,7 @@ private:
 
 	/* MUTEX PROTECTED DATA (mIdMtx - maybe should use a 2nd?) */
 
-	std::map<RsPgpId, PGPFingerprintType> mPgpFingerprintMap;
+	std::map<RsPgpId, RsPgpFingerprint> mPgpFingerprintMap;
 	std::list<RsGxsIdGroup> mGroupsToProcess;
 
 	/************************************************************************
@@ -621,5 +624,5 @@ private:
 	bool mAutoAddFriendsIdentitiesAsContacts;
 	uint32_t mMaxKeepKeysBanned;
 
-	RS_SET_CONTEXT_DEBUG_LEVEL(1)
+	RS_SET_CONTEXT_DEBUG_LEVEL(2)
 };

--- a/libretroshare/src/util/rstickevent.h
+++ b/libretroshare/src/util/rstickevent.h
@@ -29,14 +29,15 @@
  */
 
 #include <map>
-#include "util/rstime.h"
 
+#include "util/rstime.h"
+#include "util/rsdebug.h"
 #include "util/rsthreads.h"
 
 class RsTickEvent
 {
-	public:
-	RsTickEvent():mEventMtx("TickEventMtx") { return; }
+public:
+	RsTickEvent(): mEventMtx("TickEventMtx") {}
 
 void	tick_events();
 
@@ -48,8 +49,8 @@ void    schedule_event(uint32_t event_type, rstime_t when, const std::string &el
 void    schedule_in(uint32_t event_type, uint32_t in_secs);
 void    schedule_in(uint32_t event_type, uint32_t in_secs, const std::string &elabel);
 
-int32_t event_count(uint32_t event_type);
-bool 	prev_event_ago(uint32_t event_type, int32_t &age);
+    int32_t event_count(uint32_t event_type);
+	bool prev_event_ago(uint32_t event_type, uint32_t& age);
 
 	protected:
 
@@ -76,6 +77,8 @@ void 	note_event_locked(uint32_t event_type);
 	std::map<uint32_t, int32_t>    mEventCount;
 	std::map<uint32_t, rstime_t>      mPreviousEvent;
 	std::multimap<rstime_t, EventData> mEvents;
+
+	RS_SET_CONTEXT_DEBUG_LEVEL(2)
 };
 
 #endif // RS_UTIL_TICK_EVENT

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -253,6 +253,15 @@ isEmpty(RS_THREAD_LIB):RS_THREAD_LIB = pthread
 #    Why:  Avoids sending probe packets
 #    BackwardCompat: old RS before Mai 2019 will not be able to distant chat.
 #
+#
+#
+#  V07_NON_BACKWARD_COMPATIBLE_CHANGE_GROUTER_SERVICE_ID:
+#    RetroShare 0.6.x uses custom numeric service ids instead of RsServiceId
+#   Since RetroShare 0.6.6 it is capable to recognize meessages that uses
+#      proper RsServiceId
+#   When this change is enabled the duplicate work necessary to be
+#      retro-compatible with RetroShare < 0.6.6 will be disabled
+#
 ###########################################################################################################################################################
 
 #CONFIG += rs_v07_changes
@@ -262,6 +271,7 @@ rs_v07_changes {
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_003
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_004
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_UNNAMED
+    DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_GROUTER_SERVICE_ID
 }
 
 ################################################################################


### PR DESCRIPTION
    Verify messages hop by hop, this avoid the spreading of invalid messages through
      the network, as a side effect missing RsGxsId keys are propagated hop by hop
      from the sender toward the destination of the message.
    Temporarly store messages which validity could not be verified because of
      missing key in a queue, attempt request sender key and signature validation
      validity periodically until timeout, drop them after timeout, this should
      avoid messages sent by new users being dropped by the GRouter, which is very
      counterintuitive and frustrating for newcomers. The queue is not persistent
      accross RetroShare restarts, so messages not yet validated are lost when
      RetroShare is turned off.
    Do not drop forwarded messages that have unkown service id.
    When receiving a message with unkown service id inform the sender setting
      specific flag in receipt.
    Use type safe flags for GRouter items.
    RsTickEvent::prev_event_ago age is unsigned!
    p3IdService improve some internal implementations and API.
    Use change assert into static_assert for some checks that can be done at compile
      time.
    Solve a bunch of compiler warnings.
    Deprecate some cruft.