### PR TITLE
removed @jsonapi from RsFiles#turtleSearchRequest at rsfiles.h

### DIFF
--- a/libretroshare/src/retroshare/rsfiles.h
+++ b/libretroshare/src/retroshare/rsfiles.h
@@ -401,11 +401,11 @@ public:
 
 	/**
 	 * @brief Request remote files search
-	 * @jsonapi{development}
+     * //jsonapi{development} // how to define a function callback in json?
 	 * @param[in] matchString string to look for in the search. If files deep
 	 *	indexing is enabled at compile time support advanced features described
 	 *	at https://xapian.org/docs/queryparser.html
-	 * @param multiCallback function that will be called each time a search
+     * @param[in] multiCallback function that will be called each time a search
 	 * result is received
 	 * @param[in] maxWait maximum wait time in seconds for search results
 	 * @return false on error, true otherwise


### PR DESCRIPTION
removed jsonapi annotation, because doxygen throws an error and a callback-function can't be called in a JSON-API Call

imho the required feature has to be wrapped in another function, which will collect the callbacked answers to be async queried in JSON-API