### PR TITLE
enabled v0.7_non_backward_compatible_changes 01,02 and 03

### DIFF
--- a/retroshare.pri
+++ b/retroshare.pri
@@ -258,6 +258,11 @@ isEmpty(RS_THREAD_LIB):RS_THREAD_LIB = pthread
 #
 ###########################################################################################################################################################
 
+
+DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_001
+DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_002
+DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_003
+
 #CONFIG += rs_v07_changes
 rs_v07_changes {
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_001


### PR DESCRIPTION
This enabled SHA256 signatures to be the default, and only hash the certificate once. Still accepts SHA1 and previous hashing method. Also changes the way SSL ids are computed (previously last bytes of the signature, which is bad), now SHA256 of the signature, which is much harder to bruteforce.

*****Please test*****
- should fix the bug reported on latest debian systems (see https://github.com/RetroShare/RetroShare/issues/1354)
- newly created peers should still connect to old peers running a version now older than nov 2017.
- newly created peers should connect to each others
The output of signature checkout should mention SHA256/SHA1 depending on whether the remote peer is new or old:
Old:  Verified: RSA+SHA1 signature of certificate sslId: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx, Version 60000 using PGP key XXXX XXXX ...
New: RSA+SHA256 signature of certificate sslId: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, Version 70001 using PGP key XXXX XXXX ...