### PR TITLE
Pass -dead_strip and -dead_strip_dylibs on macOS

### DIFF
--- a/retroshare.pri
+++ b/retroshare.pri
@@ -712,8 +712,9 @@ macx-* {
 	INCLUDEPATH += "/usr/local/include"
 	RS_UPNP_LIB = miniupnpc
 	QT += macextras
-	LIBS+= -Wl,-dead_strip
-    	LIBS+= -Wl,-dead_strip_dylibs
+    LIBS+= -Wl,-dead_strip
+    LIBS+= -Wl,-dead_strip_dylibs
+    LIBS+= -Wl,-bind_at_load
 }
 
 # If not yet defined attempt UPnP library autodetection should works at least

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -712,6 +712,8 @@ macx-* {
 	INCLUDEPATH += "/usr/local/include"
 	RS_UPNP_LIB = miniupnpc
 	QT += macextras
+	LIBS+= -Wl,-dead_strip
+    	LIBS+= -Wl,-dead_strip_dylibs
 }
 
 # If not yet defined attempt UPnP library autodetection should works at least


### PR DESCRIPTION
From `man ld`.
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```

Before:
<img width="862" alt="Screen Shot 2020-01-12 at 18 42 14" src="https://user-images.githubusercontent.com/227442/72222460-a7bb5180-356d-11ea-968d-21827cfb16f8.png">
After:
<img width="859" alt="Screen Shot 2020-01-12 at 18 52 58" src="https://user-images.githubusercontent.com/227442/72222464-ad189c00-356d-11ea-8f9d-59f00a659408.png">

From `man ld`.
```
-dead_strip_dylibs
                 Remove dylibs that are unreachable by the entry point or exported symbols. That is, suppresses the generation of load
                 command commands for dylibs which supplied no symbols during the link. This option should not be used when linking
                 against a dylib which is required at runtime for some indirect reason such as the dylib has an important initializer.
```

Before:
```
% otool -L retroshare.app/Contents/MacOS/retroshare
        /opt/local/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.8)
	/usr/local/lib/libsqlcipher.0.dylib (compatibility version 9.0.0, current version 9.6.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/opt/local/lib/libminiupnpc.17.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1673.126.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 59306.41.2)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 162.0.0)
	/opt/local/libexec/qt5/lib/QtMacExtras.framework/Versions/5/QtMacExtras (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtPrintSupport.framework/Versions/5/QtPrintSupport (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtMultimedia.framework/Versions/5/QtMultimedia (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 1894.10.126)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 212.2.3)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtXml.framework/Versions/5/QtXml (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
```
After:
```
% otool -L retroshare.app/Contents/MacOS/retroshare
        /opt/local/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.8)
	/usr/local/lib/libsqlcipher.0.dylib (compatibility version 9.0.0, current version 9.6.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/opt/local/lib/libminiupnpc.17.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1673.126.0)
	/opt/local/libexec/qt5/lib/QtPrintSupport.framework/Versions/5/QtPrintSupport (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtMultimedia.framework/Versions/5/QtMultimedia (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtXml.framework/Versions/5/QtXml (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
```