### PR TITLE
Insert wiki/etc and plugins before the log tab

### DIFF
--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -423,7 +423,6 @@ void MainWindow::initStackedPage()
   PeopleDialog *peopleDialog = NULL;
   addPage(peopleDialog = new PeopleDialog(ui->stackPages), grp, &notify);
   #endif
-  addPage(newsFeed = new NewsFeed(ui->stackPages), grp, &notify);
 #ifdef RS_USE_WIKI
   WikiDialog *wikiDialog = NULL;
   addPage(wikiDialog = new WikiDialog(ui->stackPages), grp, &notify);
@@ -494,6 +493,7 @@ void MainWindow::initStackedPage()
       }
   }
 
+  addPage(newsFeed = new NewsFeed(ui->stackPages), grp, &notify);
   addPage(settingsDialog = new SettingsPage(ui->stackPages),grp,&notify);
 
   /* Create the toolbar */


### PR DESCRIPTION
Add content containing tabs before the log log tab, which always was on the right most end (just before settings and exit)