### PR TITLE
Fix crash on Android due to dangling reference

### DIFF
--- a/libretroshare/src/jsonapi/jsonapi.cpp
+++ b/libretroshare/src/jsonapi/jsonapi.cpp
@@ -465,14 +465,17 @@ void JsonApiServer::registerHandler(
 		                const std::shared_ptr<rb::Session> session,
 		                const std::function<void (const std::shared_ptr<rb::Session>)>& callback )
 		{
+			/* Declare outside the lambda to avoid returning a dangling
+			 * reference on Android */
+			RsWarn tWarn;
 			const auto authFail =
-			        [&path, &session](int status) -> RsWarn::stream_type&
+			        [&](int status) -> RsWarn::stream_type&
 			{
 				/* Capture session by reference as it is cheaper then copying
 				 * shared_ptr by value which is not needed in this case */
 
 				session->close(status, corsOptionsHeaders);
-				return RsWarn() << "JsonApiServer authentication handler "
+				return tWarn << "JsonApiServer authentication handler "
 				                   "blocked an attempt to call JSON API "
 				                   "authenticated method: " << path;
 			};


### PR DESCRIPTION
JSON API debug lambda returned a dangling reference on Android, fix by
  moving the scope of the returned object
What made this a bit tricky to understand was the fact that it happened
only on Android, while the code was formally incorrect for all
platforms, and strangely caused a stack overflow due to two std lib
functions (sentry and flush) calling each other ad infinitum

#23379 0x603cb2a8 in std::__ndk1::basic_ostream<char, std::__ndk1::char_traits<char> >::flush (this=0x618e92bc) at /opt/android-ndk/sources/cxx-stl/llvm-libc++/include/ostream:949
#23380 0x603cad08 in std::__ndk1::basic_ostream<char, std::__ndk1::char_traits<char> >::sentry::sentry (this=0x618e9284, __os=...) at /opt/android-ndk/sources/cxx-stl/llvm-libc++/include/ostream:270
#23381 0x603cb2a8 in std::__ndk1::basic_ostream<char, std::__ndk1::char_traits<char> >::flush (this=0x618e92bc) at /opt/android-ndk/sources/cxx-stl/llvm-libc++/include/ostream:949
#23382 0x603cad08 in std::__ndk1::basic_ostream<char, std::__ndk1::char_traits<char> >::sentry::sentry (this=0x618e9304, __os=...) at /opt/android-ndk/sources/cxx-stl/llvm-libc++/include/ostream:270
#23383 0x603caa6c in std::__ndk1::__put_character_sequence<char, std::__ndk1::char_traits<char> > (__os=..., __str=0x61379a60 " user: ", __len=7) at /opt/android-ndk/sources/cxx-stl/llvm-libc++/include/ostream:726
#23384 0x603caa30 in std::__ndk1::operator<< <std::__ndk1::char_traits<char> > (__os=..., __str=0x61379a60 " user: ") at /opt/android-ndk/sources/cxx-stl/llvm-libc++/include/ostream:869
#23385 0x60522184 in t_RsLogger<(RsLoggerCategories)5>::operator<< <char [8]> (this=0x618e92bc, val=...) at ../../../../Development/rs-develop/libretroshare/src/util/rsdebug.h:53
#23386 0x60bbe5ec in JsonApiServer::registerHandler(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, std::__ndk1::function<void (std::__ndk1::shared_ptr<restbed::Session>)> const&, bool)::$_259::operator()(std::__ndk1::shared_ptr<restbed::Session>, std::__ndk1::function<void (std::__ndk1::shared_ptr<restbed::Session>)> const&) const (this=0x617d8364, session=..., callback=...) at ../../../../Development/rs-develop/libretroshare/src/jsonapi/jsonapi.cpp:517
