### PR TITLE
i2pbob: fix deadlock on shutdown

### DIFF
--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -1131,6 +1131,9 @@ std::string p3I2pBob::recv()
 		// clear and resize buffer again
 		buffer.clear();
 		buffer.resize(bufferSize);
+
+		if (this->shouldStop())
+			break;
 	} while(length == bufferSize || ans.size() < 4);
 
 	return ans;


### PR DESCRIPTION
I've always wondered why the thread **somtimes** doesn't exit. gdb told me today...
Add a break to exit the loop when it should stop.