### PR TITLE
Hide RSImageBlockWidget when changing Forum Post.

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1049,6 +1049,8 @@ void GxsForumThreadWidget::insertMessage()
 	ui->lineLeft->hide();
 	ui->by_text_label->hide();
 	ui->by_label->hide();
+	ui->postText->setImageBlockWidget(ui->imageBlockWidget) ;
+	ui->postText->resetImagesStatus(Settings->getForumLoadEmbeddedImages());
 
     // add/show combobox for versions, if applicable, and enable it. If no older versions of the post available, hide the combobox.
 


### PR DESCRIPTION
No more "The loading of embedded images is blocked." message when post don't have image.