### PR TITLE
attempt to fix bug in forum search

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
@@ -53,9 +53,13 @@ RsGxsForumModel::RsGxsForumModel(QObject *parent)
 void RsGxsForumModel::preMods()
 {
  	emit layoutAboutToBeChanged();
+
+	beginResetModel();
 }
 void RsGxsForumModel::postMods()
 {
+	endResetModel();
+
     if(mTreeMode == TREE_MODE_FLAT)
 		emit dataChanged(createIndex(0,0,(void*)NULL), createIndex(mPosts.size(),COLUMN_THREAD_NB_COLUMNS-1,(void*)NULL));
     else


### PR DESCRIPTION
This really needs to be tested. It should solve the bug that causes random crashes (not reliable to reproduce) obtained by starting RS, loading a forum, and typing in the search field for posts.

One user reported very weird behavior because of this patch, but the connection to this patch is very very unlikely.