### PR TITLE
Fix log spam by handling deprecated packet gracefully

### DIFF
--- a/libretroshare/src/gossipdiscovery/gossipdiscoveryitems.cc
+++ b/libretroshare/src/gossipdiscovery/gossipdiscoveryitems.cc
@@ -37,6 +37,7 @@ RsItem *RsDiscSerialiser::create_item(
 	{
 	case RsGossipDiscoveryItemType::PGP_LIST: return new RsDiscPgpListItem();
 	case RsGossipDiscoveryItemType::PGP_CERT_BINARY: return new RsDiscPgpKeyItem();
+	case RsGossipDiscoveryItemType::PGP_CERT: return new RsDiscPgpCertItem();	// deprecated, hanlde to suppress "unkown item" warning
 	case RsGossipDiscoveryItemType::CONTACT:  return new RsDiscContactItem();
 	case RsGossipDiscoveryItemType::IDENTITY_LIST: return new RsDiscIdentityListItem();
     default:

--- a/libretroshare/src/gossipdiscovery/gossipdiscoveryitems.h
+++ b/libretroshare/src/gossipdiscovery/gossipdiscoveryitems.h
@@ -97,6 +97,27 @@ public:
     uint32_t bin_len;
 };
 
+class RS_DEPRECATED_FOR(RsDiscPgpKeyItem) RsDiscPgpCertItem: public RsDiscItem
+{
+public:
+    RsDiscPgpCertItem() : RsDiscItem(RsGossipDiscoveryItemType::PGP_CERT)
+    { setPriorityLevel(QOS_PRIORITY_RS_DISC_PGP_CERT); }
+
+    void clear() override
+    {
+        pgpId.clear();
+        pgpCert.clear();
+    }
+    void serial_process(RsGenericSerializer::SerializeJob j, RsGenericSerializer::SerializeContext& ctx) override
+    {
+        RsTypeSerializer::serial_process(j,ctx,pgpId,"pgpId") ;
+        RsTypeSerializer::serial_process(j,ctx,TLV_TYPE_STR_PGPCERT,pgpCert,"pgpCert") ;
+    }
+
+    RsPgpId pgpId;
+    std::string pgpCert;
+};
+
 class RsDiscContactItem: public RsDiscItem
 {
 public:

--- a/libretroshare/src/gossipdiscovery/p3gossipdiscovery.cc
+++ b/libretroshare/src/gossipdiscovery/p3gossipdiscovery.cc
@@ -260,6 +260,7 @@ int p3discovery2::handleIncoming()
 	{
 		RsDiscPgpListItem*      pgplist  = nullptr;
 		RsDiscPgpKeyItem*       pgpkey   = nullptr;
+		RsDiscPgpCertItem*      pgpcert	 = nullptr;	 // deprecated, hanlde for retro compability
 		RsDiscContactItem*      contact  = nullptr;
 		RsDiscIdentityListItem* gxsidlst = nullptr;
 
@@ -282,6 +283,9 @@ int p3discovery2::handleIncoming()
 		}
 		else if((pgpkey = dynamic_cast<RsDiscPgpKeyItem *>(item)) != nullptr)
 			recvPGPCertificate(item->PeerId(), pgpkey);
+		else if((pgpcert = dynamic_cast<RsDiscPgpCertItem *>(item)) != nullptr)
+			// sink
+			delete pgpcert;
 		else if((pgplist = dynamic_cast<RsDiscPgpListItem *>(item)) != nullptr)
 		{
 			if (pgplist->mode == RsGossipDiscoveryPgpListMode::FRIENDS)


### PR DESCRIPTION
Partially reverts bea6769a4e23b9e20af738e6e302b8c0324e1472.
Fixes:
```
RsSerialiser::deserialise() ERROR Failed!
RsSerialiser::deserialise() pkt_size: 958 vs *size: 958
RsSerialiser::deserialise() FAILED PACKET Size: 958 ID: 2001102
RsSerialiser::deserialise() FAILED PACKET:  Version: 2 Class: 0 Type: 11 SubType: 2 Data: 02...
```
Currently the log is flooded with messages about "unkown" packets which are actually just deprecated ones. Add back the code to gracefully handle them (= delete them).