### PR TITLE
Set default column width for nickname columns & fixed missed icons (Circles Create Dialog)

### DIFF
--- a/retroshare-gui/src/gui/Circles/CreateCircleDialog.cpp
+++ b/retroshare-gui/src/gui/Circles/CreateCircleDialog.cpp
@@ -78,6 +78,11 @@ CreateCircleDialog::CreateCircleDialog()
 	headerText = headerItem->text(RSCIRCLEID_COL_KEYID);
 	ui.IdFilter->addFilter(QIcon(), headerText, RSCIRCLEID_COL_KEYID, QString("%1 %2").arg(tr("Search"), headerText));
 	
+	/* Set initial column width */
+	int fontWidth = QFontMetricsF(ui.treeWidget_IdList->font()).width("W");
+	ui.treeWidget_IdList->setColumnWidth(RSCIRCLEID_COL_NICKNAME, 17 * fontWidth);
+	ui.treeWidget_membership->setColumnWidth(RSCIRCLEID_COL_NICKNAME, 17 * fontWidth);
+	
 	ui.removeButton->setEnabled(false);
 	ui.addButton->setEnabled(false);
 	ui.radioButton_ListAll->setChecked(true);

--- a/retroshare-gui/src/gui/Circles/CreateCircleDialog.ui
+++ b/retroshare-gui/src/gui/Circles/CreateCircleDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1211</width>
-    <height>647</height>
+    <width>721</width>
+    <height>561</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -106,8 +106,8 @@
              <string/>
             </property>
             <property name="icon">
-             <iconset resource="../images.qrc">
-              <normaloff>:/images/back.png</normaloff>:/images/back.png</iconset>
+             <iconset resource="../icons.qrc">
+              <normaloff>:/icons/png/arrow-left.png</normaloff>:/icons/png/arrow-left.png</iconset>
             </property>
            </widget>
           </item>
@@ -120,8 +120,8 @@
              <string/>
             </property>
             <property name="icon">
-             <iconset resource="../images.qrc">
-              <normaloff>:/images/forward.png</normaloff>:/images/forward.png</iconset>
+             <iconset resource="../icons.qrc">
+              <normaloff>:/icons/png/arrow-right.png</normaloff>:/icons/png/arrow-right.png</iconset>
             </property>
            </widget>
           </item>

--- a/retroshare-gui/src/gui/TheWire/WireGroupItem.ui
+++ b/retroshare-gui/src/gui/TheWire/WireGroupItem.ui
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QFrame" name="frame">
+    <widget class="QFrame" name="wire_frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
      </property>

--- a/retroshare-gui/src/gui/qss/stylesheet/Standard.qss
+++ b/retroshare-gui/src/gui/qss/stylesheet/Standard.qss
@@ -870,3 +870,6 @@ WireGroupItem QWidget:hover
 	background-color: #7ecbfb;
 }
 
+WireDialog QFrame#frame{
+	background-color: white;
+}


### PR DESCRIPTION
* Set default column width for nickname columns & fixed missed icons
* Set by default white background color for the  Follower list frame