### PR TITLE
clean rewrite of RsServer::threadTick

### DIFF
--- a/libretroshare/src/rsserver/p3face-server.cc
+++ b/libretroshare/src/rsserver/p3face-server.cc
@@ -41,7 +41,9 @@
 #include "services/rseventsservice.h"
 
 
+/*******************
 #define TICK_DEBUG 1
+*******************/
 
 #define WARN_BIG_CYCLE_TIME	(0.2)
 

--- a/libretroshare/src/rsserver/p3face.h
+++ b/libretroshare/src/rsserver/p3face.h
@@ -188,10 +188,11 @@ public:
 
 		// Worker Data.....
 
-        double mLastts;
-        double mTickInterval;
+	double mLastts;
+	double mTickInterval;
 	double mLastRunDuration;
 	double mAvgRunDuration;
+	double mCycle1, mCycle2, mCycle3, mCycle4;
 
 	static const double minTickInterval;
 	static const double maxTickInterval;

--- a/libretroshare/src/rsserver/p3face.h
+++ b/libretroshare/src/rsserver/p3face.h
@@ -172,8 +172,8 @@ public:
 //		p3Posted *mPosted;
 //		p3PhotoService *mPhoto;
 //		p3GxsCircles *mGxsCircles;
-//        p3GxsNetService *mGxsNetService;
-//        p3IdService *mGxsIdService;
+//		p3GxsNetService *mGxsNetService;
+//		p3IdService *mGxsIdService;
 //		p3GxsForums *mGxsForums;
 //		p3GxsChannels *mGxsChannels;
 //		p3Wire *mWire;
@@ -188,16 +188,13 @@ public:
 
 		// Worker Data.....
 
-    int mMin ;
-    int mLoop ;
-    int mLastts ;
-    long mLastSec ;
-    double mAvgTickRate ;
-    double mTimeDelta ;
+        double mLastts;
+        double mTickInterval;
+	double mLastRunDuration;
+	double mAvgRunDuration;
 
-    static const double minTimeDelta; // 25;
-    static const double maxTimeDelta;
-    static const double kickLimit;
+	static const double minTickInterval;
+	static const double maxTickInterval;
 
 	/// @see RsControl::setShutdownCallback
 	std::function<void(int)> mShutdownCallback;


### PR DESCRIPTION
- switch all TS to double, no more int
- remove the useless "if" at the beginning of threadTick, that was always true because of the usleep!
- stabilize the tick rate by properly calculating the sleeping time
- adjust the tick rate depending on the load
- clean the code for conditionnal run every second, 5s, 60s and 1h