### PR TITLE
[Mail] Set a default item height for the mail tree item to avoid shrinking

### DIFF
--- a/retroshare-gui/src/gui/msgs/MessageModel.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageModel.cpp
@@ -408,14 +408,17 @@ QVariant RsMessageModel::backgroundRole(const Rs::Msgs::MsgInfoSummary &fmpe, in
 
 QVariant RsMessageModel::sizeHintRole(int col) const
 {
-	float factor = QFontMetricsF(QApplication::font()).height()/14.0f ;
+	float x_factor = QFontMetricsF(QApplication::font()).height()/14.0f ;
+	float y_factor = QFontMetricsF(QApplication::font()).height()/14.0f ;
+	
+	y_factor = std::max(y_factor, 18.0f / 14.0f ); // allows to have a minimum 21 pixels default height
 
 	switch(col)
 	{
 	default:
-	case COLUMN_THREAD_SUBJECT:      return QVariant( QSize(factor * 170, factor*14 ));
-	case COLUMN_THREAD_DATE:         return QVariant( QSize(factor * 75 , factor*14 ));
-	case COLUMN_THREAD_AUTHOR:       return QVariant( QSize(factor * 75 , factor*14 ));
+	case COLUMN_THREAD_SUBJECT:      return QVariant( QSize(x_factor * 170 , y_factor*14*1.1f ));
+	case COLUMN_THREAD_DATE:         return QVariant( QSize(x_factor * 160 , y_factor*14*1.1f ));
+	case COLUMN_THREAD_AUTHOR:       return QVariant( QSize(x_factor * 160 , y_factor*14*1.1f ));
 	}
 }
 

--- a/retroshare-gui/src/gui/msgs/MessagesDialog.cpp
+++ b/retroshare-gui/src/gui/msgs/MessagesDialog.cpp
@@ -143,7 +143,7 @@ MessagesDialog::MessagesDialog(QWidget *parent)
 	mMessageProxyModel->setFilterRole(RsMessageModel::FilterRole);
 	mMessageProxyModel->setFilterRegExp(QRegExp(RsMessageModel::FilterString));
 
-    ui.messageTreeWidget->setModel(mMessageProxyModel);
+	ui.messageTreeWidget->setModel(mMessageProxyModel);
 
 	changeBox(0);	// set to inbox
 
@@ -196,8 +196,8 @@ MessagesDialog::MessagesDialog(QWidget *parent)
     msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_READ,       fm.width('0')*1.5);
 
     msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_SUBJECT,    fm.width("You have a message")*3.0);
-    msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_AUTHOR,     fm.width("[Retroshare]")*1.1);
-    msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_DATE,       fm.width("01/01/1970")*1.1);
+    //msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_AUTHOR,     fm.width("[Retroshare]")*1.5);
+    //msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_DATE,       fm.width("01/01/1970")*1.5);
 
     QHeaderView_setSectionResizeModeColumn(msgwheader, RsMessageModel::COLUMN_THREAD_SUBJECT,    QHeaderView::Interactive);
     QHeaderView_setSectionResizeModeColumn(msgwheader, RsMessageModel::COLUMN_THREAD_AUTHOR,     QHeaderView::Interactive);


### PR DESCRIPTION
* Set a default item height for the mail tree item to avoid shrinking under 20 pixel

Always the items on mail shrinks when From column contains no Avatar to avoid this i set a default height like how on the Friendslist.
Shrinking is gone not sure if this helps with the shrinking "Date" column.

Disabled in Messages Dialog
`    //msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_AUTHOR,     fm.width("[Retroshare]")*1.5);
    //msgwheader->resizeSection (RsMessageModel::COLUMN_THREAD_DATE,       fm.width("01/01/1970")*1.5);

this get conflicts with the defined values from RsMessageModel::sizeHintRole