### PR TITLE
Two small fixes.

### DIFF
--- a/libretroshare/src/retroshare/rsgxschannels.h
+++ b/libretroshare/src/retroshare/rsgxschannels.h
@@ -337,9 +337,9 @@ public:
 	 * @brief Get channel comments corresponding to the given IDs.
 	 * If the set is empty, nothing is returned.
 	 * @jsonapi{development}
-	 * @param channelId id of the channel of which the content is requested
-	 * @param contentIds ids of requested contents
-	 * @param comments storage for the comments
+	 * @param[in] channelId id of the channel of which the content is requested
+	 * @param[in] contentIds ids of requested contents
+	 * @param[out] comments storage for the comments
 	 * @return false if something failed, true otherwhise
 	 */
 	virtual bool getChannelComments(const RsGxsGroupId &channelId,

--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -91,8 +91,6 @@ ServerPage::ServerPage(QWidget * parent, Qt::WindowFlags flags)
 		  ui.tabWidget->removeTab(TAB_RELAYS) ;		// remove relays. Not useful in Tor mode.
 		  ui.tabWidget->removeTab(TAB_IP_FILTERS) ;	// remove IP filters. Not useful in Tor mode.
 
-		  ui.hiddenServiceTab->removeTab(TAB_HIDDEN_SERVICE_I2P_BOB) ; // remove the Automatic I2P/BOB tab
-
 		  ui.hiddenpage_proxyAddress_i2p->hide() ;
 		  ui.hiddenpage_proxyLabel_i2p->hide() ;
 		  ui.hiddenpage_proxyPort_i2p->hide() ;
@@ -109,8 +107,7 @@ ServerPage::ServerPage(QWidget * parent, Qt::WindowFlags flags)
   }
   else
   {
-      ui.hiddenServiceTab->removeTab(TAB_HIDDEN_SERVICE_I2P_BOB);	// warning: the order of operation here is very important.
-      ui.hiddenServiceTab->removeTab(TAB_HIDDEN_SERVICE_INCOMING);
+	  ui.hiddenServiceTab->removeTab(TAB_HIDDEN_SERVICE_INCOMING);	// warning: the order of operation here is very important.
   }
 
     ui.filteredIpsTable->setHorizontalHeaderItem(COLUMN_RANGE,new QTableWidgetItem(tr("IP Range"))) ;


### PR DESCRIPTION
The 1st fixes compilation when the json api is enabled.
The 2nd fixes https://github.com/RetroShare/RetroShare/commit/a6a8e69965907b336db8c4bca9e9dafa668a9642#diff-08e31744580db05b2e0861ee9e243e8b which remove the bob configuration page which is needed (or useful) for all kind of locations hidden or clear net.