### PR TITLE
Fix unix_fcntl_nonblock() to not overwrite any existing flags.

### DIFF
--- a/libretroshare/src/pqi/pqinetwork.cc
+++ b/libretroshare/src/pqi/pqinetwork.cc
@@ -413,9 +413,10 @@ int unix_fcntl_nonblock(int fd)
 {
         int ret;
 
-/******************* WINDOWS SPECIFIC PART ******************/
+/******************* OS SPECIFIC PART ******************/
 #ifndef WINDOWS_SYS // ie UNIX
-	ret = fcntl(fd, F_SETFL, O_NONBLOCK);
+	int flags = fcntl(fd, F_GETFL);
+	ret = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 
 #ifdef NET_DEBUG
 	std::cerr << "unix_fcntl_nonblock():" << ret << " errno:" << errno << std::endl;


### PR DESCRIPTION
Currently `unix_fcntl_nonblock` removes all flags and sets `O_NONBLOCK` only. This patch fixes this for Linux.