### PR TITLE
Create chat lobby checks

### DIFF
--- a/libretroshare/src/chat/distributedchat.cc
+++ b/libretroshare/src/chat/distributedchat.cc
@@ -1604,14 +1604,13 @@ ChatLobbyId DistributedChatService::createChatLobby(const std::string& lobby_nam
 #endif
 	ChatLobbyId lobby_id ;
 	{
-		RsStackMutex stack(mDistributedChatMtx); /********** STACK LOCKED MTX ******/
-
 		if (!rsIdentity->isOwnId(lobby_identity))
 		{
 			RsErr() << __PRETTY_FUNCTION__ << " lobby_identity RsGxsId id must be own" << std::endl;
-			lobby_id = 00000000000000000000;
-			return lobby_id;
+			return 0;
 		}
+
+		RsStackMutex stack(mDistributedChatMtx); /********** STACK LOCKED MTX ******/
 
 		// create a unique id.
 		//

--- a/libretroshare/src/chat/distributedchat.cc
+++ b/libretroshare/src/chat/distributedchat.cc
@@ -1606,6 +1606,13 @@ ChatLobbyId DistributedChatService::createChatLobby(const std::string& lobby_nam
 	{
 		RsStackMutex stack(mDistributedChatMtx); /********** STACK LOCKED MTX ******/
 
+		if (!rsIdentity->isOwnId(lobby_identity))
+		{
+			RsErr() << __PRETTY_FUNCTION__ << " lobby_identity RsGxsId id must be own" << std::endl;
+			lobby_id = 00000000000000000000;
+			return lobby_id;
+		}
+
 		// create a unique id.
 		//
 		do { lobby_id = RSRandom::random_u64() ; } while(_chat_lobbys.find(lobby_id) != _chat_lobbys.end()) ;


### PR DESCRIPTION
Using JSON API if you try to create a chat lobby it didn't check if the identity is correct and return a chat lobby id:

```bash
curl -u  "locatin:pass"  -d '{ "lobby_name":"curlcreated","lobby_identity":"wrongstuff" }' http://127.0.0.1:9092/rsMsgs/createChatLobby
```