### PR TITLE
Fix miss doxygen parameter

### DIFF
--- a/libretroshare/src/retroshare/rsgxschannels.h
+++ b/libretroshare/src/retroshare/rsgxschannels.h
@@ -310,6 +310,7 @@ public:
 	 * @param[in] channelId id of the channel of which the content is requested
 	 * @param[out] posts storage for posts
 	 * @param[out] comments storage for the comments
+	 * @param[out] votes storage for the votes
 	 * @return false if something failed, true otherwhise
 	 */
 	virtual bool getChannelAllContent( const RsGxsGroupId& channelId,


### PR DESCRIPTION
Parameter: votes of: /rsGxsChannels/getChannelAllContent declared in:
retroshare/rsgxschannels.h miss doxygen parameter direction attribute!