### PR TITLE
i2p refactoring

### DIFF
--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -154,6 +154,7 @@ rs_webui {
 HEADERS += plugins/pluginmanager.h \
 		plugins/dlfcn_win32.h \
 		rsitems/rspluginitems.h \
+    util/i2pcommon.h \
     util/rsinitedptr.h
 
 HEADERS += $$PUBLIC_HEADERS
@@ -517,7 +518,8 @@ SOURCES +=	ft/ftchunkmap.cc \
 			ft/ftfilesearch.cc \
 			ft/ftserver.cc \
 			ft/fttransfermodule.cc \
-            ft/ftturtlefiletransferitem.cc
+            ft/ftturtlefiletransferitem.cc \
+    util/i2pcommon.cpp
 
 SOURCES += crypto/chacha20.cpp \
            crypto/hashstream.cc\

--- a/libretroshare/src/rsserver/p3face.h
+++ b/libretroshare/src/rsserver/p3face.h
@@ -161,7 +161,9 @@ public:
 		p3ChatService *chatSrv;
 		p3StatusService *mStatusSrv;
 		p3GxsTunnelService *mGxsTunnels;
+#ifdef RS_USE_I2P_BOB
 		p3I2pBob *mI2pBob;
+#endif
 
         // This list contains all threaded services. It will be used to shut them down properly.
 

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -1724,7 +1724,7 @@ int RsServer::StartupRetroShare()
 				// now enable bob
 				bobSettings bs;
 				autoProxy->taskSync(autoProxyType::I2PBOB, autoProxyTask::getSettings, &bs);
-				bs.enableBob = true;
+				bs.enable = true;
 				autoProxy->taskSync(autoProxyType::I2PBOB, autoProxyTask::setSettings, &bs);
 			} else {
 				std::cerr << "RsServer::StartupRetroShare failed to receive keys" << std::endl;

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -923,8 +923,10 @@ int RsServer::StartupRetroShare()
 	mNetMgr->setManagers(mPeerMgr, mLinkMgr);
 
 	rsAutoProxyMonitor *autoProxy = rsAutoProxyMonitor::instance();
+#ifdef RS_USE_I2P_BOB
 	mI2pBob = new p3I2pBob(mPeerMgr);
 	autoProxy->addProxy(autoProxyType::I2PBOB, mI2pBob);
+#endif
 
 	//load all the SSL certs as friends
 	//        std::list<std::string> sslIds;
@@ -1649,7 +1651,9 @@ int RsServer::StartupRetroShare()
 	mConfigMgr->addConfiguration("wire.cfg", wire_ns);
 #endif
 #endif //RS_ENABLE_GXS
+#ifdef RS_USE_I2P_BOB
 	mConfigMgr->addConfiguration("I2PBOB.cfg", mI2pBob);
+#endif
 
 	mPluginsManager->addConfigurations(mConfigMgr) ;
 
@@ -1795,7 +1799,9 @@ int RsServer::StartupRetroShare()
 	/**************************************************************************/
 
 	// auto proxy threads
+#ifdef RS_USE_I2P_BOB
 	startServiceThread(mI2pBob, "I2P-BOB");
+#endif
 
 #ifdef RS_ENABLE_GXS
 	// Must Set the GXS pointers before starting threads.

--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -26,7 +26,6 @@
 
 #include "pqi/p3peermgr.h"
 #include "rsitems/rsconfigitems.h"
-#include "util/rsdebug.h"
 #include "util/radix32.h"
 #include "util/radix64.h"
 #include "util/rsdebug.h"
@@ -51,8 +50,6 @@ static const useconds_t sleepTimeWait = 50; // times 1000 = 50ms or 0.05s
 static const int sleepFactorDefault   = 10; // 0.5s
 static const int sleepFactorFast      = 1;  // 0.05s
 static const int sleepFactorSlow      = 20; // 1s
-
-RS_SET_CONTEXT_DEBUG_LEVEL(0)
 
 static const rstime_t selfCheckPeroid = 30;
 
@@ -83,7 +80,7 @@ bool p3I2pBob::isEnabled()
 
 bool p3I2pBob::initialSetup(std::string &addr, uint16_t &/*port*/)
 {
-	std::cout << "p3I2pBob::initialSetup" << std::endl;
+	RS_DBG("") << std::endl;
 
 	// update config
 	{
@@ -96,7 +93,7 @@ bool p3I2pBob::initialSetup(std::string &addr, uint16_t &/*port*/)
 		}
 	}
 
-	std::cout << "p3I2pBob::initialSetup config updated" << std::endl;
+	RS_DBG("config updated") << std::endl;
 
 	// request keys
 	// p3I2pBob::stateMachineBOB expects mProcessing to be set therefore
@@ -106,12 +103,12 @@ bool p3I2pBob::initialSetup(std::string &addr, uint16_t &/*port*/)
 	fakeTicket->task = autoProxyTask::receiveKey;
 	processTaskAsync(fakeTicket);
 
-	std::cout << "p3I2pBob::initialSetup fakeTicket requested" << std::endl;
+	RS_DBG("fakeTicket requested") << std::endl;
 
 	// now start thread
 	start("I2P-BOB gen key");
 
-	std::cout << "p3I2pBob::initialSetup thread started" << std::endl;
+	RS_DBG("thread started") << std::endl;
 
 	int counter = 0;
 	// wait for keys
@@ -125,24 +122,24 @@ bool p3I2pBob::initialSetup(std::string &addr, uint16_t &/*port*/)
 			break;
 
 		if (++counter > 30) {
-			std::cout << "p3I2pBob::initialSetup timeout!" << std::endl;
+			RS_DBG4("timeout!") << std::endl;
 			return false;
 		}
 	}
 
-	std::cout << "p3I2pBob::initialSetup got keys" << std::endl;
+	RS_DBG("got keys") << std::endl;
 
 	// stop thread
 	fullstop();
 
-	std::cout << "p3I2pBob::initialSetup thread stopped" << std::endl;
+	RS_DBG("thread stopped") << std::endl;
 
 	{
 		RS_STACK_MUTEX(mLock);
 		addr = mSetting.address.base32;
 	}
 
-	std::cout << "p3I2pBob::initialSetup addr '" << addr << "'" << std::endl;
+	RS_DBG4("addr '" + addr + "'") << std::endl;
 
 	return true;
 }
@@ -160,7 +157,7 @@ void p3I2pBob::processTaskAsync(taskTicket *ticket)
 	}
 		break;
 	default:
-		RsDbg() << __PRETTY_FUNCTION__ << " unknown task" << std::endl;
+		RS_DBG("unknown task") << std::endl;
 		rsAutoProxyMonitor::taskError(ticket);
 		break;
 	}
@@ -175,7 +172,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 	case autoProxyTask::status:
 		// check if everything needed is set
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::status data is missing" << std::endl;
+			RS_DBG("autoProxyTask::status data is missing") << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 			break;
 		}
@@ -189,7 +186,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 	case autoProxyTask::getSettings:
 		// check if everything needed is set
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::getSettings data is missing" << std::endl;
+			RS_DBG("autoProxyTask::getSettings data is missing") << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 			break;
 		}
@@ -203,7 +200,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 	case autoProxyTask::setSettings:
 		// check if everything needed is set
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::setSettings data is missing" << std::endl;
+			RS_DBG("autoProxyTask::setSettings data is missing") << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 			break;
 		}
@@ -223,7 +220,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 		break;
 	case autoProxyTask::getErrorInfo:
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::getErrorInfo data is missing" << std::endl;
+			RS_DBG("autoProxyTask::getErrorInfo data is missing") << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 		} else {
 			RS_STACK_MUTEX(mLock);
@@ -232,7 +229,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 		}
 		break;
 	default:
-		RsDbg() << __PRETTY_FUNCTION__ << " unknown task" << std::endl;
+		RS_DBG("unknown task") << std::endl;
 		rsAutoProxyMonitor::taskError(ticket);
 		break;
 	}
@@ -253,7 +250,7 @@ void p3I2pBob::threadTick()
 		RS_STACK_MUTEX(mLock);
 		std::stringstream ss;
 		ss << "data_tick mState: " << mState << " mTask: " << mTask << " mBOBState: " << mBOBState << " mPending: " << mPending.size();
-		Dbg4() << __PRETTY_FUNCTION__ << " " + ss.str() << std::endl;
+		RS_DBG4("" + ss.str()) << std::endl;
 	}
 
 	sleepTime += stateMachineController();
@@ -294,13 +291,13 @@ int p3I2pBob::stateMachineBOB()
 		while (answer.find("OK Listing done") == std::string::npos) {
 			std::stringstream ss;
 			ss << "stateMachineBOB status check: read loop, counter: " << counter;
-			Dbg3() << __PRETTY_FUNCTION__ << " " + ss.str() << std::endl;
+			RS_DBG3("" + ss.str()) << std::endl;
 			answer += recv();
 			counter++;
 		}
 
 		if (answer.find(mTunnelName) == std::string::npos) {
-			RsDbg() << __PRETTY_FUNCTION__ << " status check: tunnel down!" << std::endl;
+			RS_DBG("status check: tunnel down!") << std::endl;
 			// signal error
 			*((bool *)mProcessing->data) = true;
 		}
@@ -340,8 +337,8 @@ int p3I2pBob::stateMachineBOB_locked_failure(const std::string &answer, const bo
 		return sleepFactorDefault;
 	}
 
-	RsDbg() << __PRETTY_FUNCTION__ << " FAILED to run command '" + currentState.command + "'" << std::endl;
-	RsDbg() << __PRETTY_FUNCTION__ << " '" + answer + "'" << std::endl;
+	RS_DBG("FAILED to run command '" + currentState.command + "'") << std::endl;
+	RS_DBG("'" + answer + "'") << std::endl;
 
 	mErrorMsg.append("FAILED to run command '" + currentState.command + "'" + '\n');
 	mErrorMsg.append("reason '" + answer + "'" + '\n');
@@ -388,14 +385,14 @@ int p3I2pBob::stateMachineController()
 		return stateMachineController_locked_idle();
 	case csDoConnect:
 		if (!connectI2P()) {
-			RsDbg() << __PRETTY_FUNCTION__ << " doConnect: unable to connect" << std::endl;
+			RS_DBG("doConnect: unable to connect") << std::endl;
 			mStateOld = mState;
 			mState = csError;
 			mErrorMsg = "unable to connect to BOB port";
 			return sleepFactorSlow;
 		}
 
-		Dbg4() << __PRETTY_FUNCTION__ << " doConnect: connected" << std::endl;
+		RS_DBG4("doConnect: connected") << std::endl;
 		mState = csConnected;
 		break;
 	case csConnected:
@@ -403,7 +400,7 @@ int p3I2pBob::stateMachineController()
 	case csWaitForBob:
 		// check connection problems
 		if (mSocket == 0) {
-			RsDbg() << __PRETTY_FUNCTION__ << " waitForBob: conection lost" << std::endl;
+			RS_DBG("waitForBob: conection lost") << std::endl;
 			mStateOld = mState;
 			mState = csError;
 			mErrorMsg = "connection lost to BOB";
@@ -413,21 +410,21 @@ int p3I2pBob::stateMachineController()
 		// check for finished BOB protocol
 		if (mBOBState == bsCleared) {
 			// done
-			Dbg4() << __PRETTY_FUNCTION__ << " waitForBob: mBOBState == bsCleared" << std::endl;
+			RS_DBG4("waitForBob: mBOBState == bsCleared") << std::endl;
 			mState = csDoDisconnect;
 		}
 		break;
 	case csDoDisconnect:
 		if (!disconnectI2P() || mSocket != 0) {
 			// just in case
-			RsDbg() << __PRETTY_FUNCTION__ << " doDisconnect: can't disconnect" << std::endl;
+			RS_DBG("doDisconnect: can't disconnect") << std::endl;
 			mStateOld = mState;
 			mState = csError;
 			mErrorMsg = "unable to disconnect from BOB";
 			return sleepFactorDefault;
 		}
 
-		Dbg4() << __PRETTY_FUNCTION__ << " doDisconnect: disconnected" << std::endl;
+		RS_DBG4("doDisconnect: disconnected") << std::endl;
 		mState = csDisconnected;
 		break;
 	case csDisconnected:
@@ -458,7 +455,7 @@ int p3I2pBob::stateMachineController_locked_idle()
 		    mProcessing->task == autoProxyTask::stop ||
 		    mProcessing->task == autoProxyTask::proxyStatusCheck)) {
 			// skip since we are not enabled
-			Dbg1() << __PRETTY_FUNCTION__ << " disabled -> skipping ticket" << std::endl;
+			RS_DBG1("disabled -> skipping ticket") << std::endl;
 			rsAutoProxyMonitor::taskDone(mProcessing, autoProxyStatus::disabled);
 			mProcessing = NULL;
 		} else {
@@ -480,7 +477,7 @@ int p3I2pBob::stateMachineController_locked_idle()
 				mTask = ctRunCheck;
 				break;
 			default:
-				Dbg1() << __PRETTY_FUNCTION__ << " unknown async task" << std::endl;
+				RS_DBG1("unknown async task") << std::endl;
 				rsAutoProxyMonitor::taskError(mProcessing);
 				mProcessing = NULL;
 				break;
@@ -528,28 +525,28 @@ int p3I2pBob::stateMachineController_locked_connected()
 	case ctRunSetUp:
 		// when we have a key use it for server tunnel!
 		if(mSetting.address.privateKey.empty()) {
-			Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = setnickC" << std::endl;
+			RS_DBG4("setting mBOBState = setnickC") << std::endl;
 			mBOBState = bsSetnickC;
 		} else {
-			Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = setnickS" << std::endl;
+			RS_DBG4("setting mBOBState = setnickS") << std::endl;
 			mBOBState = bsSetnickS;
 		}
 		break;
 	case ctRunShutDown:
 		// shut down existing tunnel
-		Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = getnick" << std::endl;
+		RS_DBG4("setting mBOBState = getnick") << std::endl;
 		mBOBState = bsGetnick;
 		break;
 	case ctRunCheck:
-		Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = list" << std::endl;
+		RS_DBG4("setting mBOBState = list") << std::endl;
 		mBOBState = bsList;
 		break;
 	case ctRunGetKeys:
-		Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = setnickN" << std::endl;
+		RS_DBG4("setting mBOBState = setnickN") << std::endl;
 		mBOBState = bsSetnickN;
 		break;
 	case ctIdle:
-		RsDbg() << __PRETTY_FUNCTION__ << " task is idle. This should not happen!" << std::endl;
+		RS_DBG("task is idle. This should not happen!") << std::endl;
 		break;
 	}
 
@@ -565,7 +562,7 @@ int p3I2pBob::stateMachineController_locked_disconnected()
 	if(errorHappened) {
 		// reset old state
 		mStateOld = csIdel;
-		RsDbg() << __PRETTY_FUNCTION__ << " error during process!" << std::endl;
+		RS_DBG("error during process!") << std::endl;
 	}
 
 	// answer ticket
@@ -594,12 +591,12 @@ int p3I2pBob::stateMachineController_locked_disconnected()
 		mTask = mTaskOld;
 
 		if (!errorHappened) {
-			Dbg4() << __PRETTY_FUNCTION__ << " run check result: ok" << std::endl;
+			RS_DBG4("run check result: ok") << std::endl;
 			break;
 		}
 		// switch to error
 		newState = csError;
-		RsDbg() << __PRETTY_FUNCTION__ << " run check result: error" << std::endl;
+		RS_DBG("run check result: error") << std::endl;
 		mErrorMsg = "Connection check failed. Will try to restart tunnel.";
 
 		break;
@@ -622,7 +619,7 @@ int p3I2pBob::stateMachineController_locked_disconnected()
 		mTask = mTaskOld;
 		break;
 	case ctIdle:
-		RsDbg() << __PRETTY_FUNCTION__ << " task is idle. This should not happen!" << std::endl;
+		RS_DBG("task is idle. This should not happen!") << std::endl;
 		rsAutoProxyMonitor::taskError(mProcessing);
 	}
 	mProcessing = NULL;
@@ -638,14 +635,14 @@ int p3I2pBob::stateMachineController_locked_error()
 {
 	// wait for bob protocoll
 	if (mBOBState != bsCleared) {
-		Dbg4() << __PRETTY_FUNCTION__ << " waiting for BOB" << std::endl;
+		RS_DBG4("waiting for BOB") << std::endl;
 		return sleepFactorFast;
 	}
 
 #if 0
 	std::stringstream ss;
 	ss << "stateMachineController_locked_error: mProcessing: " << (mProcessing ? "not null" : "null");
-	Dbg4() << __PRETTY_FUNCTION__ << " " + ss.str() << std::endl;
+	RS_DBG4("" + ss.str()) << std::endl;
 #endif
 
 	// try to finish ticket
@@ -653,7 +650,7 @@ int p3I2pBob::stateMachineController_locked_error()
 		switch (mTask) {
 		case ctRunCheck:
 			// connection check failed at some point
-			RsDbg() << __PRETTY_FUNCTION__ << " failed to check proxy status (it's likely dead)!" << std::endl;
+			RS_DBG("failed to check proxy status (it's likely dead)!") << std::endl;
 			*((bool *)mProcessing->data) = true;
 			mState = csDoDisconnect;
 			mStateOld = csIdel;
@@ -661,7 +658,7 @@ int p3I2pBob::stateMachineController_locked_error()
 			break;
 		case ctRunShutDown:
 			// not a big deal though
-			RsDbg() << __PRETTY_FUNCTION__ << " failed to shut down tunnel (it's likely dead though)!" << std::endl;
+			RS_DBG("failed to shut down tunnel (it's likely dead though)!") << std::endl;
 			mState = csDoDisconnect;
 			mStateOld = csIdel;
 			mErrorMsg.clear();
@@ -669,14 +666,14 @@ int p3I2pBob::stateMachineController_locked_error()
 		case ctIdle:
 			// should not happen but we need to deal with it
 			// this will produce some error messages in the log and finish the task (marked as failed)
-			RsDbg() << __PRETTY_FUNCTION__ << " task is idle. This should not happen!" << std::endl;
+			RS_DBG("task is idle. This should not happen!") << std::endl;
 			mState = csDoDisconnect;
 			mStateOld = csIdel;
 			mErrorMsg.clear();
 			break;
 		case ctRunGetKeys:
 		case ctRunSetUp:
-			RsDbg() << __PRETTY_FUNCTION__ << " failed to receive key / start up" << std::endl;
+			RS_DBG("failed to receive key / start up") << std::endl;
 			mStateOld = csError;
 			mState = csDoDisconnect;
 			// keep the error message
@@ -687,7 +684,7 @@ int p3I2pBob::stateMachineController_locked_error()
 
 	// periodically retry
 	if (mLastProxyCheck < time(NULL) - (selfCheckPeroid >> 1) && mTask == ctRunSetUp) {
-		RsDbg() << __PRETTY_FUNCTION__ << " retrying" << std::endl;
+		RS_DBG("retrying") << std::endl;
 
 		mLastProxyCheck = time(NULL);
 		mErrorMsg.clear();
@@ -700,7 +697,7 @@ int p3I2pBob::stateMachineController_locked_error()
 
 	// check for new tickets
 	if (!mPending.empty()) {
-		Dbg4() << __PRETTY_FUNCTION__ << " processing new ticket" << std::endl;
+		RS_DBG4("processing new ticket") << std::endl;
 
 		// reset and try new task
 		mTask = ctIdle;
@@ -731,7 +728,7 @@ RsSerialiser *p3I2pBob::setupSerialiser()
 
 bool p3I2pBob::saveList(bool &cleanup, std::list<RsItem *> &lst)
 {
-	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
+	RS_DBG4("") << std::endl;
 
 	cleanup = true;
 	RsConfigKeyValueSet *vitem = new RsConfigKeyValueSet;
@@ -766,7 +763,7 @@ bool p3I2pBob::saveList(bool &cleanup, std::list<RsItem *> &lst)
 
 bool p3I2pBob::loadList(std::list<RsItem *> &load)
 {
-	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
+	RS_DBG4("") << std::endl;
 
 	for(std::list<RsItem*>::const_iterator it = load.begin(); it!=load.end(); ++it) {
 		RsConfigKeyValueSet *vitem = dynamic_cast<RsConfigKeyValueSet*>(*it);
@@ -786,7 +783,7 @@ bool p3I2pBob::loadList(std::list<RsItem *> &load)
 				getKVSUInt(kit, kConfigKeyOutQuantity, mSetting.outQuantity)
 				getKVSUInt(kit, kConfigKeyOutVariance, mSetting.outVariance)
 				else
-				    RsDbg() << __PRETTY_FUNCTION__ << " unknown key: " + kit->key << std::endl;
+				    RS_DBG("unknown key: " + kit->key) << std::endl;
 			}
 		}
 		delete vitem;
@@ -850,7 +847,7 @@ void p3I2pBob::getStates(bobStates *bs)
 
 std::string p3I2pBob::executeCommand(const std::string &command)
 {
-	Dbg4() << __PRETTY_FUNCTION__ << " running '" + command + "'" << std::endl;
+	RS_DBG4("running '" + command + "'") << std::endl;
 
 	std::string copy = command;
 	copy.push_back('\n');
@@ -862,7 +859,7 @@ std::string p3I2pBob::executeCommand(const std::string &command)
 	// receive answer (trailing new line is already removed!)
 	std::string ans = recv();
 
-	Dbg4() << __PRETTY_FUNCTION__ << " answer '" + ans + "'" << std::endl;
+	RS_DBG4("answer '" + ans + "'") << std::endl;
 
 	return ans;
 }
@@ -872,7 +869,7 @@ bool p3I2pBob::connectI2P()
 	// there is only one thread that touches mSocket - no need for a lock
 
 	if (mSocket != 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " mSocket != 0" << std::endl;
+		RS_DBG("mSocket != 0") << std::endl;
 		return false;
 	}
 
@@ -880,21 +877,21 @@ bool p3I2pBob::connectI2P()
 	mSocket = unix_socket(PF_INET, SOCK_STREAM, 0);
 	if (mSocket < 0)
 	{
-		RsDbg() << __PRETTY_FUNCTION__ << " Failed to open socket! Socket Error: " + socket_errorType(errno) << std::endl;
+		RS_DBG("Failed to open socket! Socket Error: " + socket_errorType(errno)) << std::endl;
 		return false;
 	}
 
 	// connect
 	int err = unix_connect(mSocket, mI2PProxyAddr);
 	if (err != 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " Failed to connect to BOB! Socket Error: " + socket_errorType(errno) << std::endl;
+		RS_DBG("Failed to connect to BOB! Socket Error: " + socket_errorType(errno)) << std::endl;
 		return false;
 	}
 
 	// receive hello msg
 	recv();
 
-	Dbg4() << __PRETTY_FUNCTION__ << " done" << std::endl;
+	RS_DBG4("done") << std::endl;
 	return true;
 }
 
@@ -903,17 +900,17 @@ bool p3I2pBob::disconnectI2P()
 	// there is only one thread that touches mSocket - no need for a lock
 
 	if (mSocket == 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " mSocket == 0" << std::endl;
+		RS_DBG("mSocket == 0") << std::endl;
 		return true;
 	}
 
 	int err = unix_close(mSocket);
 	if (err != 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " Failed to close socket! Socket Error: " + socket_errorType(errno) << std::endl;
+		RS_DBG("Failed to close socket! Socket Error: " + socket_errorType(errno)) << std::endl;
 		return false;
 	}
 
-	Dbg4() << __PRETTY_FUNCTION__ << " done" << std::endl;
+	RS_DBG4("done") << std::endl;
 	mSocket = 0;
 	return true;
 }
@@ -934,7 +931,7 @@ std::string toString(const std::string &a, const int8_t b) {
 
 void p3I2pBob::finalizeSettings_locked()
 {
-	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
+	RS_DBG4("") << std::endl;
 
 	sockaddr_storage_clear(mI2PProxyAddr);
 	// get i2p proxy addr
@@ -945,8 +942,8 @@ void p3I2pBob::finalizeSettings_locked()
 	sockaddr_storage_setipv4(mI2PProxyAddr, (sockaddr_in*)&proxy);
 	sockaddr_storage_setport(mI2PProxyAddr, 2827);
 
-	Dbg4() << __PRETTY_FUNCTION__ << " using " + sockaddr_storage_tostring(mI2PProxyAddr) << std::endl;
-	Dbg4() << __PRETTY_FUNCTION__ << " using " + mSetting.address.base32 << std::endl;
+	RS_DBG4("using " + sockaddr_storage_tostring(mI2PProxyAddr)) << std::endl;
+	RS_DBG4("using " + mSetting.address.base32) << std::endl;
 
 	peerState ps;
 	mPeerMgr->getOwnNetStatus(ps);
@@ -961,7 +958,7 @@ void p3I2pBob::finalizeSettings_locked()
 	std::vector<uint8_t> tmp(len);
 	RSRandom::random_bytes(tmp.data(), len);
 	const std::string location = Radix32::encode(tmp.data(), len);
-	Dbg4() << __PRETTY_FUNCTION__ << " using suffix " + location << std::endl;
+	RS_DBG4("using suffix " + location) << std::endl;
 	mTunnelName = "RetroShare-" + location;
 
 	const std::string setnick    = "setnick RetroShare-" + location;
@@ -1029,7 +1026,7 @@ void p3I2pBob::finalizeSettings_locked()
 
 void p3I2pBob::updateSettings_locked()
 {
-	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
+	RS_DBG4("") << std::endl;
 
 	sockaddr_storage proxy;
 	mPeerMgr->getProxyServerAddress(RS_HIDDEN_TYPE_I2P, proxy);
@@ -1105,7 +1102,7 @@ std::string p3I2pBob::recv()
 			// sanity check
 			if (length != bufferSize) {
 				// expectation: a full buffer was peeked)
-				Dbg1() << __PRETTY_FUNCTION__ << " peeked less than bufferSize but also didn't found a new line character" << std::endl;
+				RS_DBG1("peeked less than bufferSize but also didn't found a new line character") << std::endl;
 			}
 			// this should never happen
 			assert(length <= bufferSize);

--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -936,7 +936,7 @@ void p3I2pBob::finalizeSettings_locked()
 	sockaddr_storage_setipv4(mI2PProxyAddr, (sockaddr_in*)&proxy);
 	sockaddr_storage_setport(mI2PProxyAddr, 2827);
 
-	RS_DBG4("using ", sockaddr_storage_tostring(mI2PProxyAddr));
+	RS_DBG4("using ", mI2PProxyAddr);
 	RS_DBG4("using ", mSetting.address.base32);
 
 	peerState ps;

--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -33,8 +33,6 @@
 #include "util/rsprint.h"
 #include "util/rsrandom.h"
 
-#include "util/rsdebuglevel4.h"
-
 static const std::string kConfigKeyBOBEnable   = "BOB_ENABLE";
 static const std::string kConfigKeyBOBKey      = "BOB_KEY";
 static const std::string kConfigKeyBOBAddr     = "BOB_ADDR";

--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -250,28 +250,6 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 	}
 }
 
-std::string p3I2pBob::keyToBase32Addr(const std::string &key)
-{
-	std::string copy(key);
-
-	// replace I2P specific chars
-	std::replace(copy.begin(), copy.end(), '~', '/');
-	std::replace(copy.begin(), copy.end(), '-', '+');
-
-	// decode
-	std::vector<uint8_t> bin = Radix64::decode(copy);
-	// hash
-	std::vector<uint8_t> sha256 = RsUtil::BinToSha256(bin);
-	// encode
-	std::string out = Radix32::encode(sha256);
-
-	// i2p uses lowercase
-	std::transform(out.begin(), out.end(), out.begin(), ::tolower);
-	out.append(".b32.i2p");
-
-	return out;
-}
-
 bool inline isAnswerOk(const std::string &answer) {
 	return (answer.compare(0, 2, "OK") == 0);
 }
@@ -346,7 +324,7 @@ int p3I2pBob::stateMachineBOB()
 		switch (mBOBState) {
 		case bsNewkeysN:
 			key = answer.substr(3, answer.length()-3);
-			mSetting.addr = keyToBase32Addr(key);
+			mSetting.addr = i2p::keyToBase32Addr(key);
 			IndicateConfigChanged();
 			break;
 		case bsGetkeys:

--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -44,11 +44,6 @@ static const std::string kConfigKeyOutLength   = "OUT_LENGTH";
 static const std::string kConfigKeyOutQuantity = "OUT_QUANTITY";
 static const std::string kConfigKeyOutVariance = "OUT_VARIANCE";
 
-static const bool   kDefaultBOBEnable = false;
-static const int8_t kDefaultLength    = 3;
-static const int8_t kDefaultQuantity  = 4;
-static const int8_t kDefaultVariance  = 0;
-
 /// Sleep duration for receiving loop
 static const useconds_t sleepTimeRecv = 10; // times 1000 = 10ms
 /// Sleep duration for everything else

--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -160,7 +160,7 @@ void p3I2pBob::processTaskAsync(taskTicket *ticket)
 	}
 		break;
 	default:
-		RsDbg() << __PRETTY_FUNCTION__ << " p3I2pBob::processTaskAsync unknown task" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " unknown task" << std::endl;
 		rsAutoProxyMonitor::taskError(ticket);
 		break;
 	}
@@ -175,7 +175,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 	case autoProxyTask::status:
 		// check if everything needed is set
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " p3I2pBob::status autoProxyTask::status data is missing" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::status data is missing" << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 			break;
 		}
@@ -189,7 +189,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 	case autoProxyTask::getSettings:
 		// check if everything needed is set
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " p3I2pBob::data_tick autoProxyTask::getSettings data is missing" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::getSettings data is missing" << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 			break;
 		}
@@ -203,7 +203,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 	case autoProxyTask::setSettings:
 		// check if everything needed is set
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " p3I2pBob::data_tick autoProxyTask::setSettings data is missing" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::setSettings data is missing" << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 			break;
 		}
@@ -223,7 +223,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 		break;
 	case autoProxyTask::getErrorInfo:
 		if (!data) {
-			RsDbg() << __PRETTY_FUNCTION__ << " p3I2pBob::data_tick autoProxyTask::getErrorInfo data is missing" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " autoProxyTask::getErrorInfo data is missing" << std::endl;
 			rsAutoProxyMonitor::taskError(ticket);
 		} else {
 			RS_STACK_MUTEX(mLock);
@@ -232,7 +232,7 @@ void p3I2pBob::processTaskSync(taskTicket *ticket)
 		}
 		break;
 	default:
-		RsDbg() << __PRETTY_FUNCTION__ << " p3I2pBob::processTaskSync unknown task" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " unknown task" << std::endl;
 		rsAutoProxyMonitor::taskError(ticket);
 		break;
 	}
@@ -300,7 +300,7 @@ int p3I2pBob::stateMachineBOB()
 		}
 
 		if (answer.find(mTunnelName) == std::string::npos) {
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineBOB status check: tunnel down!" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " status check: tunnel down!" << std::endl;
 			// signal error
 			*((bool *)mProcessing->data) = true;
 		}
@@ -340,8 +340,8 @@ int p3I2pBob::stateMachineBOB_locked_failure(const std::string &answer, const bo
 		return sleepFactorDefault;
 	}
 
-	RsDbg() << __PRETTY_FUNCTION__ << " stateMachineBOB FAILED to run command '" + currentState.command + "'" << std::endl;
-	RsDbg() << __PRETTY_FUNCTION__ << " stateMachineBOB '" + answer + "'" << std::endl;
+	RsDbg() << __PRETTY_FUNCTION__ << " FAILED to run command '" + currentState.command + "'" << std::endl;
+	RsDbg() << __PRETTY_FUNCTION__ << " '" + answer + "'" << std::endl;
 
 	mErrorMsg.append("FAILED to run command '" + currentState.command + "'" + '\n');
 	mErrorMsg.append("reason '" + answer + "'" + '\n');
@@ -388,14 +388,14 @@ int p3I2pBob::stateMachineController()
 		return stateMachineController_locked_idle();
 	case csDoConnect:
 		if (!connectI2P()) {
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController doConnect: unable to connect" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " doConnect: unable to connect" << std::endl;
 			mStateOld = mState;
 			mState = csError;
 			mErrorMsg = "unable to connect to BOB port";
 			return sleepFactorSlow;
 		}
 
-		Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController doConnect: connected" << std::endl;
+		Dbg4() << __PRETTY_FUNCTION__ << " doConnect: connected" << std::endl;
 		mState = csConnected;
 		break;
 	case csConnected:
@@ -403,7 +403,7 @@ int p3I2pBob::stateMachineController()
 	case csWaitForBob:
 		// check connection problems
 		if (mSocket == 0) {
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController waitForBob: conection lost" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " waitForBob: conection lost" << std::endl;
 			mStateOld = mState;
 			mState = csError;
 			mErrorMsg = "connection lost to BOB";
@@ -413,21 +413,21 @@ int p3I2pBob::stateMachineController()
 		// check for finished BOB protocol
 		if (mBOBState == bsCleared) {
 			// done
-			Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController waitForBob: mBOBState == bsCleared" << std::endl;
+			Dbg4() << __PRETTY_FUNCTION__ << " waitForBob: mBOBState == bsCleared" << std::endl;
 			mState = csDoDisconnect;
 		}
 		break;
 	case csDoDisconnect:
 		if (!disconnectI2P() || mSocket != 0) {
 			// just in case
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController doDisconnect: can't disconnect" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " doDisconnect: can't disconnect" << std::endl;
 			mStateOld = mState;
 			mState = csError;
 			mErrorMsg = "unable to disconnect from BOB";
 			return sleepFactorDefault;
 		}
 
-		Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController doDisconnect: disconnected" << std::endl;
+		Dbg4() << __PRETTY_FUNCTION__ << " doDisconnect: disconnected" << std::endl;
 		mState = csDisconnected;
 		break;
 	case csDisconnected:
@@ -458,7 +458,7 @@ int p3I2pBob::stateMachineController_locked_idle()
 		    mProcessing->task == autoProxyTask::stop ||
 		    mProcessing->task == autoProxyTask::proxyStatusCheck)) {
 			// skip since we are not enabled
-			Dbg1() << __PRETTY_FUNCTION__ << " stateMachineController_locked_idle: disabled -> skipping ticket" << std::endl;
+			Dbg1() << __PRETTY_FUNCTION__ << " disabled -> skipping ticket" << std::endl;
 			rsAutoProxyMonitor::taskDone(mProcessing, autoProxyStatus::disabled);
 			mProcessing = NULL;
 		} else {
@@ -480,7 +480,7 @@ int p3I2pBob::stateMachineController_locked_idle()
 				mTask = ctRunCheck;
 				break;
 			default:
-				Dbg1() << __PRETTY_FUNCTION__ << " stateMachineController_locked_idle unknown async task" << std::endl;
+				Dbg1() << __PRETTY_FUNCTION__ << " unknown async task" << std::endl;
 				rsAutoProxyMonitor::taskError(mProcessing);
 				mProcessing = NULL;
 				break;
@@ -528,28 +528,28 @@ int p3I2pBob::stateMachineController_locked_connected()
 	case ctRunSetUp:
 		// when we have a key use it for server tunnel!
 		if(mSetting.address.privateKey.empty()) {
-			Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_connected: setting mBOBState = setnickC" << std::endl;
+			Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = setnickC" << std::endl;
 			mBOBState = bsSetnickC;
 		} else {
-			Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_connected: setting mBOBState = setnickS" << std::endl;
+			Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = setnickS" << std::endl;
 			mBOBState = bsSetnickS;
 		}
 		break;
 	case ctRunShutDown:
 		// shut down existing tunnel
-		Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_connected: setting mBOBState = getnick" << std::endl;
+		Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = getnick" << std::endl;
 		mBOBState = bsGetnick;
 		break;
 	case ctRunCheck:
-		Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_connected: setting mBOBState = list" << std::endl;
+		Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = list" << std::endl;
 		mBOBState = bsList;
 		break;
 	case ctRunGetKeys:
-		Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_connected: setting mBOBState = setnickN" << std::endl;
+		Dbg4() << __PRETTY_FUNCTION__ << " setting mBOBState = setnickN" << std::endl;
 		mBOBState = bsSetnickN;
 		break;
 	case ctIdle:
-		RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_connected: task is idle. This should not happen!" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " task is idle. This should not happen!" << std::endl;
 		break;
 	}
 
@@ -565,7 +565,7 @@ int p3I2pBob::stateMachineController_locked_disconnected()
 	if(errorHappened) {
 		// reset old state
 		mStateOld = csIdel;
-		RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_disconnected: error during process!" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " error during process!" << std::endl;
 	}
 
 	// answer ticket
@@ -594,12 +594,12 @@ int p3I2pBob::stateMachineController_locked_disconnected()
 		mTask = mTaskOld;
 
 		if (!errorHappened) {
-			Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_disconnected: run check result: ok" << std::endl;
+			Dbg4() << __PRETTY_FUNCTION__ << " run check result: ok" << std::endl;
 			break;
 		}
 		// switch to error
 		newState = csError;
-		RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_disconnected: run check result: error" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " run check result: error" << std::endl;
 		mErrorMsg = "Connection check failed. Will try to restart tunnel.";
 
 		break;
@@ -622,7 +622,7 @@ int p3I2pBob::stateMachineController_locked_disconnected()
 		mTask = mTaskOld;
 		break;
 	case ctIdle:
-		RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_disconnected: task is idle. This should not happen!" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " task is idle. This should not happen!" << std::endl;
 		rsAutoProxyMonitor::taskError(mProcessing);
 	}
 	mProcessing = NULL;
@@ -638,7 +638,7 @@ int p3I2pBob::stateMachineController_locked_error()
 {
 	// wait for bob protocoll
 	if (mBOBState != bsCleared) {
-		Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_error: waiting for BOB" << std::endl;
+		Dbg4() << __PRETTY_FUNCTION__ << " waiting for BOB" << std::endl;
 		return sleepFactorFast;
 	}
 
@@ -653,7 +653,7 @@ int p3I2pBob::stateMachineController_locked_error()
 		switch (mTask) {
 		case ctRunCheck:
 			// connection check failed at some point
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_error: failed to check proxy status (it's likely dead)!" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " failed to check proxy status (it's likely dead)!" << std::endl;
 			*((bool *)mProcessing->data) = true;
 			mState = csDoDisconnect;
 			mStateOld = csIdel;
@@ -661,7 +661,7 @@ int p3I2pBob::stateMachineController_locked_error()
 			break;
 		case ctRunShutDown:
 			// not a big deal though
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_error: failed to shut down tunnel (it's likely dead though)!" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " failed to shut down tunnel (it's likely dead though)!" << std::endl;
 			mState = csDoDisconnect;
 			mStateOld = csIdel;
 			mErrorMsg.clear();
@@ -669,14 +669,14 @@ int p3I2pBob::stateMachineController_locked_error()
 		case ctIdle:
 			// should not happen but we need to deal with it
 			// this will produce some error messages in the log and finish the task (marked as failed)
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_error: task is idle. This should not happen!" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " task is idle. This should not happen!" << std::endl;
 			mState = csDoDisconnect;
 			mStateOld = csIdel;
 			mErrorMsg.clear();
 			break;
 		case ctRunGetKeys:
 		case ctRunSetUp:
-			RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_error: failed to receive key / start up" << std::endl;
+			RsDbg() << __PRETTY_FUNCTION__ << " failed to receive key / start up" << std::endl;
 			mStateOld = csError;
 			mState = csDoDisconnect;
 			// keep the error message
@@ -687,7 +687,7 @@ int p3I2pBob::stateMachineController_locked_error()
 
 	// periodically retry
 	if (mLastProxyCheck < time(NULL) - (selfCheckPeroid >> 1) && mTask == ctRunSetUp) {
-		RsDbg() << __PRETTY_FUNCTION__ << " stateMachineController_locked_error: retrying" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " retrying" << std::endl;
 
 		mLastProxyCheck = time(NULL);
 		mErrorMsg.clear();
@@ -700,7 +700,7 @@ int p3I2pBob::stateMachineController_locked_error()
 
 	// check for new tickets
 	if (!mPending.empty()) {
-		Dbg4() << __PRETTY_FUNCTION__ << " stateMachineController_locked_error: processing new ticket" << std::endl;
+		Dbg4() << __PRETTY_FUNCTION__ << " processing new ticket" << std::endl;
 
 		// reset and try new task
 		mTask = ctIdle;
@@ -731,7 +731,7 @@ RsSerialiser *p3I2pBob::setupSerialiser()
 
 bool p3I2pBob::saveList(bool &cleanup, std::list<RsItem *> &lst)
 {
-	Dbg4() << __PRETTY_FUNCTION__ << " saveList" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
 
 	cleanup = true;
 	RsConfigKeyValueSet *vitem = new RsConfigKeyValueSet;
@@ -766,7 +766,7 @@ bool p3I2pBob::saveList(bool &cleanup, std::list<RsItem *> &lst)
 
 bool p3I2pBob::loadList(std::list<RsItem *> &load)
 {
-	Dbg4() << __PRETTY_FUNCTION__ << " loadList" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
 
 	for(std::list<RsItem*>::const_iterator it = load.begin(); it!=load.end(); ++it) {
 		RsConfigKeyValueSet *vitem = dynamic_cast<RsConfigKeyValueSet*>(*it);
@@ -786,7 +786,7 @@ bool p3I2pBob::loadList(std::list<RsItem *> &load)
 				getKVSUInt(kit, kConfigKeyOutQuantity, mSetting.outQuantity)
 				getKVSUInt(kit, kConfigKeyOutVariance, mSetting.outVariance)
 				else
-				    RsDbg() << __PRETTY_FUNCTION__ << " loadList unknown key: " + kit->key << std::endl;
+				    RsDbg() << __PRETTY_FUNCTION__ << " unknown key: " + kit->key << std::endl;
 			}
 		}
 		delete vitem;
@@ -850,7 +850,7 @@ void p3I2pBob::getStates(bobStates *bs)
 
 std::string p3I2pBob::executeCommand(const std::string &command)
 {
-	Dbg4() << __PRETTY_FUNCTION__ << " executeCommand_locked running '" + command + "'" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << " running '" + command + "'" << std::endl;
 
 	std::string copy = command;
 	copy.push_back('\n');
@@ -862,7 +862,7 @@ std::string p3I2pBob::executeCommand(const std::string &command)
 	// receive answer (trailing new line is already removed!)
 	std::string ans = recv();
 
-	Dbg4() << __PRETTY_FUNCTION__ << " executeCommand_locked answer '" + ans + "'" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << " answer '" + ans + "'" << std::endl;
 
 	return ans;
 }
@@ -872,7 +872,7 @@ bool p3I2pBob::connectI2P()
 	// there is only one thread that touches mSocket - no need for a lock
 
 	if (mSocket != 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " connectI2P_locked mSocket != 0" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " mSocket != 0" << std::endl;
 		return false;
 	}
 
@@ -880,21 +880,21 @@ bool p3I2pBob::connectI2P()
 	mSocket = unix_socket(PF_INET, SOCK_STREAM, 0);
 	if (mSocket < 0)
 	{
-		RsDbg() << __PRETTY_FUNCTION__ << " connectI2P_locked Failed to open socket! Socket Error: " + socket_errorType(errno) << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " Failed to open socket! Socket Error: " + socket_errorType(errno) << std::endl;
 		return false;
 	}
 
 	// connect
 	int err = unix_connect(mSocket, mI2PProxyAddr);
 	if (err != 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " connectI2P_locked Failed to connect to BOB! Socket Error: " + socket_errorType(errno) << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " Failed to connect to BOB! Socket Error: " + socket_errorType(errno) << std::endl;
 		return false;
 	}
 
 	// receive hello msg
 	recv();
 
-	Dbg4() << __PRETTY_FUNCTION__ << " connectI2P_locked done" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << " done" << std::endl;
 	return true;
 }
 
@@ -903,17 +903,17 @@ bool p3I2pBob::disconnectI2P()
 	// there is only one thread that touches mSocket - no need for a lock
 
 	if (mSocket == 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " disconnectI2P_locked mSocket == 0" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " mSocket == 0" << std::endl;
 		return true;
 	}
 
 	int err = unix_close(mSocket);
 	if (err != 0) {
-		RsDbg() << __PRETTY_FUNCTION__ << " disconnectI2P_locked Failed to close socket! Socket Error: " + socket_errorType(errno) << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__ << " Failed to close socket! Socket Error: " + socket_errorType(errno) << std::endl;
 		return false;
 	}
 
-	Dbg4() << __PRETTY_FUNCTION__ << " disconnectI2P_locked done" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << " done" << std::endl;
 	mSocket = 0;
 	return true;
 }
@@ -934,7 +934,7 @@ std::string toString(const std::string &a, const int8_t b) {
 
 void p3I2pBob::finalizeSettings_locked()
 {
-	Dbg4() << __PRETTY_FUNCTION__ << " finalizeSettings_locked" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
 
 	sockaddr_storage_clear(mI2PProxyAddr);
 	// get i2p proxy addr
@@ -945,8 +945,8 @@ void p3I2pBob::finalizeSettings_locked()
 	sockaddr_storage_setipv4(mI2PProxyAddr, (sockaddr_in*)&proxy);
 	sockaddr_storage_setport(mI2PProxyAddr, 2827);
 
-	Dbg4() << __PRETTY_FUNCTION__ << " finalizeSettings_locked using " + sockaddr_storage_tostring(mI2PProxyAddr) << std::endl;
-	Dbg4() << __PRETTY_FUNCTION__ << " finalizeSettings_locked using " + mSetting.address.base32 << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << " using " + sockaddr_storage_tostring(mI2PProxyAddr) << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << " using " + mSetting.address.base32 << std::endl;
 
 	peerState ps;
 	mPeerMgr->getOwnNetStatus(ps);
@@ -961,7 +961,7 @@ void p3I2pBob::finalizeSettings_locked()
 	std::vector<uint8_t> tmp(len);
 	RSRandom::random_bytes(tmp.data(), len);
 	const std::string location = Radix32::encode(tmp.data(), len);
-	Dbg4() << __PRETTY_FUNCTION__ << " finalizeSettings_locked using suffix " + location << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << " using suffix " + location << std::endl;
 	mTunnelName = "RetroShare-" + location;
 
 	const std::string setnick    = "setnick RetroShare-" + location;
@@ -1029,7 +1029,7 @@ void p3I2pBob::finalizeSettings_locked()
 
 void p3I2pBob::updateSettings_locked()
 {
-	Dbg4() << __PRETTY_FUNCTION__ << " updateSettings_locked" << std::endl;
+	Dbg4() << __PRETTY_FUNCTION__ << std::endl;
 
 	sockaddr_storage proxy;
 	mPeerMgr->getProxyServerAddress(RS_HIDDEN_TYPE_I2P, proxy);

--- a/libretroshare/src/services/autoproxy/p3i2pbob.cc
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.cc
@@ -945,13 +945,9 @@ void p3I2pBob::finalizeSettings_locked()
 	// setup commands
 	// new lines are appended later!
 
-	// generate random suffix for name
-	// RSRandom::random_alphaNumericString can return very weird looking strings like: ,,@z+M
-	// use base32 instead
-	size_t len = 5; // 5 characters = 8 base32 symbols
-	std::vector<uint8_t> tmp(len);
-	RSRandom::random_bytes(tmp.data(), len);
-	const std::string location = Radix32::encode(tmp.data(), len);
+	// generate 8 characater long random suffix for name
+	constexpr size_t len = 8;
+	const std::string location = RsRandom::alphaNumeric(len);
 	RS_DBG4("using suffix ", location);
 	mTunnelName = "RetroShare-" + location;
 

--- a/libretroshare/src/services/autoproxy/p3i2pbob.h
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.h
@@ -30,9 +30,10 @@
 	#include <sys/socket.h>
 #endif
 
+#include "pqi/p3cfgmgr.h"
 #include "services/autoproxy/rsautoproxymonitor.h"
 #include "util/rsthreads.h"
-#include "pqi/p3cfgmgr.h"
+#include "util/i2pcommon.h"
 
 /*
  * This class implements I2P BOB (BASIC OPEN BRIDGE) communication to allow RS
@@ -49,7 +50,7 @@
  *
  * Note 3:
  *	BOB needs a unique name as an ID for each tunnel.
- *	We use 'RetroShare-' + 8 base32 characters.
+ *	We use 'RetroShare-' + 8 random base32 characters.
  *
  * Design:
  *	The service uses three state machines to manage its task:
@@ -72,7 +73,7 @@
  *		mCommands[bobState::quit]     = {quit,    bobState::cleared};
  *
  * stateMachineController:
- *	This state machone manages the high level tasks.
+ *	This state machine manages the high level tasks.
  *	It is controlled by mState and mTask.
  *
  *		mTast:
@@ -202,8 +203,6 @@ public:
 	bool initialSetup(std::string &addr, uint16_t &);
 	void processTaskAsync(taskTicket *ticket);
 	void processTaskSync(taskTicket *ticket);
-
-	static std::string keyToBase32Addr(const std::string &key);
 
 	void threadTick() override; /// @see RsTickingThread
 

--- a/libretroshare/src/services/autoproxy/p3i2pbob.h
+++ b/libretroshare/src/services/autoproxy/p3i2pbob.h
@@ -163,19 +163,7 @@ struct bobStateInfo {
 	bobState    nextState;
 };
 
-struct bobSettings {
-	bool enableBob;		///< This field is used by the pqi subsystem to determinine whether SOCKS proxy or BOB is used for I2P connections
-	std::string keys;	///< (optional) server keys
-	std::string addr;	///< (optional) hidden service addr. in base32 form
-
-	int8_t inLength;
-	int8_t inQuantity;
-	int8_t inVariance;
-
-	int8_t outLength;
-	int8_t outQuantity;
-	int8_t outVariance;
-};
+struct bobSettings : i2p::settings {};
 
 ///
 /// \brief The bobStates struct

--- a/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
+++ b/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
@@ -44,7 +44,7 @@ void rsAutoProxyMonitor::addProxy(autoProxyType::autoProxyType_enum type, autoPr
 {
 	RS_STACK_MUTEX(mLock);
 	if (mProxies.find(type) != mProxies.end()) {
-		RsErr() << __PRETTY_FUNCTION__<< " type " << type << " already added - OVERWRITING" << std::endl;
+		RS_ERR("type ", type, " already added - OVERWRITING");
 		print_stacktrace();
 	}
 
@@ -120,7 +120,7 @@ void rsAutoProxyMonitor::stopAllRSShutdown()
 	do {		
 		rstime::rs_usleep(1000 * 1000);
 		RS_STACK_MUTEX(mLock);
-		RsDbg() << __PRETTY_FUNCTION__<< " waiting for auto proxy service(s) to shut down " << t << "/" << timeout << " (remaining: " << mProxies.size() << ")" << std::endl;
+		RS_DBG("waiting for auto proxy service(s) to shut down ", t, "/", timeout, " (remaining: ", mProxies.size(), ")");
 		if (mProxies.empty())
 			break;
 		t++;
@@ -149,15 +149,15 @@ void rsAutoProxyMonitor::task(taskTicket *ticket)
 {
 	// sanity checks
 	if (!ticket->async && ticket->types.size() > 1) {
-		RsErr() << __PRETTY_FUNCTION__<< " synchronous call to multiple services. This can cause problems!" << std::endl;
+		RS_ERR("synchronous call to multiple services. This can cause problems!");
 		print_stacktrace();
 	}
 	if (ticket->async && !ticket->cb && ticket->data) {
-		RsErr() << __PRETTY_FUNCTION__<< " asynchronous call with data but no callback. This will likely causes memory leak!" << std::endl;
+		RS_ERR("asynchronous call with data but no callback. This will likely causes memory leak!");
 		print_stacktrace();
 	}
 	if (ticket->types.size() > 1 && ticket->data) {
-		RsErr() << __PRETTY_FUNCTION__<< " call with data to multiple services. This will likely causes memory leak!" << std::endl;
+		RS_ERR("call with data to multiple services. This will likely causes memory leak!");
 		print_stacktrace();
 	}
 
@@ -197,7 +197,7 @@ void rsAutoProxyMonitor::taskAsync(std::vector<autoProxyType::autoProxyType_enum
 	if (!isAsyncTask(task)) {
 		// Usually the services will reject this ticket.
 		// Just print a warning - maybe there is some special case where this is a good idea.
-		RsErr() << __PRETTY_FUNCTION__<< " called with a synchronous task!" << std::endl;
+		RS_ERR("called with a synchronous task!");
 		print_stacktrace();
 	}
 
@@ -226,7 +226,7 @@ void rsAutoProxyMonitor::taskSync(std::vector<autoProxyType::autoProxyType_enum>
 	if (isAsyncTask(task)) {
 		// Usually the services will reject this ticket.
 		// Just print a warning - maybe there is some special case where this is a good idea.
-		RsErr() << __PRETTY_FUNCTION__<< " called with an asynchronous task!" << std::endl;
+		RS_ERR("called with an asynchronous task!");
 		print_stacktrace();
 	}
 
@@ -256,7 +256,7 @@ void rsAutoProxyMonitor::taskDone(taskTicket *t, autoProxyStatus::autoProxyStatu
 		t->cb->taskFinished(t);
 		if (t != NULL) {
 			// callack did not clean up properly
-			RsErr() << __PRETTY_FUNCTION__<< " callback did not clean up!" << std::endl;
+			RS_ERR("callback did not clean up!");
 			print_stacktrace();
 			cleanUp = true;
 		}
@@ -265,12 +265,12 @@ void rsAutoProxyMonitor::taskDone(taskTicket *t, autoProxyStatus::autoProxyStatu
 		// we must take care of deleting
 		cleanUp = true;
 		if(t->data)
-			RsErr() << __PRETTY_FUNCTION__<< " async call with data attached but no callback set!" << std::endl;
+			RS_ERR("sync call with data attached but no callback set!");
 	}
 
 	if (cleanUp) {
 		if (t->data) {
-			RsErr() << __PRETTY_FUNCTION__<< " will try to delete void pointer!" << std::endl;
+			RS_ERR("will try to delete void pointer!");
 			print_stacktrace();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdelete-incomplete"
@@ -304,7 +304,7 @@ void rsAutoProxyMonitor::taskFinished(taskTicket *&ticket)
 
 	// clean up
 	if (ticket->data) {
-		RsErr() << __PRETTY_FUNCTION__<< " data set. Will try to delete void pointer" << std::endl;
+		RS_ERR(" data set. Will try to delete void pointer");
 		print_stacktrace();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdelete-incomplete"
@@ -323,7 +323,7 @@ autoProxyService *rsAutoProxyMonitor::lookUpService(autoProxyType::autoProxyType
 	if ((itService = mProxies.find(t)) != mProxies.end()) {
 		return itService->second;
 	}
-	RsDbg() << __PRETTY_FUNCTION__<< " no service for type " << t << " found!" << std::endl;
+	RS_DBG("no service for type ", t, " found!");
 	return NULL;
 }
 

--- a/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
+++ b/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
@@ -22,6 +22,7 @@
 #include "rsautoproxymonitor.h"
 
 #include <unistd.h>		/* for usleep() */
+#include "util/rsdebug.h"
 #include "util/rstime.h"
 
 rsAutoProxyMonitor *rsAutoProxyMonitor::mInstance = NULL;
@@ -42,8 +43,10 @@ rsAutoProxyMonitor *rsAutoProxyMonitor::instance()
 void rsAutoProxyMonitor::addProxy(autoProxyType::autoProxyType_enum type, autoProxyService *service)
 {
 	RS_STACK_MUTEX(mLock);
-	if (mProxies.find(type) != mProxies.end())
-		std::cerr << "sAutoProxyMonitor::addProxy type " << type << " already added - OVERWRITING" << std::endl;
+	if (mProxies.find(type) != mProxies.end()) {
+		RsErr() << __PRETTY_FUNCTION__<< " type " << type << " already added - OVERWRITING" << std::endl;
+		print_stacktrace();
+	}
 
 	mProxies[type] = service;
 }
@@ -117,7 +120,7 @@ void rsAutoProxyMonitor::stopAllRSShutdown()
 	do {		
 		rstime::rs_usleep(1000 * 1000);
 		RS_STACK_MUTEX(mLock);
-		std::cout << "(II) waiting for auto proxy service(s) to shut down " << t << "/" << timeout << " (remaining: " << mProxies.size() << ")" << std::endl;
+		RsDbg() << __PRETTY_FUNCTION__<< " waiting for auto proxy service(s) to shut down " << t << "/" << timeout << " (remaining: " << mProxies.size() << ")" << std::endl;
 		if (mProxies.empty())
 			break;
 		t++;
@@ -146,13 +149,16 @@ void rsAutoProxyMonitor::task(taskTicket *ticket)
 {
 	// sanity checks
 	if (!ticket->async && ticket->types.size() > 1) {
-		std::cerr << "(WW) rsAutoProxyMonitor::task synchronous call to multiple services. This can cause problems!" << std::endl;
+		RsErr() << __PRETTY_FUNCTION__<< " synchronous call to multiple services. This can cause problems!" << std::endl;
+		print_stacktrace();
 	}
 	if (ticket->async && !ticket->cb && ticket->data) {
-		std::cerr << "(WW) rsAutoProxyMonitor::task asynchronous call with data but no callback. This will likely causes memory leak!" << std::endl;
+		RsErr() << __PRETTY_FUNCTION__<< " asynchronous call with data but no callback. This will likely causes memory leak!" << std::endl;
+		print_stacktrace();
 	}
 	if (ticket->types.size() > 1 && ticket->data) {
-		std::cerr << "(WW) rsAutoProxyMonitor::task call with data to multiple services. This will likely causes memory leak!" << std::endl;
+		RsErr() << __PRETTY_FUNCTION__<< " call with data to multiple services. This will likely causes memory leak!" << std::endl;
+		print_stacktrace();
 	}
 
 	std::vector<autoProxyType::autoProxyType_enum>::const_iterator it;
@@ -187,7 +193,8 @@ void rsAutoProxyMonitor::taskAsync(std::vector<autoProxyType::autoProxyType_enum
 	if (!isAsyncTask(task)) {
 		// Usually the services will reject this ticket.
 		// Just print a warning - maybe there is some special case where this is a good idea.
-		std::cerr << "(WW) rsAutoProxyMonitor::taskAsync called with a synchronous task!" << std::endl;
+		RsErr() << __PRETTY_FUNCTION__<< " called with a synchronous task!" << std::endl;
+		print_stacktrace();
 	}
 
 	taskTicket *tt = getTicket();
@@ -215,7 +222,8 @@ void rsAutoProxyMonitor::taskSync(std::vector<autoProxyType::autoProxyType_enum>
 	if (isAsyncTask(task)) {
 		// Usually the services will reject this ticket.
 		// Just print a warning - maybe there is some special case where this is a good idea.
-		std::cerr << "(WW) rsAutoProxyMonitor::taskSync called with an asynchronous task!" << std::endl;
+		RsErr() << __PRETTY_FUNCTION__<< " called with an asynchronous task!" << std::endl;
+		print_stacktrace();
 	}
 
 	taskTicket *tt = getTicket();
@@ -244,7 +252,8 @@ void rsAutoProxyMonitor::taskDone(taskTicket *t, autoProxyStatus::autoProxyStatu
 		t->cb->taskFinished(t);
 		if (t != NULL) {
 			// callack did not clean up properly
-			std::cerr << "(WW) rsAutoProxyMonitor::taskFinish callback did not clean up!" << std::endl;
+			RsErr() << __PRETTY_FUNCTION__<< " callback did not clean up!" << std::endl;
+			print_stacktrace();
 			cleanUp = true;
 		}
 	} else if (t->async){
@@ -252,12 +261,13 @@ void rsAutoProxyMonitor::taskDone(taskTicket *t, autoProxyStatus::autoProxyStatu
 		// we must take care of deleting
 		cleanUp = true;
 		if(t->data)
-			std::cerr << "(WW) rsAutoProxyMonitor::taskFinish async call with data attached but no callback set!" << std::endl;
+			RsErr() << __PRETTY_FUNCTION__<< " async call with data attached but no callback set!" << std::endl;
 	}
 
 	if (cleanUp) {
 		if (t->data) {
-			std::cerr << "(WW) rsAutoProxyMonitor::taskFinish will try to delete void pointer!" << std::endl;
+			RsErr() << __PRETTY_FUNCTION__<< " will try to delete void pointer!" << std::endl;
+			print_stacktrace();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdelete-incomplete"
 			delete t->data;
@@ -290,7 +300,8 @@ void rsAutoProxyMonitor::taskFinished(taskTicket *&ticket)
 
 	// clean up
 	if (ticket->data) {
-		std::cerr << "rsAutoProxyMonitor::taskFinished data set. Will try to delete void pointer" << std::endl;
+		RsErr() << __PRETTY_FUNCTION__<< " data set. Will try to delete void pointer" << std::endl;
+		print_stacktrace();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdelete-incomplete"
 		delete ticket->data;
@@ -308,7 +319,7 @@ autoProxyService *rsAutoProxyMonitor::lookUpService(autoProxyType::autoProxyType
 	if ((itService = mProxies.find(t)) != mProxies.end()) {
 		return itService->second;
 	}
-	std::cerr << "sAutoProxyMonitor::lookUpService no service for type " << t << " found!" << std::endl;
+	RsDbg() << __PRETTY_FUNCTION__<< " no service for type " << t << " found!" << std::endl;
 	return NULL;
 }
 

--- a/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
+++ b/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
@@ -265,7 +265,7 @@ void rsAutoProxyMonitor::taskDone(taskTicket *t, autoProxyStatus::autoProxyStatu
 		// we must take care of deleting
 		cleanUp = true;
 		if(t->data)
-			RS_ERR("sync call with data attached but no callback set!");
+			RS_ERR("async call with data attached but no callback set!");
 	}
 
 	if (cleanUp) {

--- a/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
+++ b/libretroshare/src/services/autoproxy/rsautoproxymonitor.cc
@@ -174,7 +174,11 @@ void rsAutoProxyMonitor::task(taskTicket *ticket)
 			*tt = *ticket;
 			tt->types.clear();
 			tt->types.push_back(*it);
-			s->processTaskAsync(tt);
+
+			// it's async!
+			RsThread::async([s, tt] {
+				s->processTaskAsync(tt);
+			});
 		} else {
 			s->processTaskSync(ticket);
 		}

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -67,7 +67,8 @@ std::string publicKeyFromPrivate(std::string const &priv)
 	// creat a copy to work on, need to convert it to standard base64
 	auto priv_copy(priv);
 	std::replace(priv_copy.begin(), priv_copy.end(), '~', '/');
-	std::replace(priv_copy.begin(), priv_copy.end(), '-', '+');
+	// replacing the - with a + is not necessary, as RsBase64 can handle base64url encoding, too
+	// std::replace(copy.begin(), copy.end(), '-', '+');
 
 	// get raw data
 	std::vector<uint8_t> dataPriv;

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -1,0 +1,172 @@
+#include "i2pcommon.h"
+
+#include "util/rsbase64.h"
+#include "util/rsdebug.h"
+
+namespace i2p {
+
+const std::string generateNameSuffix(const size_t len) {
+	std::vector<uint8_t> tmp(len);
+	RsRandom::random_bytes(tmp.data(), len);
+	const std::string location = Radix32::encode(tmp.data(), len);
+
+	return location;
+}
+
+std::string keyToBase32Addr(const std::string &key)
+{
+	std::string copy(key);
+
+	// replace I2P specific chars
+	std::replace(copy.begin(), copy.end(), '~', '/');
+	std::replace(copy.begin(), copy.end(), '-', '+');
+
+	// decode
+	std::vector<uint8_t> bin;
+	RsBase64::decode(copy, bin);
+
+	// hash
+	std::vector<uint8_t> sha256 = RsUtil::BinToSha256(bin);
+	// encode
+	std::string out = Radix32::encode(sha256);
+
+	// i2p uses lowercase
+	std::transform(out.begin(), out.end(), out.begin(), ::tolower);
+	out.append(".b32.i2p");
+
+	return out;
+}
+
+const std::string makeOption(const std::string &lhs, const int8_t &rhs) {
+	// convert number to int
+	std::ostringstream oss;
+	oss << (int)rhs;
+	return lhs + "=" + oss.str();
+}
+
+uint16_t readTwoBytesBE(std::vector<uint8_t>::const_iterator &p)
+{
+	uint16_t val = 0;
+	val += *p++;
+	val <<= 8;
+	val += *p++;
+	return val;
+}
+
+std::string publicKeyFromPrivate(std::string const &priv)
+{
+	/*
+	 * https://geti2p.net/spec/common-structures#destination
+	 * https://geti2p.net/spec/common-structures#keysandcert
+	 * https://geti2p.net/spec/common-structures#certificate
+	 */
+	if (priv.length() < 884) // base64 ( = 663 bytes = KeyCert + priv Keys)
+		return std::string();
+
+	// creat a copy to work on, need to convert it to standard base64
+	auto priv_copy(priv);
+	std::replace(priv_copy.begin(), priv_copy.end(), '~', '/');
+	std::replace(priv_copy.begin(), priv_copy.end(), '-', '+');
+
+	// get raw data
+	std::vector<uint8_t> dataPriv;
+	RsBase64::decode(priv_copy, dataPriv);
+
+	auto p = dataPriv.cbegin();
+	RsDbg() << __PRETTY_FUNCTION__ << " dataPriv.size " << dataPriv.size() << std::endl;
+
+	size_t publicKeyLen = 256 + 128; // default length (bytes)
+	uint8_t certType = 0;
+	uint16_t len = 0;
+	uint16_t signingKeyType = 0;
+	uint16_t cryptKey = 0;
+
+	// only used for easy break
+	do {
+		try {
+			// jump to certificate
+			p += publicKeyLen;
+			// try to read type and length
+			certType = *p++;
+			len = readTwoBytesBE(p);
+
+			// only 0 and 5 are used / valid at this point
+			// check for == 0
+			if (certType == static_cast<typename std::underlying_type<CertType>::type>(CertType::Null)) {
+				/*
+				 * CertType.Null
+				 * type null is followed by 0x00 0x00 <END>
+				 * so has to be 0!
+				 */
+				RsDbg() << __PRETTY_FUNCTION__ << " cert is CertType.Null" << std::endl;
+				publicKeyLen += 3; // add 0x00 0x00 0x00
+
+				if (len != 0)
+					// weird
+					RsDbg() << __PRETTY_FUNCTION__ << " cert is CertType.Null but len != 0" << std::endl;
+
+				break;
+			}
+
+			// check for != 5
+			if (certType != static_cast<typename std::underlying_type<CertType>::type>(CertType::Key)) {
+				// unsupported
+				RsDbg() << __PRETTY_FUNCTION__ << " cert type " << certType << " is unsupported" << std::endl;
+				return std::string();
+			}
+
+			RsDbg() << __PRETTY_FUNCTION__ << " cert is CertType.Key" << std::endl;
+			publicKeyLen += 7; // <type 1B> <len 2B> <keyType1 2B> <keyType2 2B> = 1 + 2 + 2 + 2 = 7 bytes
+
+			/*
+			 * "Key certificates were introduced in release 0.9.12. Prior to that release, all PublicKeys were 256-byte ElGamal keys, and all SigningPublicKeys were 128-byte DSA-SHA1 keys."
+			 * --> there is space for 256+128 bytes, longer keys are splitted and appended to the certificate
+			 * We don't need to bother with the splitting here as only the lenght is important!
+			 */
+
+			// Signing Public Key
+			// likely 7
+			signingKeyType = readTwoBytesBE(p);
+
+			RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << std::endl;
+			if (signingKeyType >= 3 && signingKeyType <= 6) {
+				RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " has oversize" << std::endl;
+				// calculate oversize
+
+				auto it = signingKeyLengths.find(static_cast<SigningKeyType>(signingKeyType));
+				if (it == signingKeyLengths.end()) {
+					// just in case
+					RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " cannot be found in size map!" << std::endl;
+					return std::string();
+				}
+
+				if (it->second.first <= 128) {
+					// just in case, it's supposed to be larger!
+					RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " is oversize but size calculation would underflow!" << std::endl;
+					return std::string();
+				}
+
+				publicKeyLen += it->second.first - 128; // 128 = default DSA key length = the space than can be used before the key must be splitted
+			}
+
+			// Crypto Public Key
+			// likely 0
+			cryptKey = readTwoBytesBE(p);
+			RsDbg() << __PRETTY_FUNCTION__ << " crypto pubkey type " << cryptKey << std::endl;
+			// info: these are all smaller than the default 256 bytes, so no oversize calculation is needed
+
+			break;
+		}  catch (const std::out_of_range &e) {
+			RsDbg() << __PRETTY_FUNCTION__ << " hit exception!" << e.what() << std::endl;
+			return std::string();
+		}
+	} while(false);
+
+	std::string pub;
+	auto data2 = std::vector<uint8_t>(dataPriv.cbegin(), dataPriv.cbegin() + publicKeyLen);
+	RsBase64::encode(data2.data(), data2.size(), pub, false, false);
+
+	return pub;
+}
+
+} // namespace i2p

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -39,10 +39,7 @@ std::string keyToBase32Addr(const std::string &key)
 }
 
 const std::string makeOption(const std::string &lhs, const int8_t &rhs) {
-	// convert number to int
-	std::ostringstream oss;
-	oss << (int)rhs;
-	return lhs + "=" + oss.str();
+	return lhs + "=" + std::to_string(rhs);
 }
 
 uint16_t readTwoBytesBE(std::vector<uint8_t>::const_iterator &p)

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -73,7 +73,7 @@ std::string publicKeyFromPrivate(std::string const &priv)
 	RsBase64::decode(priv_copy, dataPriv);
 
 	auto p = dataPriv.cbegin();
-	RsDbg() << __PRETTY_FUNCTION__ << " dataPriv.size " << dataPriv.size() << std::endl;
+	RS_DBG("dataPriv.size ") << dataPriv.size() << std::endl;
 
 	size_t publicKeyLen = 256 + 128; // default length (bytes)
 	uint8_t certType = 0;
@@ -98,12 +98,12 @@ std::string publicKeyFromPrivate(std::string const &priv)
 				 * type null is followed by 0x00 0x00 <END>
 				 * so has to be 0!
 				 */
-				RsDbg() << __PRETTY_FUNCTION__ << " cert is CertType.Null" << std::endl;
+				RS_DBG("cert is CertType.Null");
 				publicKeyLen += 3; // add 0x00 0x00 0x00
 
 				if (len != 0)
 					// weird
-					RsDbg() << __PRETTY_FUNCTION__ << " cert is CertType.Null but len != 0" << std::endl;
+					RS_DBG("cert is CertType.Null but len != 0");
 
 				break;
 			}
@@ -111,11 +111,11 @@ std::string publicKeyFromPrivate(std::string const &priv)
 			// check for != 5
 			if (certType != static_cast<typename std::underlying_type<CertType>::type>(CertType::Key)) {
 				// unsupported
-				RsDbg() << __PRETTY_FUNCTION__ << " cert type " << certType << " is unsupported" << std::endl;
+				RS_DBG("cert type ") << certType << " is unsupported" << std::endl;
 				return std::string();
 			}
 
-			RsDbg() << __PRETTY_FUNCTION__ << " cert is CertType.Key" << std::endl;
+			RS_DBG("cert is CertType.Key");
 			publicKeyLen += 7; // <type 1B> <len 2B> <keyType1 2B> <keyType2 2B> = 1 + 2 + 2 + 2 = 7 bytes
 
 			/*
@@ -128,21 +128,21 @@ std::string publicKeyFromPrivate(std::string const &priv)
 			// likely 7
 			signingKeyType = readTwoBytesBE(p);
 
-			RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << std::endl;
+			RS_DBG("signing pubkey type ") << certType << std::endl;
 			if (signingKeyType >= 3 && signingKeyType <= 6) {
-				RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " has oversize" << std::endl;
+				RS_DBG("signing pubkey type ") << certType << " has oversize" << std::endl;
 				// calculate oversize
 
 				if (signingKeyType >= signingKeyLengths.size()) {
 					// just in case
-					RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " cannot be found in size map!" << std::endl;
+					RS_DBG("signing pubkey type ") << certType << " cannot be found in size map!" << std::endl;
 					return std::string();
 				}
 
 				auto values = signingKeyLengths[signingKeyType];
 				if (values.first <= 128) {
 					// just in case, it's supposed to be larger!
-					RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " is oversize but size calculation would underflow!" << std::endl;
+					RS_DBG("signing pubkey type ") << certType << " is oversize but size calculation would underflow!" << std::endl;
 					return std::string();
 				}
 
@@ -152,12 +152,12 @@ std::string publicKeyFromPrivate(std::string const &priv)
 			// Crypto Public Key
 			// likely 0
 			cryptKey = readTwoBytesBE(p);
-			RsDbg() << __PRETTY_FUNCTION__ << " crypto pubkey type " << cryptKey << std::endl;
+			RS_DBG("crypto pubkey type ") << cryptKey << std::endl;
 			// info: these are all smaller than the default 256 bytes, so no oversize calculation is needed
 
 			break;
 		}  catch (const std::out_of_range &e) {
-			RsDbg() << __PRETTY_FUNCTION__ << " hit exception!" << e.what() << std::endl;
+			RS_DBG("hit exception! ") << e.what() << std::endl;
 			return std::string();
 		}
 	} while(false);

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -5,14 +5,6 @@
 
 namespace i2p {
 
-const std::string generateNameSuffix(const size_t len) {
-	std::vector<uint8_t> tmp(len);
-	RsRandom::random_bytes(tmp.data(), len);
-	const std::string location = Radix32::encode(tmp.data(), len);
-
-	return location;
-}
-
 std::string keyToBase32Addr(const std::string &key)
 {
 	std::string copy(key);

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -73,7 +73,7 @@ std::string publicKeyFromPrivate(std::string const &priv)
 	RsBase64::decode(priv_copy, dataPriv);
 
 	auto p = dataPriv.cbegin();
-	RS_DBG("dataPriv.size ") << dataPriv.size() << std::endl;
+	RS_DBG("dataPriv.size ", dataPriv.size());
 
 	size_t publicKeyLen = 256 + 128; // default length (bytes)
 	uint8_t certType = 0;
@@ -111,7 +111,7 @@ std::string publicKeyFromPrivate(std::string const &priv)
 			// check for != 5
 			if (certType != static_cast<typename std::underlying_type<CertType>::type>(CertType::Key)) {
 				// unsupported
-				RS_DBG("cert type ") << certType << " is unsupported" << std::endl;
+				RS_DBG("cert type ", certType, " is unsupported");
 				return std::string();
 			}
 
@@ -128,21 +128,21 @@ std::string publicKeyFromPrivate(std::string const &priv)
 			// likely 7
 			signingKeyType = readTwoBytesBE(p);
 
-			RS_DBG("signing pubkey type ") << certType << std::endl;
+			RS_DBG("signing pubkey type ", certType);
 			if (signingKeyType >= 3 && signingKeyType <= 6) {
-				RS_DBG("signing pubkey type ") << certType << " has oversize" << std::endl;
+				RS_DBG("signing pubkey type ", certType, " has oversize");
 				// calculate oversize
 
 				if (signingKeyType >= signingKeyLengths.size()) {
 					// just in case
-					RS_DBG("signing pubkey type ") << certType << " cannot be found in size map!" << std::endl;
+					RS_DBG("signing pubkey type ", certType, " cannot be found in size data!");
 					return std::string();
 				}
 
 				auto values = signingKeyLengths[signingKeyType];
 				if (values.first <= 128) {
 					// just in case, it's supposed to be larger!
-					RS_DBG("signing pubkey type ") << certType << " is oversize but size calculation would underflow!" << std::endl;
+					RS_DBG("signing pubkey type ", certType, " is oversize but size calculation would underflow!");
 					return std::string();
 				}
 
@@ -152,12 +152,12 @@ std::string publicKeyFromPrivate(std::string const &priv)
 			// Crypto Public Key
 			// likely 0
 			cryptKey = readTwoBytesBE(p);
-			RS_DBG("crypto pubkey type ") << cryptKey << std::endl;
+			RS_DBG("crypto pubkey type ", cryptKey);
 			// info: these are all smaller than the default 256 bytes, so no oversize calculation is needed
 
 			break;
 		}  catch (const std::out_of_range &e) {
-			RS_DBG("hit exception! ") << e.what() << std::endl;
+			RS_DBG("hit exception! ", e.what());
 			return std::string();
 		}
 	} while(false);

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -133,20 +133,20 @@ std::string publicKeyFromPrivate(std::string const &priv)
 				RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " has oversize" << std::endl;
 				// calculate oversize
 
-				auto it = signingKeyLengths.find(static_cast<SigningKeyType>(signingKeyType));
-				if (it == signingKeyLengths.end()) {
+				if (signingKeyType >= signingKeyLengths.size()) {
 					// just in case
 					RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " cannot be found in size map!" << std::endl;
 					return std::string();
 				}
 
-				if (it->second.first <= 128) {
+				auto values = signingKeyLengths[signingKeyType];
+				if (values.first <= 128) {
 					// just in case, it's supposed to be larger!
 					RsDbg() << __PRETTY_FUNCTION__ << " signing pubkey type " << certType << " is oversize but size calculation would underflow!" << std::endl;
 					return std::string();
 				}
 
-				publicKeyLen += it->second.first - 128; // 128 = default DSA key length = the space than can be used before the key must be splitted
+				publicKeyLen += values.first - 128; // 128 = default DSA key length = the space than can be used before the key must be splitted
 			}
 
 			// Crypto Public Key

--- a/libretroshare/src/util/i2pcommon.cpp
+++ b/libretroshare/src/util/i2pcommon.cpp
@@ -19,7 +19,8 @@ std::string keyToBase32Addr(const std::string &key)
 
 	// replace I2P specific chars
 	std::replace(copy.begin(), copy.end(), '~', '/');
-	std::replace(copy.begin(), copy.end(), '-', '+');
+	// replacing the - with a + is not necessary, as RsBase64 can handle base64url encoding, too
+	// std::replace(copy.begin(), copy.end(), '-', '+');
 
 	// decode
 	std::vector<uint8_t> bin;

--- a/libretroshare/src/util/i2pcommon.h
+++ b/libretroshare/src/util/i2pcommon.h
@@ -161,25 +161,27 @@ enum class CryptoKeyType : uint16_t {
 	X25519  = 4
 };
 
-static const std::map<CryptoKeyType, std::pair<uint16_t, uint16_t>> cryptoKeyLengths {
-	{CryptoKeyType::ElGamal, {256, 256}},
-	{CryptoKeyType::P256,    { 64,  32}},
-	{CryptoKeyType::P384,    { 96,  48}},
-	{CryptoKeyType::P521,    {132,  66}},
-	{CryptoKeyType::X25519,  { 32,  32}},
+static const std::array<std::pair<uint16_t, uint16_t>, 5> cryptoKeyLengths {
+	/*CryptoKeyType::ElGamal*/ std::make_pair<uint16_t, uint16_t>(256, 256),
+	/*CryptoKeyType::P256,  */ std::make_pair<uint16_t, uint16_t>( 64,  32),
+	/*CryptoKeyType::P384,  */ std::make_pair<uint16_t, uint16_t>( 96,  48),
+	/*CryptoKeyType::P521,  */ std::make_pair<uint16_t, uint16_t>(132,  66),
+	/*CryptoKeyType::X25519,*/ std::make_pair<uint16_t, uint16_t>( 32,  32),
 };
 
-static const std::map<SigningKeyType, std::pair<uint16_t, uint16_t>> signingKeyLengths {
-	{SigningKeyType::DSA_SHA1,              {128, 128}},
-	{SigningKeyType::ECDSA_SHA256_P256,     { 64,  32}},
-	{SigningKeyType::ECDSA_SHA384_P384,     { 96,  48}},
-	{SigningKeyType::ECDSA_SHA512_P521,     {132,  66}},
-	{SigningKeyType::RSA_SHA256_2048,       {256, 512}},
-	{SigningKeyType::RSA_SHA384_3072,       {384, 768}},
-	{SigningKeyType::RSA_SHA512_4096,       {512,1024}},
-	{SigningKeyType::EdDSA_SHA512_Ed25519,  { 32,  32}},
-	{SigningKeyType::EdDSA_SHA512_Ed25519ph,{ 32,  32}},
-	{SigningKeyType::RedDSA_SHA512_Ed25519, { 32,  32}},
+static const std::array<std::pair<uint16_t, uint16_t>, 12> signingKeyLengths {
+	/*SigningKeyType::DSA_SHA1,              */ std::make_pair<uint16_t, uint16_t>(128, 128),
+	/*SigningKeyType::ECDSA_SHA256_P256,     */ std::make_pair<uint16_t, uint16_t>( 64,  32),
+	/*SigningKeyType::ECDSA_SHA384_P384,     */ std::make_pair<uint16_t, uint16_t>( 96,  48),
+	/*SigningKeyType::ECDSA_SHA512_P521,     */ std::make_pair<uint16_t, uint16_t>(132,  66),
+	/*SigningKeyType::RSA_SHA256_2048,       */ std::make_pair<uint16_t, uint16_t>(256, 512),
+	/*SigningKeyType::RSA_SHA384_3072,       */ std::make_pair<uint16_t, uint16_t>(384, 768),
+	/*SigningKeyType::RSA_SHA512_4096,       */ std::make_pair<uint16_t, uint16_t>(512,1024),
+	/*SigningKeyType::EdDSA_SHA512_Ed25519   */ std::make_pair<uint16_t, uint16_t>( 32,  32),
+	/*SigningKeyType::EdDSA_SHA512_Ed25519ph */ std::make_pair<uint16_t, uint16_t>( 32,  32),
+	/*reserved (GOST)                        */ std::make_pair<uint16_t, uint16_t>( 64,   0),
+	/*reserved (GOST)                        */ std::make_pair<uint16_t, uint16_t>(128,   0),
+	/*SigningKeyType::RedDSA_SHA512_Ed25519  */ std::make_pair<uint16_t, uint16_t>( 32,  32),
 };
 
 

--- a/libretroshare/src/util/i2pcommon.h
+++ b/libretroshare/src/util/i2pcommon.h
@@ -184,19 +184,6 @@ static const std::array<std::pair<uint16_t, uint16_t>, 12> signingKeyLengths {
 	/*SigningKeyType::RedDSA_SHA512_Ed25519  */ std::make_pair<uint16_t, uint16_t>( 32,  32),
 };
 
-
-/**
- * @brief generateNameSuffix Generates a base32 name suffix for tunnel identification
- * @param len lenght of random bytes, will be expanded by base32 encoding
- * @return base32 string
- *
- * RSRandom::random_alphaNumericString can return very weird looking strings like: ,,@z+M
- * -> so use base32 instead
- *
- * 5 characters = 8 base32 symbols
- */
-const std::string generateNameSuffix(const size_t len = 5);
-
 /**
  * @brief makeOption Creates the string "lhs=rhs" used by BOB and SAM. Converts rhs
  * @param lhs option to set

--- a/libretroshare/src/util/i2pcommon.h
+++ b/libretroshare/src/util/i2pcommon.h
@@ -1,0 +1,222 @@
+#ifndef I2PCOMMON_H
+#define I2PCOMMON_H
+
+#include <algorithm>
+#include <map>
+
+#include "util/rsrandom.h"
+#include "util/radix32.h"
+#include "util/rsbase64.h"
+#include "util/rsprint.h"
+#include "util/rsdebug.h"
+
+/*
+ * This header provides common code for i2p related code, namely BOB and SAM3 support.
+ */
+
+namespace i2p {
+
+static constexpr int8_t kDefaultLength   = 3; // i2p default
+static constexpr int8_t kDefaultQuantity = 3; // i2p default + 1
+static constexpr int8_t kDefaultVariance = 0;
+static constexpr int8_t kDefaultBackupQuantity = 0;
+
+/**
+ * @brief The address struct
+ * This structure is a container for any i2p address/key. The public key is used for addressing and can be (optionally) hashed to generate the .b32.i2p address.
+ */
+struct address {
+	std::string base32;
+	std::string publicKey;
+	std::string privateKey;
+
+	void clear() {
+		base32.clear();
+		publicKey.clear();
+		privateKey.clear();
+	}
+};
+
+/**
+ * @brief The settings struct
+ * Common structure with all settings that are shared between any i2p backends
+ */
+struct settings {
+	bool enable;
+	struct address address;
+
+	// connection parameter
+	int8_t inLength;
+	int8_t inQuantity;
+	int8_t inVariance;
+	int8_t inBackupQuantity;
+
+	int8_t outLength;
+	int8_t outQuantity;
+	int8_t outVariance;
+	int8_t outBackupQuantity;
+
+	void initDefault() {
+		enable = false;
+		address.clear();
+
+		inLength    = kDefaultLength;
+		inQuantity  = kDefaultQuantity;
+		inVariance  = kDefaultVariance;
+		inBackupQuantity = kDefaultBackupQuantity;
+
+		outLength   = kDefaultLength;
+		outQuantity = kDefaultQuantity;
+		outVariance = kDefaultVariance;
+		outBackupQuantity = kDefaultBackupQuantity;
+	}
+};
+
+/*
+	Type		Type Code	Payload Length	Total Length	Notes
+	Null		0			0				3
+	HashCash	1			varies			varies			Experimental, unused. Payload contains an ASCII colon-separated hashcash string.
+	Hidden		2			0				3				Experimental, unused. Hidden routers generally do not announce that they are hidden.
+	Signed		3			40 or 72		43 or 75		Experimental, unused. Payload contains a 40-byte DSA signature, optionally followed by the 32-byte Hash of the signing Destination.
+	Multiple	4			varies			varies			Experimental, unused. Payload contains multiple certificates.
+	Key			5			4+				7+				Since 0.9.12. See below for details.
+*/
+enum class CertType : uint8_t {
+	Null     = 0,
+	HashCash = 1,
+	Hidden   = 2,
+	Signed   = 3,
+	Multiple = 4,
+	Key      = 5
+};
+
+/*
+ * public
+	Type					Type Code	Total Public Key Length	Since	Usage
+	DSA_SHA1				0			128						0.9.12	Legacy Router Identities and Destinations, never explicitly set
+	ECDSA_SHA256_P256		1			64						0.9.12	Older Destinations
+	ECDSA_SHA384_P384		2			96						0.9.12	Rarely if ever used for Destinations
+	ECDSA_SHA512_P521		3			132						0.9.12	Rarely if ever used for Destinations
+	RSA_SHA256_2048			4			256						0.9.12	Offline only; never used in Key Certificates for Router Identities or Destinations
+	RSA_SHA384_3072			5			384						0.9.12	Offline only; never used in Key Certificates for Router Identities or Destinations
+	RSA_SHA512_4096			6			512						0.9.12	Offline only; never used in Key Certificates for Router Identities or Destinations
+	EdDSA_SHA512_Ed25519	7			32						0.9.15	Recent Router Identities and Destinations
+	EdDSA_SHA512_Ed25519ph	8			32						0.9.25	Offline only; never used in Key Certificates for Router Identities or Destinations
+	reserved (GOST)			9			64								Reserved, see proposal 134
+	reserved (GOST)			10			128								Reserved, see proposal 134
+	RedDSA_SHA512_Ed25519	11			32						0.9.39	For Destinations and encrypted leasesets only; never used for Router Identities
+	reserved				65280-65534									Reserved for experimental use
+	reserved				65535										Reserved for future expansion
+
+ * private
+	Type					Length (bytes)	Since	Usage
+	DSA_SHA1				20						Legacy Router Identities and Destinations
+	ECDSA_SHA256_P256		32				0.9.12	Recent Destinations
+	ECDSA_SHA384_P384		48				0.9.12	Rarely used for Destinations
+	ECDSA_SHA512_P521		66				0.9.12	Rarely used for Destinations
+	RSA_SHA256_2048			512				0.9.12	Offline signing, never used for Router Identities or Destinations
+	RSA_SHA384_3072			768				0.9.12	Offline signing, never used for Router Identities or Destinations
+	RSA_SHA512_4096			1024			0.9.12	Offline signing, never used for Router Identities or Destinations
+	EdDSA_SHA512_Ed25519	32				0.9.15	Recent Router Identities and Destinations
+	EdDSA_SHA512_Ed25519ph	32				0.9.25	Offline signing, never used for Router Identities or Destinations
+	RedDSA_SHA512_Ed25519	32				0.9.39	For Destinations and encrypted leasesets only, never used for Router Identities
+ */
+enum class SigningKeyType :  uint16_t {
+	DSA_SHA1          = 0,
+	ECDSA_SHA256_P256 = 1,
+	ECDSA_SHA384_P384 = 2,
+	ECDSA_SHA512_P521 = 3,
+	RSA_SHA256_2048   = 4,
+	RSA_SHA384_3072   = 5,
+	RSA_SHA512_4096   = 6,
+	EdDSA_SHA512_Ed25519   = 7,
+	EdDSA_SHA512_Ed25519ph = 8,
+	RedDSA_SHA512_Ed25519  = 11
+};
+
+/*
+ * public
+	Type		Type Code	Total Public Key Length	Usage
+	ElGamal		0			256						All Router Identities and Destinations
+	P256		1			64						Reserved, see proposal 145
+	P384		2			96						Reserved, see proposal 145
+	P521		3			132						Reserved, see proposal 145
+	X25519		4			32						Not for use in key certs. See proposal 144
+	reserved	65280-65534	 						Reserved for experimental use
+	reserved	65535								Reserved for future expansion
+
+ * private
+	Type	Length (bytes)	Since	Usage
+	ElGamal	256						All Router Identities and Destinations
+	P256	32				TBD		Reserved, see proposal 145
+	P384	48				TBD		Reserved, see proposal 145
+	P521	66				TBD		Reserved, see proposal 145
+	X25519	32				0.9.38	Little-endian. See proposal 144
+*/
+enum class CryptoKeyType : uint16_t {
+	ElGamal = 0,
+	P256    = 1,
+	P384    = 2,
+	P521    = 3,
+	X25519  = 4
+};
+
+static const std::map<CryptoKeyType, std::pair<uint16_t, uint16_t>> cryptoKeyLengths {
+	{CryptoKeyType::ElGamal, {256, 256}},
+	{CryptoKeyType::P256,    { 64,  32}},
+	{CryptoKeyType::P384,    { 96,  48}},
+	{CryptoKeyType::P521,    {132,  66}},
+	{CryptoKeyType::X25519,  { 32,  32}},
+};
+
+static const std::map<SigningKeyType, std::pair<uint16_t, uint16_t>> signingKeyLengths {
+	{SigningKeyType::DSA_SHA1,              {128, 128}},
+	{SigningKeyType::ECDSA_SHA256_P256,     { 64,  32}},
+	{SigningKeyType::ECDSA_SHA384_P384,     { 96,  48}},
+	{SigningKeyType::ECDSA_SHA512_P521,     {132,  66}},
+	{SigningKeyType::RSA_SHA256_2048,       {256, 512}},
+	{SigningKeyType::RSA_SHA384_3072,       {384, 768}},
+	{SigningKeyType::RSA_SHA512_4096,       {512,1024}},
+	{SigningKeyType::EdDSA_SHA512_Ed25519,  { 32,  32}},
+	{SigningKeyType::EdDSA_SHA512_Ed25519ph,{ 32,  32}},
+	{SigningKeyType::RedDSA_SHA512_Ed25519, { 32,  32}},
+};
+
+
+/**
+ * @brief generateNameSuffix Generates a base32 name suffix for tunnel identification
+ * @param len lenght of random bytes, will be expanded by base32 encoding
+ * @return base32 string
+ *
+ * RSRandom::random_alphaNumericString can return very weird looking strings like: ,,@z+M
+ * -> so use base32 instead
+ *
+ * 5 characters = 8 base32 symbols
+ */
+const std::string generateNameSuffix(const size_t len = 5);
+
+/**
+ * @brief makeOption Creates the string "lhs=rhs" used by BOB and SAM. Converts rhs
+ * @param lhs option to set
+ * @param rhs value to set
+ * @return concatenated string
+ */
+const std::string makeOption(const std::string &lhs, const int8_t &rhs);
+
+/**
+ * @brief keyToBase32Addr generated a base32 address (.b32.i2p) from a given public key
+ * @param key public key
+ * @return generated base32 address
+ */
+std::string keyToBase32Addr(const std::string &key);
+
+/**
+ * @brief publicKeyFromPrivate parses the private key and calculates the lenght of the public key
+ * @param priv private key (which includes the public key) to read
+ * @return public key used for addressing
+ */
+std::string  publicKeyFromPrivate(const std::string &priv);
+
+} // namespace i2p
+
+#endif // I2PCOMMON_H

--- a/retroshare-gui/src/gui/GenCertDialog.cpp
+++ b/retroshare-gui/src/gui/GenCertDialog.cpp
@@ -340,6 +340,10 @@ void GenCertDialog::setupState()
 	ui.hiddenport_spinBox->setVisible(hidden_state && !tor_auto);
 
 	ui.cbUseBob->setVisible(hidden_state && !tor_auto);
+#ifndef RS_USE_I2P_BOB
+	ui.cbUseBob->setDisabled(true);
+	ui.cbUseBob->setToolTip(tr("BOB support is not available"));
+#endif
 
 	if(!mAllFieldsOk)
 	{

--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -83,6 +83,10 @@ ServerPage::ServerPage(QWidget * parent, Qt::WindowFlags flags)
   manager = NULL ;
   mOngoingConnectivityCheck = -1;
 
+#ifndef RS_USE_I2P_BOB
+  ui.hiddenServiceTab->removeTab(TAB_HIDDEN_SERVICE_I2P_BOB);	// warning: the order of operation here is very important.
+#endif
+
   if(RsAccounts::isHiddenNode())
   {
 	  if(RsAccounts::isTorAuto())

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -140,6 +140,11 @@ rs_macos10.15:CONFIG -= rs_macos10.11
 CONFIG *= no_rs_jsonapi
 rs_jsonapi:CONFIG -= no_rs_jsonapi
 
+# Disable i2p BOB support for automatically setting up an i2p tunnel for RS
+# "CONFIG+=no_rs_bob"
+CONFIG *= rs_bob
+no_rs_bob:CONFIG -= rs_bob
+
 # To enable channel indexing append the following assignation to qmake command
 # line "CONFIG+=rs_deep_channel_index"
 CONFIG *= no_rs_deep_channel_index
@@ -548,6 +553,10 @@ to contain the path to an host executable jsonapi-generator")
 rs_webui {
     !rs_jsonapi: error("Cannot enable rs_webui without rs_jsonapi")
     DEFINES *= RS_WEBUI
+}
+
+rs_bob {
+    DEFINES *= RS_USE_I2P_BOB
 }
 
 rs_deep_channels_index:DEFINES *= RS_DEEP_CHANNEL_INDEX


### PR DESCRIPTION
This patchset factors out some common i2p code (which can later be reused by SAM)
It also does some maintenance:
 - convert bob and autoproxy to `RsDebug`
 - handle timeouts during `recv()` (instead of endless loop)
 - use `RsThread::async()` to make autoproxy's asynchronous tickets actually async
 - fix a bug when manually setting a private key