### PR TITLE
Change raw memory JSON representation

### DIFF
--- a/libretroshare/src/serialiser/rstypeserializer.h
+++ b/libretroshare/src/serialiser/rstypeserializer.h
@@ -59,12 +59,17 @@ struct RsTypeSerializer
 		/// Maximum supported size 10MB
 		static constexpr uint32_t MAX_SERIALIZED_CHUNK_SIZE = 10*1024*1024;
 
+		/** Key used for JSON serialization.
+		 * @note Changing this value breaks JSON API retro-compatibility */
+		static constexpr char base64_key[] = "base64";
+
 		/// @see RsSerializable
 		void serial_process(
 		        RsGenericSerializer::SerializeJob j,
 		        RsGenericSerializer::SerializeContext& ctx ) override;
 	private:
 		void clear();
+		bool freshMemCheck();
 	};
 
 	/// Most types are not valid sequence containers
@@ -777,9 +782,9 @@ struct RsTypeSerializer
 			{
 				if(!yielding)
 				{
-					std::cerr << __PRETTY_FUNCTION__ << " \"" << memberName
-					          << "\" not found in JSON:" << std::endl
-					          << jDoc << std::endl << std::endl;
+					RsErr() << __PRETTY_FUNCTION__ << " \"" << memberName
+					        << "\" not found in JSON:" << std::endl
+					        << jDoc << std::endl << std::endl;
 					print_stacktrace();
 				}
 				ctx.mOk = false;
@@ -790,9 +795,9 @@ struct RsTypeSerializer
 
 			if(!v.IsObject())
 			{
-				std::cerr << __PRETTY_FUNCTION__ << " \"" << memberName
-				          << "\" has wrong type in JSON, object expected, got:"
-				          << std::endl << jDoc << std::endl << std::endl;
+				RsErr() << __PRETTY_FUNCTION__ << " \"" << memberName
+				        << "\" has wrong type in JSON, object expected, got:"
+				        << std::endl << jDoc << std::endl << std::endl;
 				print_stacktrace();
 				ctx.mOk = false;
 				break;

--- a/libretroshare/src/util/rsdebug.h
+++ b/libretroshare/src/util/rsdebug.h
@@ -32,6 +32,8 @@ std::ostream &operator<<(std::ostream& out, const std::error_condition& err);
 #	include <sstream>
 #	include <string>
 
+#	include "util/rsjson.h"
+
 enum class RsLoggerCategories
 {
 	DEBUG   = ANDROID_LOG_DEBUG,
@@ -53,6 +55,10 @@ struct t_RsLogger
 
 	template<typename T>
 	inline stream_type& operator<<(const T& val)
+	{ ostr << val; return *this; }
+
+	template<typename T>
+	inline stream_type& operator<<(const RsJson& val)
 	{ ostr << val; return *this; }
 
 	/// needed for manipulators and things like std::endl
@@ -111,7 +117,7 @@ struct t_RsLogger
 		const auto now = system_clock::now();
 		const auto sec = time_point_cast<seconds>(now);
 		const auto msec = duration_cast<milliseconds>(now - sec);
-		std::stringstream tstream;
+		std::ostringstream tstream;
 		tstream << static_cast<char>(CATEGORY) << " "
 		        << sec.time_since_epoch().count() << "."
 		        << std::setfill('0') << std::setw(3) << msec.count()

--- a/libretroshare/src/util/rsjson.h
+++ b/libretroshare/src/util/rsjson.h
@@ -29,7 +29,7 @@
 typedef rapidjson::Document RsJson;
 
 /**
- * Print out RsJson to a stream, use std::stringstream to get the string
+ * Print out RsJson to a stream, use std::ostringstream to get the string
  * @param[out] out output stream
  * @param[in] jDoc JSON document to print
  * @return same output stream passed as out parameter


### PR DESCRIPTION
Fix bug reported by b1rdG
The new way permits to add more formats in the future without breaking
  retro-compatibility again.
Add support for RsJson in rsdebug for Android

The base64 representation is now wrapped into a JSON object like this `{"base64":"base64string99=="}`