### PR TITLE
ExtraFileHash check for integer overflow

### DIFF
--- a/libretroshare/src/ft/ftextralist.h
+++ b/libretroshare/src/ft/ftextralist.h
@@ -60,7 +60,7 @@
 #include "pqi/p3cfgmgr.h"
 #include "util/rstime.h"
 
-class FileDetails
+class RS_DEPRECATED_FOR(FileInfo) FileDetails
 {
 	public:
 		FileDetails()
@@ -130,7 +130,11 @@ public:
 		 * file is removed after period.
 		 **/
 
-	bool 		hashExtraFile(std::string path, uint32_t period, TransferRequestFlags flags);
+	/**
+	 * Hash file, and add to the files, file is removed after period.
+	 */
+	bool hashExtraFile(
+	        std::string path, uint32_t period, TransferRequestFlags flags );
 	bool	 	hashExtraFileDone(std::string path, FileInfo &info);
 
 	/***
@@ -165,7 +169,6 @@ private:
 	/* Worker Functions */
 	void	hashAFile();
 	bool	cleanupOldFiles();
-	bool    cleanupEntry(std::string path, TransferRequestFlags flags);
 
 	mutable RsMutex extMutex;
 

--- a/libretroshare/src/ft/ftserver.cc
+++ b/libretroshare/src/ft/ftserver.cc
@@ -22,6 +22,8 @@
 
 #include <algorithm>
 #include <iostream>
+#include <limits>
+#include <system_error>
 
 #include "crypto/chacha20.h"
 //const int ftserverzone = 29539;
@@ -820,6 +822,14 @@ bool ftServer::ExtraFileRemove(const RsFileHash& hash)
 bool ftServer::ExtraFileHash(
         std::string localpath, rstime_t period, TransferRequestFlags flags )
 {
+	constexpr rstime_t uintmax = std::numeric_limits<uint32_t>::max();
+	if(period > uintmax)
+	{
+		RsErr() << __PRETTY_FUNCTION__ << " period: " << period << " > "
+		        << uintmax << std::errc::value_too_large << std::endl;
+		return false;
+	}
+
 	return mFtExtra->hashExtraFile(
 	            localpath, static_cast<uint32_t>(period), flags );
 }

--- a/libretroshare/src/retroshare/rsfiles.h
+++ b/libretroshare/src/retroshare/rsfiles.h
@@ -658,7 +658,8 @@ public:
 	 * @brief Get file details
 	 * @jsonapi{development}
 	 * @param[in] hash file identifier
-	 * @param[in] hintflags filtering hint (RS_FILE_HINTS_EXTRA|...|RS_FILE_HINTS_LOCAL)
+	 * @param[in] hintflags filtering hint ( RS_FILE_HINTS_UPLOAD|...|
+	 *	RS_FILE_HINTS_EXTRA|RS_FILE_HINTS_LOCAL )
 	 * @param[out] info storage for file information
 	 * @return true if file found, false otherwise
 	 */


### PR DESCRIPTION
When passing large periods 2038 problems was silently triggered due to
  time being stored as int in FileInfo::age, thus causing erratic
  behaviour in extra files timeout. Now period is checked and if too
  large an error is reported.
Deprecate FileDetails which is confusing dummy wrapper of FileInfo
Remove ftExtraList::cleanupEntry deadcode