### PR TITLE
    Multiple improvements in debugging helpers

### DIFF
--- a/libretroshare/src/jsonapi/jsonapi.cpp
+++ b/libretroshare/src/jsonapi/jsonapi.cpp
@@ -467,18 +467,18 @@ void JsonApiServer::registerHandler(
 		                const std::function<void (const std::shared_ptr<rb::Session>)>& callback )
 		{
 			/* Declare outside the lambda to avoid returning a dangling
-			 * reference on Android */
+			 * reference */
 			RsWarn tWarn;
 			const auto authFail =
-			        [&](int status) -> RsWarn::stream_type&
+			        [&](int status) -> std::ostream&
 			{
 				/* Capture session by reference as it is cheaper then copying
 				 * shared_ptr by value which is not needed in this case */
 
 				session->close(status, corsOptionsHeaders);
 				return tWarn << "JsonApiServer authentication handler "
-				                   "blocked an attempt to call JSON API "
-				                   "authenticated method: " << path;
+				                "blocked an attempt to call JSON API "
+				                "authenticated method: " << path;
 			};
 
 			if(session->get_request()->get_method() == "OPTIONS")

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -468,7 +468,12 @@ HEADERS +=	turtle/p3turtle.h \
 			turtle/turtleclientservice.h
 
 HEADERS +=	util/folderiterator.h \
-			util/rsdebug.h \
+    util/rsdebug.h \
+    util/rsdebuglevel0.h \
+    util/rsdebuglevel1.h \
+    util/rsdebuglevel2.h \
+    util/rsdebuglevel3.h \
+    util/rsdebuglevel4.h \
 			util/rskbdinput.h \
 			util/rsmemory.h \
 			util/smallobject.h \

--- a/libretroshare/src/retroshare/rsgxsifacehelper.h
+++ b/libretroshare/src/retroshare/rsgxsifacehelper.h
@@ -507,25 +507,27 @@ private:
 
 	std::map<uint32_t,TokenRequestType> mActiveTokens;
 
+#ifdef DEBUG_GXSIFACEHELPER
 	void locked_dumpTokens()
 	{
 		const uint16_t service_id =  mGxs.serviceType();
 		const auto countSize = static_cast<size_t>(TokenRequestType::__MAX);
 		uint32_t count[countSize] = {0};
 
-		RsDbg() << __PRETTY_FUNCTION__ << "Service 0x" << std::hex << service_id
-		        << " (" << rsServiceControl->getServiceName(
-		               RsServiceInfo::RsServiceInfoUIn16ToFullServiceId(service_id) )
-		        << ") this=0x" << static_cast<void*>(this)
-		        << ") Active tokens (per type): ";
+		RsDbg rsdbg;
+		rsdbg << __PRETTY_FUNCTION__ << " Service 0x" << std::hex << service_id
+		      << " (" << rsServiceControl->getServiceName(
+		             RsServiceInfo::RsServiceInfoUIn16ToFullServiceId(service_id) )
+		      << ") this=0x" << static_cast<void*>(this)
+		      << ") Active tokens (per type): ";
 
 		// let's count how many token of each type we've got.
 		for(auto& it: mActiveTokens) ++count[static_cast<size_t>(it.second)];
 
 		for(uint32_t i=0; i < countSize; ++i)
-			RsDbg().uStream() /* << i << ":" */ << count[i] << " ";
-		RsDbg().uStream() << std::endl;
+			rsdbg /* << i << ":" */ << count[i] << " ";
 	}
+#endif // def DEBUG_GXSIFACEHELPER
 
 	RS_SET_CONTEXT_DEBUG_LEVEL(1)
 };

--- a/libretroshare/src/serialiser/rstypeserializer.cc
+++ b/libretroshare/src/serialiser/rstypeserializer.cc
@@ -235,8 +235,7 @@ template<> bool RsTypeSerializer::from_JSON( \
  \
 	if(!ret) \
     { \
-	    Dbg3() << __PRETTY_FUNCTION__ << " " << memberName << " not found" \
-	           << std::endl; \
+	    RS_DBG3(memberName, " not found"); \
 	    return false; \
 	} \
  \

--- a/libretroshare/src/util/rsdebug.h
+++ b/libretroshare/src/util/rsdebug.h
@@ -21,19 +21,23 @@
  *******************************************************************************/
 #pragma once
 
-#include <ostream>
+#include <string>
+#include <sstream>
 #include <system_error>
-
-/** Stream helper for std::error_condition */
-std::ostream &operator<<(std::ostream& out, const std::error_condition& err);
 
 #ifdef __ANDROID__
 #	include <android/log.h>
-#	include <sstream>
-#	include <string>
+#else // def __ANDROID__
+#	include <iostream>
+#	include <chrono>
+#	include <iomanip>
+#endif // def __ANDROID__
 
-#	include "util/rsjson.h"
 
+#include "util/rsjson.h"
+
+
+#ifdef __ANDROID__
 enum class RsLoggerCategories
 {
 	DEBUG   = ANDROID_LOG_DEBUG,
@@ -42,72 +46,7 @@ enum class RsLoggerCategories
 	ERROR   = ANDROID_LOG_ERROR,
 	FATAL   = ANDROID_LOG_FATAL
 };
-
-template <RsLoggerCategories CATEGORY>
-struct t_RsLogger
-{
-	inline t_RsLogger() = default;
-
-	/** Offer variadic style too, as a benefit this has better atomicity then
-	 * << style, but doesn't supports manipulators and things like std::endl
-	 * @see https://stackoverflow.com/a/27375675 */
-	template <typename Arg, typename... Args>
-	inline t_RsLogger(Arg&& arg, Args&&... args)
-	{
-		ostr << std::forward<Arg>(arg);
-		using expander = int[];
-		(void)expander{0, (void(ostr << std::forward<Args>(args)), 0)...};
-		mFlush();
-	}
-
-	/** On other platforms expose the type of underlying stream.
-	 * On Android it cannot work like that so return the class type itself
-	 * just for code compatibility with other platforms */
-	using stream_type = t_RsLogger;
-
-	template<typename T>
-	inline stream_type& operator<<(const T& val)
-	{ ostr << val; return *this; }
-
-	template<typename T>
-	inline stream_type& operator<<(const RsJson& val)
-	{ ostr << val; return *this; }
-
-	/// needed for manipulators and things like std::endl
-	stream_type& operator<<(std::ostream& (*pf)(std::ostream&))
-	{
-		if(pf == static_cast<std::ostream& (*)(std::ostream&)>(
-		            &std::endl< char, std::char_traits<char> > ))
-			mFlush();
-		else ostr << pf;
-
-		return *this;
-	}
-
-	/** On other platforms return underlying stream to write avoiding additional
-	 * prefixes. On Android it cannot work like that so return the object itself
-	 * just for code compatibility with other platforms */
-	inline stream_type& uStream() { return *this; }
-
-private:
-	std::ostringstream ostr;
-
-	void mFlush()
-	{
-		__android_log_write(
-		            static_cast<int>(CATEGORY),
-		            "RetroShare", ostr.str().c_str() );
-		ostr.str() = "";
-	}
-};
-
 #else // def __ANDROID__
-
-#include <iostream>
-#include <chrono>
-#include <iomanip>
-#include <sstream>
-
 enum class RsLoggerCategories
 {
 	DEBUG   = 'D',
@@ -116,89 +55,100 @@ enum class RsLoggerCategories
 	ERROR   = 'E',
 	FATAL   = 'F'
 };
+#endif // def __ANDROID__
+
+
+/** Stream helper for std::error_condition */
+std::ostream &operator<<(std::ostream& out, const std::error_condition& err);
+
 
 template <RsLoggerCategories CATEGORY>
-struct t_RsLogger
+struct t_RsLogger : std::ostringstream
 {
-	/// Expose the type of underlying stream
-	using stream_type = decltype(std::cerr);
+	t_RsLogger() { setPrefix(); }
+	~t_RsLogger() { flush(); }
 
-	/// Return underlying stream to write avoiding additional prefixes
-	static inline stream_type& uStream() { return std::cerr; }
-
-	inline t_RsLogger() = default;
-
-	/** Offer variadic style too, as a benefit this has better atomicity then
-	 * << style, but doesn't supports manipulators and things like std::endl
-	 * @see https://stackoverflow.com/a/27375675 */
-	template <typename Arg, typename... Args>
-	inline t_RsLogger(Arg&& arg, Args&&... args)
+	/** Offer variadic style, this doesn't supports things like std::endl as
+	 * paramether but when used toghether with conditional debugging macros
+	 * reduces binary size as paramethers of suppressed calls are not evaluated
+	 * and literally disappear in preprocessing fase @see RsDbg */
+	template <typename... Args>
+	explicit inline t_RsLogger(Args&&... args)
 	{
-		std::ostringstream ostr;
-		ostr << getPrefix() << std::forward<Arg>(arg);
-		using expander = int[];
-		(void)expander{0, (void(ostr << std::forward<Args>(args)), 0)...};
-		ostr << std::endl;
-		uStream() << ostr.str();
+		setPrefix();
+
+		/* Combine initializer list and comma operator so the compiler unpack
+		 * template arguments and feed our own stream without recursion
+		 * see https://stackoverflow.com/a/27375675 */
+		using expander = char[];
+		(void) expander {0, (void((*this) << std::forward<Args>(args)), 0)...};
 	}
 
-	template<typename T>
-	inline stream_type& operator<<(const T& val)
-	{ return uStream() << getPrefix() << val; }
-
-	/// needed for manipulators and things like std::endl
-	stream_type& operator<<(std::ostream& (*pf)(std::ostream&))
-	{ return uStream() << pf; }
+	/** Dump buffer stream to log */
+	void flush()
+	{
+#ifdef __ANDROID__
+		__android_log_write(
+		            static_cast<int>(CATEGORY),
+		            "RetroShare", str().c_str() );
+#else // def __ANDROID__
+		(*this) << std::endl;
+		std::cerr << str();
+#endif // def __ANDROID__
+		str() = "";
+	}
 
 private:
-	std::string getPrefix()
+#ifdef __ANDROID__
+	inline void setPrefix() {}
+#else // def __ANDROID__
+	void setPrefix()
 	{
 		using namespace std::chrono;
 		const auto now = system_clock::now();
 		const auto sec = time_point_cast<seconds>(now);
 		const auto msec = duration_cast<milliseconds>(now - sec);
-		std::ostringstream tstream;
-		tstream << static_cast<char>(CATEGORY) << " "
+		(*this) << static_cast<char>(CATEGORY) << " "
 		        << sec.time_since_epoch().count() << "."
-		        << std::setfill('0') << std::setw(3) << msec.count()
-		        << " ";
-		return tstream.str();
+		        << std::setfill('0') << std::setw(3) << msec.count() << " ";
 	}
-};
 #endif // def __ANDROID__
+};
 
 
 /**
- * Comfortable debug message logging, supports chaining like std::cerr but can
- * be easly and selectively disabled at compile time to reduce generated binary
- * size and performance impact without too many \#ifdef around.
+ * Comfortable debug message logging, supports both variadic style and chaining
+ * style like std::cerr.
+ * Can be easly and selectively disabled at compile time.
+ * To reduce generated binary size and performance impact when debugging is
+ * disabled without too many \#ifdef around the code combining the variadic
+ * style with the leveled debugging macros is the way to go.
  *
- * To selectively debug your context you can just add something like this in
- * in that context, as an example for a class you can just add a line like this
- * inside class declaration:
+ * To selectively debug your file you just need to include the header of desired
+ * debugging level (0 to 4)
 @code{.cpp}
-RS_SET_CONTEXT_DEBUG_LEVEL(2)
+#include "util/rsdebuglevel2.h"
 @endcode
- * And the you can write debug messages around the code of the class like this:
+ * Then where you want to print debug messages use
 @code{.cpp}
-Dbg1() << "Level 1 debug message example, this will be compiled and "
-	   << "printed" << std::endl;
-Dbg2() << "Level 2 debug message example, this will be compiled and "
-	   << "printed" << std::endl;
-Dbg3() << "Level 3 debug message example, this will not be compiled and "
-	   << "printed, and without #ifdef around!!" << std::endl;
-Dbg4() << "Level 4 debug message example, this will not be compiled and "
-	   << "printed, and without #ifdef around!!" << std::endl;
+RS_DBG0("Hello 0 ", "my debug ", my_variable) << " message " << variable2;
+RS_DBG1("Hello 1 ", "my debug ", my_variable) << " message " << variable2;
+RS_DBG2("Hello 2 ", "my debug ", my_variable) << " message " << variable2;
+RS_DBG3("Hello 3 ", "my debug ", my_variable) << " message " << variable2;
+RS_DBG4("Hello 4 ", "my debug ", my_variable) << " message " << variable2;
 @endcode
- * To change the debugging level, for example to completely disable debug
- * messages you can change it to 0
-@code{.cpp}
-RS_SET_CONTEXT_DEBUG_LEVEL(0)
-@endcode
- * While to set it to maximim level you have to pass 4.
+ * To change the debugging level just include a different level header like
+ * `util/rsdebuglevel1.h`, debug messages with lower or equal level then the
+ * included header will be printed, the others will not.
+ * Remember then on messages with debug level higher then the included the
+ * paramethers you pass as macro arguments (variadic style) will disappear in
+ * the preprocessing phase, so their evaluation will not be included in the
+ * final binary and not executed at runtime, instead the paramether passed with
+ * `<<` (chaining style) will be in the compiled binary and evaluated at runtime
+ * even if are not printed, due to how C++ is made it is not possible to avoid
+ * this, so we suggest to use variadic style for debug messages.
  */
 using RsDbg    = t_RsLogger<RsLoggerCategories::DEBUG>;
-
 
 /**
  * Comfortable log information reporting helper, supports chaining like
@@ -220,6 +170,7 @@ using RsErr    = t_RsLogger<RsLoggerCategories::ERROR>;
  * to terminate) messages */
 using RsFatal  = t_RsLogger<RsLoggerCategories::FATAL>;
 
+
 /**
  * Keeps compatible syntax with RsDbg but explicitely do nothing in a way that
  * any modern compiler should be smart enough to optimize out all the function
@@ -228,26 +179,31 @@ using RsFatal  = t_RsLogger<RsLoggerCategories::FATAL>;
 struct RsNoDbg
 {
 	inline RsNoDbg() = default;
-
-	template <typename T, typename... Args> inline RsNoDbg(T, Args...) {}
-
-	/** Defined as the type itself just for code compatibility with other
-	 * logging classes */
-	using stream_type = RsNoDbg;
+	template <typename... Args> inline explicit RsNoDbg(Args...) {}
 
 	/** This match most of the types, but might be not enough for templated
 	 * types */
 	template<typename T>
-	inline stream_type& operator<<(const T&) { return *this; }
+	inline RsNoDbg& operator<<(const T&) { return *this; }
 
 	/// needed for manipulators and things like std::endl
-	inline stream_type& operator<<(std::ostream& (*/*pf*/)(std::ostream&))
+	inline RsNoDbg& operator<<(std::ostream& (*/*pf*/)(std::ostream&))
 	{ return *this; }
 
-	/** Return the object itself just for code compatibility with other
-	 * logging classes */
-	inline stream_type& uStream() { return *this; }
+	/** Do nothing. Just for code compatibility with other logging classes */
+	inline void flush() {}
 };
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+/// All the following lines are DEPRECATED!!
+
+#include "util/rsdeprecate.h"
 
 /**
  * Concatenate preprocessor tokens A and B without expanding macro definitions
@@ -267,41 +223,30 @@ struct RsNoDbg
 
 // A bunch of boilerplate, but just in one place
 #define RS_SET_CONTEXT_DEBUG_LEVEL0 \
-	using Dbg1 = RsNoDbg; \
-	using Dbg2 = RsNoDbg; \
-	using Dbg3 = RsNoDbg; \
-	using Dbg4 = RsNoDbg;
+	using Dbg1 RS_DEPRECATED_FOR(RS_DBG1) = RsNoDbg; \
+	using Dbg2 RS_DEPRECATED_FOR(RS_DBG2) = RsNoDbg; \
+	using Dbg3 RS_DEPRECATED_FOR(RS_DBG3) = RsNoDbg; \
+	using Dbg4 RS_DEPRECATED_FOR(RS_DBG4) = RsNoDbg;
 #define RS_SET_CONTEXT_DEBUG_LEVEL1 \
-	using Dbg1 = RsDbg; \
-	using Dbg2 = RsNoDbg; \
-	using Dbg3 = RsNoDbg; \
-	using Dbg4 = RsNoDbg;
+	using Dbg1 RS_DEPRECATED_FOR(RS_DBG1) = RsDbg; \
+	using Dbg2 RS_DEPRECATED_FOR(RS_DBG2) = RsNoDbg; \
+	using Dbg3 RS_DEPRECATED_FOR(RS_DBG3) = RsNoDbg; \
+	using Dbg4 RS_DEPRECATED_FOR(RS_DBG4) = RsNoDbg;
 #define RS_SET_CONTEXT_DEBUG_LEVEL2 \
-	using Dbg1 = RsDbg; \
-	using Dbg2 = RsDbg; \
-	using Dbg3 = RsNoDbg; \
-	using Dbg4 = RsNoDbg;
+	using Dbg1 RS_DEPRECATED_FOR(RS_DBG1) = RsDbg; \
+	using Dbg2 RS_DEPRECATED_FOR(RS_DBG2) = RsDbg; \
+	using Dbg3 RS_DEPRECATED_FOR(RS_DBG3) = RsNoDbg; \
+	using Dbg4 RS_DEPRECATED_FOR(RS_DBG4) = RsNoDbg;
 #define RS_SET_CONTEXT_DEBUG_LEVEL3 \
-	using Dbg1 = RsDbg; \
-	using Dbg2 = RsDbg; \
-	using Dbg3 = RsDbg; \
-	using Dbg4 = RsNoDbg;
+	using Dbg1 RS_DEPRECATED_FOR(RS_DBG1) = RsDbg; \
+	using Dbg2 RS_DEPRECATED_FOR(RS_DBG2) = RsDbg; \
+	using Dbg3 RS_DEPRECATED_FOR(RS_DBG3) = RsDbg; \
+	using Dbg4 RS_DEPRECATED_FOR(RS_DBG4) = RsNoDbg;
 #define RS_SET_CONTEXT_DEBUG_LEVEL4 \
-	using Dbg1 = RsDbg; \
-	using Dbg2 = RsDbg; \
-	using Dbg3 = RsDbg; \
-	using Dbg4 = RsDbg;
-
-
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-/// All the following lines are DEPRECATED!!
-
-#include <string>
-
-#include "util/rsdeprecate.h"
+	using Dbg1 RS_DEPRECATED_FOR(RS_DBG1) = RsDbg; \
+	using Dbg2 RS_DEPRECATED_FOR(RS_DBG2) = RsDbg; \
+	using Dbg3 RS_DEPRECATED_FOR(RS_DBG3) = RsDbg; \
+	using Dbg4 RS_DEPRECATED_FOR(RS_DBG4) = RsDbg;
 
 namespace RsLog {
     enum RS_DEPRECATED_FOR("RsErr, RsDbg, RsNoDbg") logLvl {

--- a/libretroshare/src/util/rsdebuglevel0.h
+++ b/libretroshare/src/util/rsdebuglevel0.h
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * RetroShare debugging level                                                  *
+ *                                                                             *
+ * Copyright (C) 2020  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2020  Asociación Civil Altermundi <info@altermundi.net>       *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+// #pragma once // This is commented out on purpose!
+
+#include <util/rsdebug.h>
+
+#undef  RS_DEBUG_LEVEL
+#define RS_DEBUG_LEVEL 0
+
+#undef  RS_DBG0
+#define RS_DBG0(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG1
+#define RS_DBG1(...) RsNoDbg("")
+
+#undef  RS_DBG2
+#define RS_DBG2(...) RsNoDbg("")
+
+#undef  RS_DBG3
+#define RS_DBG3(...) RsNoDbg("")
+
+#undef  RS_DBG4
+#define RS_DBG4(...) RsNoDbg("")

--- a/libretroshare/src/util/rsdebuglevel1.h
+++ b/libretroshare/src/util/rsdebuglevel1.h
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * RetroShare debugging level                                                  *
+ *                                                                             *
+ * Copyright (C) 2020  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2020  Asociación Civil Altermundi <info@altermundi.net>       *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+// #pragma once // This is commented out on purpose!
+
+#include <util/rsdebug.h>
+
+#undef  RS_DEBUG_LEVEL
+#define RS_DEBUG_LEVEL 1
+
+#undef  RS_DBG0
+#define RS_DBG0(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG1
+#define RS_DBG1(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG2
+#define RS_DBG2(...) RsNoDbg()
+
+#undef  RS_DBG3
+#define RS_DBG3(...) RsNoDbg()
+
+#undef  RS_DBG4
+#define RS_DBG4(...) RsNoDbg()

--- a/libretroshare/src/util/rsdebuglevel2.h
+++ b/libretroshare/src/util/rsdebuglevel2.h
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * RetroShare debugging level                                                  *
+ *                                                                             *
+ * Copyright (C) 2020  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2020  Asociación Civil Altermundi <info@altermundi.net>       *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+// #pragma once // This is commented out on purpose!
+
+#include <util/rsdebug.h>
+
+#undef  RS_DEBUG_LEVEL
+#define RS_DEBUG_LEVEL 2
+
+#undef  RS_DBG0
+#define RS_DBG0(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG1
+#define RS_DBG1(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG2
+#define RS_DBG2(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG3
+#define RS_DBG3(...) RsNoDbg()
+
+#undef  RS_DBG4
+#define RS_DBG4(...) RsNoDbg()

--- a/libretroshare/src/util/rsdebuglevel3.h
+++ b/libretroshare/src/util/rsdebuglevel3.h
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * RetroShare debugging level                                                  *
+ *                                                                             *
+ * Copyright (C) 2020  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2020  Asociación Civil Altermundi <info@altermundi.net>       *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+// #pragma once // This is commented out on purpose!
+
+#include <util/rsdebug.h>
+
+#undef  RS_DEBUG_LEVEL
+#define RS_DEBUG_LEVEL 3
+
+#undef  RS_DBG0
+#define RS_DBG0(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG1
+#define RS_DBG1(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG2
+#define RS_DBG2(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG3
+#define RS_DBG3(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG4
+#define RS_DBG4(...) RsNoDbg()

--- a/libretroshare/src/util/rsdebuglevel4.h
+++ b/libretroshare/src/util/rsdebuglevel4.h
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * RetroShare debugging level                                                  *
+ *                                                                             *
+ * Copyright (C) 2020  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2020  Asociación Civil Altermundi <info@altermundi.net>       *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+// #pragma once // This is commented out on purpose!
+
+#include <util/rsdebug.h>
+
+#undef  RS_DEBUG_LEVEL
+#define RS_DEBUG_LEVEL 4
+
+#undef  RS_DBG0
+#define RS_DBG0(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG1
+#define RS_DBG1(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG2
+#define RS_DBG2(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG3
+#define RS_DBG3(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)
+
+#undef  RS_DBG4
+#define RS_DBG4(...) RsDbg(__PRETTY_FUNCTION__, " ", __VA_ARGS__)


### PR DESCRIPTION
  
    Add variadic style macro helpers that make debugging code disappear completely
      (also the paramethers evaluation) when debugging level is lower
    Chained style << is now atomic like variadic style, still can't benefit
      of paramethers eveluation stripping
    Reduced to minimum the difference between Android and other platform
      debugging code
    Port debugging code to new helpers, expecially a few corner cases to
      test it, and as examples of how to use it.