### PR TITLE
missing include "bio.h" in openpgpsdk

### DIFF
--- a/openpgpsdk/src/openpgpsdk/openssl_crypto.c
+++ b/openpgpsdk/src/openpgpsdk/openssl_crypto.c
@@ -22,6 +22,7 @@
 /** \file
  */
 
+#include <openssl/bio.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 #include <openssl/dsa.h>


### PR DESCRIPTION
This trivial fix was found in 2016 by @agl, see https://github.com/public/OpenPGP-SDK/pull/3.