### PR TITLE
remove retroshare password from json tokens

### DIFF
--- a/libretroshare/src/jsonapi/jsonapi.cpp
+++ b/libretroshare/src/jsonapi/jsonapi.cpp
@@ -180,6 +180,7 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 			std::string errorMessage;
 			bool makeHidden = false;
 			bool makeAutoTor = false;
+			std::string createToken;
 
 			// deserialize input parameters from JSON
 			{
@@ -189,6 +190,7 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 				RS_SERIAL_PROCESS(password);
 				RS_SERIAL_PROCESS(makeHidden);
 				RS_SERIAL_PROCESS(makeAutoTor);
+				RS_SERIAL_PROCESS(createToken);
 			}
 
 			// call retroshare C++ API
@@ -196,8 +198,9 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 			            location, password, errorMessage, makeHidden,
 			            makeAutoTor );
 
-			if(retval)
-				authorizeUser(location.mLocationId.toStdString(),password);
+			std::string tokenUser, tokenPw;
+			if(retval && parseToken(createToken, tokenUser, tokenPw))
+				authorizeUser(tokenUser,tokenPw);
 
 			// serialize out parameters and return value to JSON
 			{
@@ -237,9 +240,6 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 			// call retroshare C++ API
 			RsInit::LoadCertificateStatus retval =
 			        rsLoginHelper->attemptLogin(account, password);
-
-			if( retval == RsInit::OK )
-				authorizeUser(account.toStdString(), password);
 
 			// serialize out parameters and return value to JSON
 			{


### PR DESCRIPTION
Currently your RS password ends up as an json api token, which is visible in the settings menu,

This patch does two things:
- add a new parameter when creating the location: `createToken`, this token is added instead of the user:password combination
- remove the token creation from login. This removes the option to add a token during login. So the token must be added before (either manually or during node creating time). This could also use the extra parameter (like above). (I personally don't see any point in constantly adding the same token again and again)

An app (e.g Android) can still insert user:password as a token, as before, using the new parameter.

Additionally `parseToken` is fixed, which previously always returned true.

This PR is untested due to 
```
../../../RetroShare-origin/retroshare-gui/src/gui/gxs/GxsCommentTreeWidget.cpp: In member function 'virtual void MultiLinesCommentDelegate::paint(QPainter*, const QStyleOptionViewItem&, const QModelIndex&) const':
../../../RetroShare-origin/retroshare-gui/src/gui/gxs/GxsCommentTreeWidget.cpp:112:22: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined
  112 |         QPainterPath path ;
      |                      ^~~~
At global scope:
```