### PR TITLE
chat: take in consideration for creation of context menu whole nickname

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -277,10 +277,21 @@ void ChatLobbyDialog::textBrowserAskContextMenu(QMenu* contextMnu, QString ancho
 
 void ChatLobbyDialog::initParticipantsContextMenu(QMenu *contextMnu, QList<RsGxsId> idList)
 {
+// later this context menu will be deleted
 	if (!contextMnu)
 		return;
 	if (idList.isEmpty())
 		return;
+
+	// not displaying unneeded menu entries when banning people
+	QAction* make_invisible = contextMnu->findChild<QAction*>("edit-copy", Qt::FindDirectChildrenOnly);
+	if (make_invisible) {
+		make_invisible->setVisible(false);
+	}
+	make_invisible = contextMnu->findChild<QAction*>("link-copy", Qt::FindDirectChildrenOnly);
+	if (make_invisible) {
+		make_invisible->setVisible(false);
+	}
 
 	contextMnu->addAction(distantChatAct);
 	contextMnu->addAction(sendMessageAct);

--- a/retroshare-gui/src/gui/common/RSTextBrowser.cpp
+++ b/retroshare-gui/src/gui/common/RSTextBrowser.cpp
@@ -267,25 +267,57 @@ bool RSTextBrowser::checkImage(QPoint pos, QString &imageStr)
 /**
  * @brief RSTextBrowser::anchorForPosition Replace anchorAt that doesn't works as expected.
  * @param pos Where to get anchor from text
- * @return anchor If text at pos is inside anchor, else empty string.
+ * @return anchor If certain text at pos is inside anchor, else empty string.
  */
 QString RSTextBrowser::anchorForPosition(const QPoint &pos) const
 {
-	QTextCursor cursor = cursorForPosition(pos);
-	cursor.select(QTextCursor::WordUnderCursor);
 	QString anchor = "";
-	if (!cursor.selectedText().isEmpty()){
-		QRegExp rx("<a name=\"(.*)\"",Qt::CaseSensitive, QRegExp::RegExp2);
-		rx.setMinimal(true);
-		QString sel = cursor.selection().toHtml();
-		QStringList anchors;
-		int pos=0;
-		while ((pos = rx.indexIn(sel,pos)) != -1) {
-			anchors << rx.cap(1);
-			pos += rx.matchedLength();
+	QTextCursor line_with_cursor = cursorForPosition(pos);
+	// if click below text browser, then last string get used for some reason
+	if (line_with_cursor.atEnd()) {
+		return anchor;
+	}
+	// keepanchor to select text from the start of a line to cursor position
+	line_with_cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor); 
+	if (!line_with_cursor.selectedText().isEmpty()) {
+		QString selection = line_with_cursor.selection().toHtml();
+		// std::cout << "RSTextBrowser::AnchorForPosition selection: " << selection.toStdString() << std::endl;
+		QRegExp name_regexp("<a name=\"(.*)\"", Qt::CaseSensitive, QRegExp::RegExp2);
+		name_regexp.setMinimal(true);
+		// XXX may[be] get changed with time. Skip:
+		// 95 - DOCTYPE stuff
+		// 73 - <html><head...
+		// 33 - p, li...
+		// 22 - <body>...
+		// 119 - <p style...
+		                        /* for click to get what we seeking for */
+		int max_allowed_position = 95 + 73 + 33 + 22 + 119; // =342
+		// get last match [of] (time, personid, .*)
+		while (name_regexp.indexIn(selection, max_allowed_position) != -1) {
+			anchor = name_regexp.cap(1);
+			max_allowed_position = name_regexp.pos(0) + name_regexp.matchedLength();
 		}
-		if (!anchors.isEmpty()){
-			anchor = anchors.at(0);
+		// have to search for full nickname (including several words with spaces)
+		if (anchor.startsWith("PersonId", Qt::CaseSensitive)) {
+			QRegExp regex_span_for_name("<span style=\".*</span>", Qt::CaseSensitive, QRegExp::RegExp2);
+			regex_span_for_name.setMinimal(true);
+			// <span style=\" ... </span> <- for the first letter of a nickname
+			if (regex_span_for_name.indexIn(selection, max_allowed_position) != -1) {
+				max_allowed_position = regex_span_for_name.pos(0) + regex_span_for_name.matchedLength();
+				// <span... <- for remaining letters of the nickname
+				if (regex_span_for_name.indexIn(selection, max_allowed_position) != -1) {
+					max_allowed_position = regex_span_for_name.pos(0) + regex_span_for_name.matchedLength();
+				}
+			}
+			// total length of start_of_line..position_of_click(htmled) for 'personid:'.
+			// do not count '<!--EndFragment--></p></body></html>'. It will be not checked.
+			int position_of_click = selection.length() - 36;
+			if( position_of_click <= max_allowed_position ) {
+				// std::cout << "RSTextBrowser::AnchorForPosition it works" << std::endl;
+			} else {
+				anchor = "";
+				// std::cout << "RSTextBrowser::AnchorForPosition not working" << std::endl;
+			}
 		}
 	}
 	return anchor;

--- a/retroshare-gui/src/gui/common/RSTextBrowser.cpp
+++ b/retroshare-gui/src/gui/common/RSTextBrowser.cpp
@@ -284,14 +284,14 @@ QString RSTextBrowser::anchorForPosition(const QPoint &pos) const
 		// std::cout << "RSTextBrowser::AnchorForPosition selection: " << selection.toStdString() << std::endl;
 		QRegExp name_regexp("<a name=\"(.*)\"", Qt::CaseSensitive, QRegExp::RegExp2);
 		name_regexp.setMinimal(true);
-		// XXX may[be] get changed with time. Skip:
-		// 95 - DOCTYPE stuff
-		// 73 - <html><head...
-		// 33 - p, li...
-		// 22 - <body>...
-		// 119 - <p style...
-		                        /* for click to get what we seeking for */
-		int max_allowed_position = 95 + 73 + 33 + 22 + 119; // =342
+		// XXX may[be] get changed with time. Will skip:
+		static const int doctype_stuff = strlen("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"); // 95
+		static const int html_head = strlen("<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"); // 73
+		static const int p_li_wrap = strlen("p, li { white-space: pre-wrap; }\n"); // 33
+		static const int start_body_html = strlen("</style></head><body>\n"); // 22
+		static const int p_style = strlen("<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\""); // 119
+		// for click to get what we seeking for ( =342 )
+		int max_allowed_position = doctype_stuff + html_head + p_li_wrap + start_body_html + p_style;
 		// get last match [of] (time, personid, .*)
 		while (name_regexp.indexIn(selection, max_allowed_position) != -1) {
 			anchor = name_regexp.cap(1);
@@ -310,8 +310,9 @@ QString RSTextBrowser::anchorForPosition(const QPoint &pos) const
 				}
 			}
 			// total length of start_of_line..position_of_click(htmled) for 'personid:'.
-			// do not count '<!--EndFragment--></p></body></html>'. It will be not checked.
-			int position_of_click = selection.length() - 36;
+			// do not count unneeded part.
+			static const int endfragment_html_part_length = strlen("<!--EndFragment--></p></body></html>");
+			int position_of_click = selection.length() - endfragment_html_part_length;
 			if( position_of_click <= max_allowed_position ) {
 				// std::cout << "RSTextBrowser::AnchorForPosition it works" << std::endl;
 			} else {


### PR DESCRIPTION
Effort to be possible to create context menu anywhere in the nickname (including several words with spaces in-between).

Also hide 'Copy' and 'Copy link' when creating context menu for nickname in chat.