### PR TITLE
Fix hidden node crashing at the startup

### DIFF
--- a/libretroshare/src/pqi/p3netmgr.cc
+++ b/libretroshare/src/pqi/p3netmgr.cc
@@ -1803,15 +1803,16 @@ void p3NetMgrIMPL::updateNatSetting()
 #endif
 		
 #ifdef RS_USE_DHT_STUNNER
-		switch(natType)
-		{
-			case RSNET_NATTYPE_RESTRICTED_CONE: 
+		if (mProxyStunner) {
+			switch(natType)
+			{
+			case RSNET_NATTYPE_RESTRICTED_CONE:
 			{
 				if ((natHole == RSNET_NATHOLE_NONE) || (natHole == RSNET_NATHOLE_UNKNOWN))
 				{
 					mProxyStunner->setRefreshPeriod(NET_STUNNER_PERIOD_FAST);
 				}
-				else 
+				else
 				{
 					mProxyStunner->setRefreshPeriod(NET_STUNNER_PERIOD_SLOW);
 				}
@@ -1826,6 +1827,7 @@ void p3NetMgrIMPL::updateNatSetting()
 
 				mProxyStunner->setRefreshPeriod(NET_STUNNER_PERIOD_SLOW);
 				break;
+			}
 		}
 #endif // RS_USE_DHT_STUNNER
 

--- a/libretroshare/src/pqi/p3netmgr.h
+++ b/libretroshare/src/pqi/p3netmgr.h
@@ -291,8 +291,8 @@ private:
 
 	//p3BitDht   *mBitDht;
 #ifdef RS_USE_DHT_STUNNER
-	pqiAddrAssist *mDhtStunner;
-	pqiAddrAssist *mProxyStunner;
+	pqiAddrAssist *mDhtStunner = nullptr;
+	pqiAddrAssist *mProxyStunner = nullptr;
 #endif // RS_USE_DHT_STUNNER
 
 	RsMutex mNetMtx; /* protects below */


### PR DESCRIPTION
Fix hidden node crashing at the startup, caused by calling uninitialized objects.