### PR TITLE
Reduce memory usage due to copying in RsQThreadUtils::postToObject

### DIFF
--- a/retroshare-gui/src/gui/Identity/IdDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDialog.cpp
@@ -509,9 +509,7 @@ void IdDialog::updateCircles()
 #endif
 
 		/* This can be big so use a smart pointer to just copy the pointer
-		 * instead of copying the whole list accross the lambdas.
-		 * Heaptrack reported 141MB of RAM where used to copy this around
-		 * before this change. */
+		 * instead of copying the whole list accross the lambdas */
 		auto circle_metas = std::make_unique<std::list<RsGroupMetaData>>();
 
 		if(!rsGxsCircles->getCirclesSummaries(*circle_metas))
@@ -1312,19 +1310,17 @@ void IdDialog::updateIdList()
 			return;
 		}
 
-		std::map<RsGxsGroupId,RsGxsIdGroup> ids_set;
+		auto ids_set = std::make_unique<std::map<RsGxsGroupId,RsGxsIdGroup>>();
+		for(auto it(groups.begin()); it!=groups.end(); ++it)
+			(*ids_set)[(*it).mMeta.mGroupId] = *it;
 
-        for(auto it(groups.begin());it!=groups.end();++it)
-            ids_set[(*it).mMeta.mGroupId] = *it;
-
-        RsQThreadUtils::postToObject( [ids_set,this]()
+		RsQThreadUtils::postToObject(
+		            [ids_set = std::move(ids_set), this] ()
 		{
 			/* Here it goes any code you want to be executed on the Qt Gui
 			 * thread, for example to update the data model with new information
 			 * after a blocking call to RetroShare API complete */
-
-            loadIdentities(ids_set);
-
+			loadIdentities(*ids_set);
 		}, this );
 
     });

--- a/retroshare-gui/src/gui/Identity/IdDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDialog.cpp
@@ -47,6 +47,7 @@
 #include "util/misc.h"
 #include "util/QtVersion.h"
 #include "util/rstime.h"
+#include "util/rsdebug.h"
 
 #include "retroshare/rsgxsflags.h"
 #include "retroshare/rsmsgs.h" 
@@ -55,6 +56,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <memory>
 
 /******
  * #define ID_DEBUG 1
@@ -506,21 +508,26 @@ void IdDialog::updateCircles()
         std::cerr << "Retrieving post data for post " << mThreadId << std::endl;
 #endif
 
-        std::list<RsGroupMetaData> circle_metas ;
+		/* This can be big so use a smart pointer to just copy the pointer
+		 * instead of copying the whole list accross the lambdas.
+		 * Heaptrack reported 141MB of RAM where used to copy this around
+		 * before this change. */
+		auto circle_metas = std::make_unique<std::list<RsGroupMetaData>>();
 
-		if(!rsGxsCircles->getCirclesSummaries(circle_metas))
+		if(!rsGxsCircles->getCirclesSummaries(*circle_metas))
 		{
-			std::cerr << __PRETTY_FUNCTION__ << " failed to retrieve circles group info list" << std::endl;
+			RS_ERR("failed to retrieve circles group info list");
 			return;
-        }
+		}
 
-        RsQThreadUtils::postToObject( [circle_metas,this]()
+		RsQThreadUtils::postToObject(
+		            [circle_metas = std::move(circle_metas), this]()
 		{
 			/* Here it goes any code you want to be executed on the Qt Gui
 			 * thread, for example to update the data model with new information
 			 * after a blocking call to RetroShare API complete */
 
-            loadCircles(circle_metas);
+			loadCircles(*circle_metas);
 
 		}, this );
 

--- a/retroshare-gui/src/gui/Identity/IdEditDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdEditDialog.cpp
@@ -210,8 +210,8 @@ void IdEditDialog::setupExistingId(const RsGxsGroupId& keyId)
 	RsThread::async([this,keyId]()
 	{
 		std::vector<RsGxsIdGroup> datavector;
-
-        bool res = rsIdentity->getIdentitiesInfo(std::set<RsGxsId>({(RsGxsId)keyId}),datavector);
+		bool res = rsIdentity->getIdentitiesInfo(
+		            std::set<RsGxsId>({(RsGxsId)keyId}), datavector );
 
 		RsQThreadUtils::postToObject( [this,keyId,res,datavector]()
 		{

--- a/retroshare-gui/src/util/qtthreadsutils.h
+++ b/retroshare-gui/src/util/qtthreadsutils.h
@@ -44,7 +44,7 @@ void postToObject(F &&fun, QObject *obj = qApp)
 	QObject src;
 	auto type = obj->metaObject();
 	QObject::connect( &src, &QObject::destroyed, obj,
-	                  [fun, type, obj]
+	                  [fun = std::move(fun), type, obj]
 	{
 		// ensure that the object is not being destructed
 		if (obj->metaObject()->inherits(type)) fun();

--- a/retroshare-gui/src/util/qtthreadsutils.h
+++ b/retroshare-gui/src/util/qtthreadsutils.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * util/qthreadutils.h                                                         *
  *                                                                             *
- * Copyright (C) 2018  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2018-2020  Gioacchino Mazzurco <gio@eigenlab.org>             *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Affero General Public License as              *
@@ -27,7 +27,9 @@
 
 #include <QtGlobal>
 #include <QtCore>
+
 #include <type_traits>
+#include <utility>
 
 namespace RsQThreadUtils {
 


### PR DESCRIPTION
Heaptrack reported 141MB of RAM where used just by IdDialog::updateCircles most proably due to the group metadata list being copied accross lambdas and threads more then necessary.
Use an unique_ptr to safely avoid copying of big structure around.