### PR TITLE
Add API method to retrieve forum child posts

### DIFF
--- a/libretroshare/src/gxs/rsgxsdataaccess.cc
+++ b/libretroshare/src/gxs/rsgxsdataaccess.cc
@@ -1240,61 +1240,42 @@ bool RsGxsDataAccess::getMsgRelatedInfo(MsgRelatedInfoReq *req)
             onlyThreadMsgs = true;
     }
 
-    if (onlyAllVersions && onlyChildMsgs)
-    {
-#ifdef DATA_DEBUG
-            RsDbg() << "RsGxsDataAccess::getMsgRelatedList() ERROR Incompatible FLAGS (VERSIONS & PARENT)" << std::endl;
-#endif
+	if(onlyAllVersions && onlyChildMsgs)
+	{
+		RS_ERR("Incompatible FLAGS (VERSIONS & PARENT)");
+		return false;
+	}
 
-            return false;
-    }
+	if(onlyAllVersions && onlyThreadMsgs)
+	{
+		RS_ERR("Incompatible FLAGS (VERSIONS & THREAD)");
+		return false;
+	}
 
-    if (onlyAllVersions && onlyThreadMsgs)
-    {
-#ifdef DATA_DEBUG
-            RsDbg() << "RsGxsDataAccess::getMsgRelatedList() ERROR Incompatible FLAGS (VERSIONS & THREAD)" << std::endl;
-#endif
+	if((!onlyLatestMsgs) && onlyChildMsgs)
+	{
+		RS_ERR("Incompatible FLAGS (!LATEST & PARENT)");
+		return false;
+	}
 
-            return false;
-    }
+	if((!onlyLatestMsgs) && onlyThreadMsgs)
+	{
+		RS_ERR("Incompatible FLAGS (!LATEST & THREAD)");
+		return false;
+	}
 
-    if ((!onlyLatestMsgs) && onlyChildMsgs)
-    {
-#ifdef DATA_DEBUG
-            RsDbg() << "RsGxsDataAccess::getMsgRelatedList() ERROR Incompatible FLAGS (!LATEST & PARENT)" << std::endl;
-#endif
+	if(onlyChildMsgs && onlyThreadMsgs)
+	{
+		RS_ERR("Incompatible FLAGS (PARENT & THREAD)");
+		return false;
+	}
 
-            return false;
-    }
-
-    if ((!onlyLatestMsgs) && onlyThreadMsgs)
-    {
-#ifdef DATA_DEBUG
-            RsDbg() << "RsGxsDataAccess::getMsgRelatedList() ERROR Incompatible FLAGS (!LATEST & THREAD)" << std::endl;
-#endif
-
-            return false;
-    }
-
-    if (onlyChildMsgs && onlyThreadMsgs)
-    {
-#ifdef DATA_DEBUG
-            RsDbg() << "RsGxsDataAccess::getMsgRelatedList() ERROR Incompatible FLAGS (PARENT & THREAD)" << std::endl;
-#endif
-
-            return false;
-    }
-
-
-    /* FALL BACK OPTION */
-    if ((!onlyLatestMsgs) && (!onlyAllVersions) && (!onlyChildMsgs) && (!onlyThreadMsgs))
-    {
-#ifdef DATA_DEBUG
-            RsDbg() << "RsGxsDataAccess::getMsgRelatedList() FALLBACK -> NO FLAGS -> SIMPLY RETURN nothing" << std::endl;
-#endif
-
-            return true;
-    }
+	if( (!onlyLatestMsgs) && (!onlyAllVersions) && (!onlyChildMsgs) &&
+	        (!onlyThreadMsgs) )
+	{
+		RS_WARN("NO FLAGS -> SIMPLY RETURN nothing");
+		return true;
+	}
 
     for(auto vit_msgIds(req->mMsgIds.begin()); vit_msgIds != req->mMsgIds.end(); ++vit_msgIds)
     {
@@ -1330,14 +1311,11 @@ bool RsGxsDataAccess::getMsgRelatedInfo(MsgRelatedInfoReq *req)
             }
         }
 
-        if(!origMeta)
-        {
-#ifdef DATA_DEBUG
-            RsDbg() << "RsGxsDataAccess::getMsgRelatedInfo(): Cannot find meta of msgId (to relate to)!"
-                      << std::endl;
-#endif
-            return false;
-        }
+		if(!origMeta)
+		{
+			RS_ERR("Cannot find meta of msgId: ", msgId, " to relate to");
+			return false;
+		}
 
         const RsGxsMessageId& origMsgId = origMeta->mOrigMsgId;
         std::map<RsGxsMessageId, const RsGxsMsgMetaData*>& metaMap = filterMap[grpId];

--- a/libretroshare/src/retroshare/rsgxsforums.h
+++ b/libretroshare/src/retroshare/rsgxsforums.h
@@ -4,7 +4,8 @@
  * libretroshare: retroshare core library                                      *
  *                                                                             *
  * Copyright (C) 2012-2014  Robert Fernie <retroshare@lunamutt.com>            *
- * Copyright (C) 2018-2019  Gioacchino Mazzurco <gio@eigenlab.org>             *
+ * Copyright (C) 2018-2020  Gioacchino Mazzurco <gio@eigenlab.org>             *
+ * Copyright (C) 2019-2020  Asociación Civil Altermundi <info@altermundi.net>  *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -25,6 +26,7 @@
 #include <cstdint>
 #include <string>
 #include <list>
+#include <system_error>
 
 #include "retroshare/rstokenservice.h"
 #include "retroshare/rsgxsifacehelper.h"
@@ -353,6 +355,19 @@ public:
 	        RsGxsGroupId& forumId = RS_DEFAULT_STORAGE_PARAM(RsGxsGroupId),
 	        std::string& errMsg = RS_DEFAULT_STORAGE_PARAM(std::string) ) = 0;
 
+	/**
+	 * @brief Get posts related to the given post.
+	 * If the set is empty, nothing is returned.
+	 * @jsonapi{development}
+	 * @param[in] forumId id of the forum of which the content is requested
+	 * @param[in] parentId id of the post of which child posts (aka replies)
+	 *	are requested.
+	 * @param[out] childPosts storage for the child posts
+	 * @return false if something failed, true otherwhise
+	 */
+	virtual std::error_condition getChildPosts(
+	        const RsGxsGroupId& forumId, const RsGxsMessageId& parentId,
+	        std::vector<RsGxsForumMsg>& childPosts ) = 0;
 
 	/**
 	 * @brief Create forum. Blocking API.

--- a/libretroshare/src/services/p3gxsforums.h
+++ b/libretroshare/src/services/p3gxsforums.h
@@ -4,7 +4,8 @@
  * libretroshare: retroshare core library                                      *
  *                                                                             *
  * Copyright (C) 2012-2014  Robert Fernie <retroshare@lunamutt.com>            *
- * Copyright (C) 2018-2019  Gioacchino Mazzurco <gio@eigenlab.org>             *
+ * Copyright (C) 2018-2020  Gioacchino Mazzurco <gio@eigenlab.org>             *
+ * Copyright (C) 2019-2020  Asociación Civil Altermundi <info@altermundi.net>  *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -130,6 +131,11 @@ public:
 	        RsGxsGroupId& forumId = RS_DEFAULT_STORAGE_PARAM(RsGxsGroupId),
 	        std::string& errMsg = RS_DEFAULT_STORAGE_PARAM(std::string)
 	        ) override;
+
+	/// @see RsGxsForums
+	std::error_condition getChildPosts(
+	        const RsGxsGroupId& forumId, const RsGxsMessageId& parentId,
+	        std::vector<RsGxsForumMsg>& childPosts ) override;
 
     /// implementation of rsGxsGorums
     ///


### PR DESCRIPTION
RsGxsDataAccess::getMsgRelatedInfo print errors also when not debugging
RsGxsForums::getChildPosts get child posts from parent id
p3gxsforums.cc remove a bit of deadcode


example usage:
```
 curl -u $API_TOKEN --data '{"forumId":"8fd22bd8f99754461e7ba1ca8a727995","parentId":"6924bf112b3a85e80a4e0c8c38b923f39925687e"}' $API_BASE_URL/rsGxsForums/getChildPosts | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2412  100  2312  100   100  22446    970 --:--:-- --:--:-- --:--:-- 23647
{
  "childPosts": [
    {
      "mMeta": {
        "mGroupId": "8fd22bd8f99754461e7ba1ca8a727995",
        "mMsgId": "d7ed8cfdc8e01a1fbdd3197d190d73f9c82aaba2",
        "mThreadId": "0000000000000000000000000000000000000000",
        "mParentId": "6924bf112b3a85e80a4e0c8c38b923f39925687e",
        "mOrigMsgId": "d7ed8cfdc8e01a1fbdd3197d190d73f9c82aaba2",
        "mAuthorId": "636e92eb56ba2a8f3ec9a64b1398bebf",
        "mMsgName": "Re: GXS anti-clogging PR 2024",
        "mPublishTs": {
          "xint64": 1593775911,
          "xstr64": "1593775911"
        },
        "mMsgFlags": 0,
        "mMsgStatus": 1,
        "mChildTs": {
          "xint64": 0,
          "xstr64": "0"
        },
        "mServiceString": ""
      },
      "mMsg": "<body><style RSOptimized=\"v2\" type=\"text/css\">.S0{font-family:'MSSansSerif';}.S0{font-style:normal;}.S0{font-size:10.;}.S0{font-weight:400;}</style><span><span class=\"S0\">>> We need testers for PR 2024. Preferably users who frequently see outqueues getting overwhelmed by GXS sync transactions. Thx<br/>> On the Bandwidth page the Allocated Sent column is just counting up. <br/>> The older build I am running resets at 6 or 7 seconds all the the time. <br/>> While writing this post the Allocated Sent started resetting for the new build as well. <br/>>  <br/>> PR2024<br/>> RetroShare Version: 0.6.5-1712-g9133adbde<br/>> Windows 10 Version 1909 QT 5.14.2<br/>> libretroshare<br/>>  - bzip2: 1.0.8, 13-Jul-2019<br/>>  - OpenSSL: OpenSSL 1.1.1g 21 Apr 2020<br/>>  - SQLite: 3.30.1<br/>>  - SQLCipher: 4.3.0 community<br/>>  - UPnP (MiniUPnP): 2.1.20190824<br/>>  - Zlib: 1.2.11<br/>> Older build<br/>> RetroShare Version: 0.6.5-1610-g800a7499d<br/>> Windows 10 Version 1909 QT 5.14.2<br/>> libretroshare<br/>>  - bzip2: 1.0.8, 13-Jul-2019<br/>>  - OpenSSL: OpenSSL 1.1.1g 21 Apr 2020<br/>>  - SQLite: 3.30.1<br/>>  - SQLCipher: 4.3.0 community<br/>>  - UPnP (MiniUPnP): 2.1.20190824<br/>>  - Zlib: 1.2.11<br/><br/>testing</span></span></body>"
    }
  ],
  "retval": {
    "errorNumber": 0,
    "errorCategory": "generic",
    "errorMessage": "Success"
  }
}
```