### PR TITLE
 [TheWire] update GroupPtrs

### DIFF
--- a/libretroshare/src/retroshare/rsgxsifacehelper.h
+++ b/libretroshare/src/retroshare/rsgxsifacehelper.h
@@ -50,12 +50,13 @@ enum class TokenRequestType: uint8_t
 	__NONE              = 0x00, /// Used to detect uninitialized
     GROUP_DATA          = 0x01,
     GROUP_META          = 0x02,
-    POSTS               = 0x03,
-    ALL_POSTS           = 0x04,
-    MSG_RELATED_INFO    = 0x05,
-    GROUP_STATISTICS    = 0x06,
-    SERVICE_STATISTICS  = 0x07,
-    NO_KILL_TYPE        = 0x08,
+    GROUP_IDS           = 0x03,
+    POSTS               = 0x04,
+    ALL_POSTS           = 0x05,
+    MSG_RELATED_INFO    = 0x06,
+    GROUP_STATISTICS    = 0x07,
+    SERVICE_STATISTICS  = 0x08,
+    NO_KILL_TYPE        = 0x09,
 	__MAX                       /// Used to detect out of range
 };
 
@@ -263,6 +264,7 @@ public:
         {
         case GXS_REQUEST_TYPE_GROUP_DATA: token_request_type = TokenRequestType::GROUP_DATA; break;
         case GXS_REQUEST_TYPE_GROUP_META: token_request_type = TokenRequestType::GROUP_META; break;
+        case GXS_REQUEST_TYPE_GROUP_IDS: token_request_type = TokenRequestType::GROUP_IDS; break;
         default:
             RsErr() << __PRETTY_FUNCTION__ << "(EE) Unexpected request type " << opts.mReqType << "!!" << std::endl;
             return false;
@@ -292,6 +294,7 @@ public:
         {
         case GXS_REQUEST_TYPE_GROUP_DATA: token_request_type = TokenRequestType::GROUP_DATA; break;
         case GXS_REQUEST_TYPE_GROUP_META: token_request_type = TokenRequestType::GROUP_META; break;
+        case GXS_REQUEST_TYPE_GROUP_IDS: token_request_type = TokenRequestType::GROUP_IDS; break;
         default:
             RsErr() << __PRETTY_FUNCTION__ << "(EE) Unexpected request type " << opts.mReqType << "!!" << std::endl;
             return false;

--- a/libretroshare/src/retroshare/rswire.h
+++ b/libretroshare/src/retroshare/rswire.h
@@ -176,8 +176,8 @@ class RsWirePulse
 
 	// Pointer to WireGroups
 	// mRefGroupPtr is opportunistically filled in, but will often be empty.
-	RsWireGroupSPtr mRefGroupPtr; //  ORIG/RESP: N/A      , REF: Reply Group
-	RsWireGroupSPtr mGroupPtr;    //  ORIG/RESP: Own Group, REF: Parent Group
+	RsWireGroupSPtr mRefGroupPtr; //  ORIG: N/A, RESP: Parent, REF: Reply Group
+	RsWireGroupSPtr mGroupPtr;    //  ORIG: Own, RESP: Own,    REF: Parent Group
 
 	// These are the direct children of this message
 	// split into likes, replies and retweets.

--- a/libretroshare/src/services/p3wire.h
+++ b/libretroshare/src/services/p3wire.h
@@ -95,16 +95,19 @@ private:
 	bool updatePulseChildren(RsWirePulseSPtr pParent,  uint32_t token);
 
 	// update GroupPtrs
+	bool updateGroups(std::list<RsWirePulseSPtr> &pulsePtrs);
+
+	// sub utility functions used by updateGroups.
 	bool extractGroupIds(RsWirePulseConstSPtr pPulse, std::set<RsGxsGroupId> &groupIds);
 
 	bool updateGroupPtrs(RsWirePulseSPtr pPulse,
 			const std::map<RsGxsGroupId, RsWireGroupSPtr> &groups);
 
-	bool fetchGroupPtrs(const std::set<RsGxsGroupId> &groupIds,
+	bool trimToAvailGroupIds(const std::set<RsGxsGroupId> &pulseGroupIds,
+		std::list<RsGxsGroupId> &availGroupIds);
+
+	bool fetchGroupPtrs(const std::list<RsGxsGroupId> &groupIds,
 			std::map<RsGxsGroupId, RsWireGroupSPtr> &groups);
-
-
-
 
 
 	virtual void generateDummyData();


### PR DESCRIPTION
Ensure all possible GroupPtrs are filled in on Pulse Data Requests.
 * Expand Id collection to include all the additonal RefGroupIds.
 * Perform intersection(available IDs, pulse GroupIds) before retrieving
 * Iterate over pulse tree and update GroupPtr references.
 * Enable GROUP_IDS gxs data fetches.