### PR TITLE
attempt to remove the hardcoded background colors for channel thumbnails

### DIFF
--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
@@ -111,9 +111,9 @@ void ChannelPostDelegate::paint(QPainter * painter, const QStyleOptionViewItem &
 	QPixmap pixmap(w.size());
 
     if((option.state & QStyle::State_Selected) && post.mMeta.mPublishTs > 0) // check if post is selected and is not empty (end of last row)
-		pixmap.fill(QRgb(0xff308dc7));	// I dont know how to grab the backgroud color for selected objects automatically.
+		pixmap.fill(mBackgroundColorSelected );	// I dont know how to grab the backgroud color for selected objects automatically.
 	else
-		pixmap.fill(QRgb(0x00ffffff));	// choose a fully transparent background
+		pixmap.fill(mBackgroundColorNotSelected);	// choose a fully transparent background
 
 	w.render(&pixmap,QPoint(),QRegion(),QWidget::DrawChildren );// draw the widgets, not the background
 
@@ -140,6 +140,8 @@ void ChannelPostDelegate::paint(QPainter * painter, const QStyleOptionViewItem &
 	painter->drawPixmap(option.rect.topLeft(),
                         pixmap.scaled(option.rect.width(),option.rect.width()*w.height()/(float)w.width(),Qt::IgnoreAspectRatio,Qt::SmoothTransformation));
 }
+
+//void ChannelPostDelegate::setTextColorSelected (QColor color) { mTextColorSelected  = color;}
 
 QSize ChannelPostDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
 {

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
@@ -141,8 +141,6 @@ void ChannelPostDelegate::paint(QPainter * painter, const QStyleOptionViewItem &
                         pixmap.scaled(option.rect.width(),option.rect.width()*w.height()/(float)w.width(),Qt::IgnoreAspectRatio,Qt::SmoothTransformation));
 }
 
-//void ChannelPostDelegate::setTextColorSelected (QColor color) { mTextColorSelected  = color;}
-
 QSize ChannelPostDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
     // This is the only place where we actually set the size of cells

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.h
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.h
@@ -59,6 +59,9 @@ class ChannelPostDelegate: public QAbstractItemDelegate
 {
 	Q_OBJECT
 
+	Q_PROPERTY(QColor backgroundColorSelected READ backgroundColorSelected WRITE setBackgroundColorSelected)
+	Q_PROPERTY(QColor backgroundColorNotSelected READ backgroundColorNotSelected WRITE setBackgroundColorNotSelected)
+
 	public:
 		ChannelPostDelegate(QObject *parent=0) : QAbstractItemDelegate(parent), mZoom(1.0){}
         virtual ~ChannelPostDelegate(){}
@@ -68,6 +71,13 @@ class ChannelPostDelegate: public QAbstractItemDelegate
 
         int cellSize(const QFont& font) const;
         void zoom(bool zoom_or_unzoom) ;
+
+		QColor backgroundColorSelected() const { return mBackgroundColorSelected; }
+		QColor backgroundColorNotSelected() const { return mBackgroundColorNotSelected; }
+
+		void setBackgroundColorSelected(QColor color) { mBackgroundColorSelected = color; }
+		void setBackgroundColorNotSelected(QColor color) { mBackgroundColorNotSelected = color; }
+
 	private:
  		static constexpr float IMAGE_MARGIN_FACTOR = 1.0;
  		static constexpr float IMAGE_SIZE_FACTOR_W = 4.0 ;
@@ -75,6 +85,10 @@ class ChannelPostDelegate: public QAbstractItemDelegate
  		static constexpr float IMAGE_ZOOM_FACTOR   = 1.0;
 
         float mZoom;	// zoom factor for the whole thumbnail
+		
+		/* Color definitions (for standard see qss.default) */
+		QColor mBackgroundColorSelected;
+		QColor mBackgroundColorNotSelected;
 };
 
 class GxsChannelPostsWidgetWithModel: public GxsMessageFrameWidget

--- a/retroshare-gui/src/gui/qss/stylesheet/qss.default
+++ b/retroshare-gui/src/gui/qss/stylesheet/qss.default
@@ -252,3 +252,9 @@ OpModeStatus[opMode="Minimal"] {
 [WrongValue="true"] {
 	background-color: #FF8080;
 }
+
+ChannelPostDelegate
+{
+	qproperty-backgroundColorSelected: rgb(120, 153, 34);
+	qproperty-backgroundColorNotSelected: white;
+}


### PR DESCRIPTION
the hardcoded colors doesnt allow to set right selection/none selection(background) colors for Thumbnails on different stylesheets like on dark stylesheet it a big issue.

this is not working yet im not sure why... i get always black background, maybe some one know it? 
@chelovechishko  @PhenomRetroShare maybe you know it?