### PR TITLE
Add proper header path for 'retroshare-gui/' headers

### DIFF
--- a/retroshare-gui/src/gui/ChatLobbyWidget.h
+++ b/retroshare-gui/src/gui/ChatLobbyWidget.h
@@ -19,9 +19,10 @@
  *******************************************************************************/
 #pragma once
 
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_ChatLobbyWidget.h"
 
-#include "RsAutoUpdatePage.h"
 #include "chat/ChatLobbyUserNotify.h"
 #include "gui/gxs/GxsIdChooser.h"
 

--- a/retroshare-gui/src/gui/FileTransfer/BannedFilesDialog.h
+++ b/retroshare-gui/src/gui/FileTransfer/BannedFilesDialog.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
 #include "ui_BannedFilesDialog.h"
 
 class BannedFilesDialog: public QDialog

--- a/retroshare-gui/src/gui/FileTransfer/FileTransferInfoWidget.h
+++ b/retroshare-gui/src/gui/FileTransfer/FileTransferInfoWidget.h
@@ -24,7 +24,8 @@
 #include <QWidget>
 #include <QPainter>
 #include <QBitmap>
-#include "RsAutoUpdatePage.h"
+
+#include <retroshare-gui/RsAutoUpdatePage.h>
 #include <retroshare/rstypes.h>
 
 struct FileChunksInfo ;

--- a/retroshare-gui/src/gui/FileTransfer/SearchDialog.h
+++ b/retroshare-gui/src/gui/FileTransfer/SearchDialog.h
@@ -23,7 +23,7 @@
 
 #include <retroshare/rstypes.h>
 #include "ui_SearchDialog.h"
-#include "mainpage.h"
+#include <retroshare-gui/mainpage.h>
 
 class AdvancedSearchDialog;
 class RSTreeWidgetItemCompareRole;

--- a/retroshare-gui/src/gui/FileTransfer/SharedFilesDialog.h
+++ b/retroshare-gui/src/gui/FileTransfer/SharedFilesDialog.h
@@ -23,7 +23,7 @@
 
 #include "ui_SharedFilesDialog.h"
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
 #include "gui/RetroShareLink.h"
 #include "util/RsProtectedTimer.h"
 

--- a/retroshare-gui/src/gui/FileTransfer/TransfersDialog.h
+++ b/retroshare-gui/src/gui/FileTransfer/TransfersDialog.h
@@ -25,7 +25,7 @@
 
 #include <retroshare/rstypes.h>
 #include <retroshare/rsevents.h>
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
 
 #include "ui_TransfersDialog.h"
 

--- a/retroshare-gui/src/gui/GetStartedDialog.h
+++ b/retroshare-gui/src/gui/GetStartedDialog.h
@@ -21,9 +21,9 @@
 #ifndef _GETTING_STARTED_DIALOG_H
 #define _GETTING_STARTED_DIALOG_H
 
-//#include <retroshare/rstypes.h>
+#include <retroshare-gui/mainpage.h>
+
 #include "ui_GetStartedDialog.h"
-#include "mainpage.h"
 
 #include <QTimer>
 

--- a/retroshare-gui/src/gui/NetworkDialog.h
+++ b/retroshare-gui/src/gui/NetworkDialog.h
@@ -21,8 +21,10 @@
 #ifndef _CONNECTIONSDIALOG_H
 #define _CONNECTIONSDIALOG_H
 
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_NetworkDialog.h"
-#include "RsAutoUpdatePage.h"
+
 #include "gui/NetworkDialog/pgpid_item_model.h"
 #include "gui/NetworkDialog/pgpid_item_proxy.h"
 

--- a/retroshare-gui/src/gui/NetworkView.h
+++ b/retroshare-gui/src/gui/NetworkView.h
@@ -25,7 +25,7 @@
 
 #include <retroshare/rstypes.h>
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
 #include "ui_NetworkView.h"
 
 

--- a/retroshare-gui/src/gui/NewsFeed.h
+++ b/retroshare-gui/src/gui/NewsFeed.h
@@ -21,7 +21,7 @@
 #ifndef _NEWS_FEED_DIALOG_H
 #define _NEWS_FEED_DIALOG_H
 
-#include "mainpage.h"
+#include <retroshare-gui/mainpage.h>
 
 #include "gui/feeds/FeedHolder.h"
 #include "util/TokenQueue.h"

--- a/retroshare-gui/src/gui/PluginsPage.h
+++ b/retroshare-gui/src/gui/PluginsPage.h
@@ -21,7 +21,7 @@
 #ifndef _PLUGINS_PAGE_H_
 #define _PLUGINS_PAGE_H_
 
-#include "mainpage.h"
+#include <retroshare-gui/mainpage.h>
 
 #include <QGroupBox>
 #include <QString>

--- a/retroshare-gui/src/gui/RemoteDirModel.cpp
+++ b/retroshare-gui/src/gui/RemoteDirModel.cpp
@@ -20,7 +20,8 @@
 
 #include "RemoteDirModel.h"
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "gui/common/FilesDefs.h"
 #include "gui/common/GroupDefs.h"
 #include "gui/common/RsCollection.h"

--- a/retroshare-gui/src/gui/RsAutoUpdatePage.cpp
+++ b/retroshare-gui/src/gui/RsAutoUpdatePage.cpp
@@ -19,7 +19,8 @@
  *******************************************************************************/
 
 #include <QTimer>
-#include "RsAutoUpdatePage.h"
+
+#include <retroshare-gui/RsAutoUpdatePage.h>
 
 bool RsAutoUpdatePage::_locked = false ;
 

--- a/retroshare-gui/src/gui/chat/PopupDistantChatDialog.cpp
+++ b/retroshare-gui/src/gui/chat/PopupDistantChatDialog.cpp
@@ -30,7 +30,8 @@
 #include <retroshare/rspeers.h>
 #include <retroshare/rsidentity.h>
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "PopupDistantChatDialog.h"
 
 #define IMAGE_RED_LED ":/icons/bullet_red_128.png"

--- a/retroshare-gui/src/gui/common/NewFriendList.h
+++ b/retroshare-gui/src/gui/common/NewFriendList.h
@@ -25,8 +25,9 @@
 #include <QWidget>
 #include <QTreeView>
 
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "FriendListModel.h"
-#include "RsAutoUpdatePage.h"
 #include "retroshare/rsstatus.h"
 
 namespace Ui {

--- a/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
+++ b/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
@@ -32,6 +32,8 @@
 #include <retroshare/rsdisc.h>
 #include <retroshare/rsmsgs.h>
 
+#include <retroshare-gui/mainpage.h>
+
 #include "gui/help/browser/helpbrowser.h"
 #include "gui/common/PeerDefs.h"
 #include "gui/common/StatusDefs.h"
@@ -39,7 +41,6 @@
 #include "gui/notifyqt.h"
 #include "gui/common/AvatarDefs.h"
 #include "gui/MainWindow.h"
-#include "mainpage.h"
 #include "util/DateTime.h"
 #include "util/misc.h"
 

--- a/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
+++ b/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
@@ -32,6 +32,8 @@
 #include <retroshare/rsdisc.h>
 #include <retroshare/rsmsgs.h>
 
+#include <retroshare-gui/mainpage.h>
+
 #include "gui/help/browser/helpbrowser.h"
 #include "gui/common/PeerDefs.h"
 #include "gui/common/StatusDefs.h"
@@ -39,7 +41,6 @@
 #include "gui/notifyqt.h"
 #include "gui/common/AvatarDefs.h"
 #include "gui/MainWindow.h"
-#include "mainpage.h"
 #include "util/DateTime.h"
 #include "util/misc.h"
 

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
@@ -21,8 +21,9 @@
 #ifndef _GXSGROUPFRAMEDIALOG_H
 #define _GXSGROUPFRAMEDIALOG_H
 
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "gui/gxs/RsGxsUpdateBroadcastPage.h"
-#include "RsAutoUpdatePage.h"
 #include "gui/RetroShareLink.h"
 #include "gui/settings/rsharesettings.h"
 #include "util/RsUserdata.h"

--- a/retroshare-gui/src/gui/gxs/RsGxsUpdateBroadcastPage.h
+++ b/retroshare-gui/src/gui/gxs/RsGxsUpdateBroadcastPage.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "mainpage.h"
+#include <retroshare-gui/mainpage.h>
 #include <retroshare/rsgxsifacetypes.h>
 
 // This class implement a basic RS functionality which is that widgets displaying info

--- a/retroshare-gui/src/gui/msgs/MessagesDialog.h
+++ b/retroshare-gui/src/gui/msgs/MessagesDialog.h
@@ -23,7 +23,8 @@
 
 #include <QSortFilterProxyModel>
 
-#include "mainpage.h"
+#include <retroshare-gui/mainpage.h>
+
 #include "ui_MessagesDialog.h"
 
 #define IMAGE_MESSAGES          ":/icons/png/message.png"

--- a/retroshare-gui/src/gui/notifyqt.cpp
+++ b/retroshare-gui/src/gui/notifyqt.cpp
@@ -32,7 +32,7 @@
 #include <retroshare/rsidentity.h>
 #include <util/rsdir.h>
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
 
 #include "MainWindow.h"
 #include "toaster/OnlineToaster.h"

--- a/retroshare-gui/src/gui/settings/rsettingswin.h
+++ b/retroshare-gui/src/gui/settings/rsettingswin.h
@@ -23,8 +23,9 @@
 
 #include <QDialog>
 #include <retroshare-gui/configpage.h>
+#include <retroshare-gui/mainpage.h>
+
 #include "ui_settingsw.h"
-#include "mainpage.h"
 
 class FloatingHelpBrowser;
 

--- a/retroshare-gui/src/gui/statistics/BwCtrlWindow.h
+++ b/retroshare-gui/src/gui/statistics/BwCtrlWindow.h
@@ -24,7 +24,7 @@
 
 #include <QAbstractItemDelegate>
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
 #include "gui/common/RSGraphWidget.h"
 #include "ui_BwCtrlWindow.h"
 

--- a/retroshare-gui/src/gui/statistics/DhtWindow.h
+++ b/retroshare-gui/src/gui/statistics/DhtWindow.h
@@ -21,7 +21,8 @@
 #ifndef RSDHT_WINDOW_H
 #define RSDHT_WINDOW_H
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_DhtWindow.h"
 
 class DhtWindow : public RsAutoUpdatePage/*,  public Ui::DhtWindow*/ {

--- a/retroshare-gui/src/gui/statistics/GlobalRouterStatistics.h
+++ b/retroshare-gui/src/gui/statistics/GlobalRouterStatistics.h
@@ -24,7 +24,8 @@
 #include <retroshare/rsgrouter.h>
 #include <retroshare/rstypes.h>
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_GlobalRouterStatistics.h"
 
 class GlobalRouterStatisticsWidget ;

--- a/retroshare-gui/src/gui/statistics/GxsIdStatistics.h
+++ b/retroshare-gui/src/gui/statistics/GxsIdStatistics.h
@@ -24,7 +24,8 @@
 #include <retroshare/rsidentity.h>
 #include <retroshare/rstypes.h>
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "Histogram.h"
 #include "ui_GxsIdStatistics.h"
 

--- a/retroshare-gui/src/gui/statistics/GxsTransportStatistics.h
+++ b/retroshare-gui/src/gui/statistics/GxsTransportStatistics.h
@@ -27,7 +27,8 @@
 #include <retroshare/rstypes.h>
 #include <retroshare/rsgxstrans.h>
 
-#include "RsAutoUpdatePage.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_GxsTransportStatistics.h"
 #include "gui/gxs/RsGxsUpdateBroadcastPage.h"
 #include "util/rstime.h"

--- a/retroshare-gui/src/gui/statistics/RttStatistics.h
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.h
@@ -22,8 +22,9 @@
 
 #include <QPoint>
 #include <retroshare/rsrtt.h>
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_RttStatistics.h"
-#include "RsAutoUpdatePage.h"
 #include <gui/common/RSGraphWidget.h>
 
 class RttStatisticsWidget ;

--- a/retroshare-gui/src/gui/statistics/TurtleRouterDialog.h
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterDialog.h
@@ -22,9 +22,11 @@
 
 #include <retroshare/rsturtle.h>
 #include <retroshare/rstypes.h>
+
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_TurtleRouterDialog.h"
 #include "ui_TurtleRouterStatistics.h"
-#include "RsAutoUpdatePage.h"
 
 
 class TurtleRouterDialog: public RsAutoUpdatePage, public Ui::TurtleRouterDialogForm

--- a/retroshare-gui/src/gui/statistics/TurtleRouterStatistics.h
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterStatistics.h
@@ -23,8 +23,10 @@
 #include <QPoint>
 #include <retroshare/rsturtle.h>
 #include <retroshare/rstypes.h>
+
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_TurtleRouterStatistics.h"
-#include "RsAutoUpdatePage.h"
 
 class TurtleRouterStatisticsWidget ;
 

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -25,8 +25,8 @@ CONFIG += console
 TARGET = retroshare
 DEFINES += TARGET=\\\"$${TARGET}\\\"
 
-DEPENDPATH  *= $${PWD} $${RS_INCLUDE_DIR} retroshare-gui
-INCLUDEPATH *= $${PWD} retroshare-gui
+DEPENDPATH  *= $${PWD} $${RS_INCLUDE_DIR}
+INCLUDEPATH *= $${PWD}
 
 !include("../../libretroshare/src/use_libretroshare.pri"):error("Including")
 


### PR DESCRIPTION
This is simplifies the include directories needed for plugins.