### PR TITLE
Trying to optimize circles and prevent the spread of unwanted/useless circles

### DIFF
--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -61,7 +61,9 @@ static const uint32_t INDEX_AUTHEN_ADMIN        = 0x00000040; // admin key
 
 #define GXS_MASK "GXS_MASK_HACK"
 
-#define GEN_EXCH_DEBUG	1
+/*
+ *  #define GEN_EXCH_DEBUG	1
+ */
 
 // Data flow in RsGenExchange
 //

--- a/libretroshare/src/pqi/pqiqos.h
+++ b/libretroshare/src/pqi/pqiqos.h
@@ -60,7 +60,6 @@ public:
 		  : _threshold(0.0)
 		  , _counter(0.0)
 		  , _inc(0.0)
-		  , _item_count(0)
 		{}
 		void *pop() 
 		{
@@ -69,7 +68,6 @@ public:
 
 			void *item = _items.front().data ;
 			_items.pop_front() ;
-			--_item_count ;
 
 			return item ;
 		}
@@ -137,12 +135,11 @@ public:
 			_items.push_back(rec) ;
 		}
 
-		uint32_t size() const { return _item_count ; }
+        uint32_t size() const { return _items.size() ; }
 
 		float _threshold ;
 		float _counter ;
 		float _inc ;
-		uint32_t _item_count ;
 
 		std::list<ItemRecord> _items ;
 	};

--- a/libretroshare/src/rsitems/itempriorities.h
+++ b/libretroshare/src/rsitems/itempriorities.h
@@ -25,30 +25,28 @@
 
 // This file centralises QoS priorities for all transfer RsItems. 
 //
-const uint8_t QOS_PRIORITY_UNKNOWN                      = 0 ;
-const uint8_t QOS_PRIORITY_DEFAULT                      = 3 ;
-const uint8_t QOS_PRIORITY_TOP                          = 9 ;
+const uint8_t QOS_PRIORITY_UNKNOWN                    = 0 ;
+const uint8_t QOS_PRIORITY_DEFAULT                    = 3 ;
+const uint8_t QOS_PRIORITY_TOP                        = 9 ;
 
 // Turtle traffic
 //
-const uint8_t QOS_PRIORITY_RS_TURTLE_OPEN_TUNNEL        = 7 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_TUNNEL_OK          = 7 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_REQUEST     = 7 ;
-
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_REQUEST       = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC_REQUEST   = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC_REQUEST  = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP_REQUEST   = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_DATA          = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC           = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC          = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP           = 5 ;
-
-const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_RESULT      = 4 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_ITEM       = 3 ;
-//const uint8_t QOS_PRIORITY_RS_TURTLE_FORWARD_FILE_DATA= 3 ;	// unused
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_DATA       = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA  = 7 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_OPEN_TUNNEL      = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_TUNNEL_OK        = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_REQUEST   = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_REQUEST     = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC_REQUEST = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC_REQUEST= 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP_REQUEST = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_RESULT    = 3 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_DATA        = 3 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC         = 3 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC        = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP         = 3 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_ITEM     = 3 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FORWARD_FILE_DATA= 3 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_DATA     = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA= 7 ;
 
 // File transfer
 //
@@ -56,23 +54,24 @@ const uint8_t QOS_PRIORITY_RS_FILE_REQUEST   			= 5 ;
 const uint8_t QOS_PRIORITY_RS_FILE_CRC_REQUEST 			= 5 ;	
 const uint8_t QOS_PRIORITY_RS_CHUNK_CRC_REQUEST			= 5 ;	
 const uint8_t QOS_PRIORITY_RS_FILE_MAP_REQUEST 			= 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_DATA      			= 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_CRC         			= 5 ;
+const uint8_t QOS_PRIORITY_RS_CACHE_REQUEST   			= 4 ;
+const uint8_t QOS_PRIORITY_RS_FILE_DATA      			= 3 ;
+const uint8_t QOS_PRIORITY_RS_FILE_CRC         			= 3 ;
 const uint8_t QOS_PRIORITY_RS_CHUNK_CRC        			= 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_MAP         			= 5 ;
-//const uint8_t QOS_PRIORITY_RS_CACHE_ITEM      			= 3 ;	// unused
+const uint8_t QOS_PRIORITY_RS_FILE_MAP         			= 3 ;
+const uint8_t QOS_PRIORITY_RS_CACHE_ITEM      			= 3 ;
 
 // Discovery
 //
 const uint8_t QOS_PRIORITY_RS_DISC_HEART_BEAT 			= 8 ;
 const uint8_t QOS_PRIORITY_RS_DISC_ASK_INFO       		= 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_REPLY      			= 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_VERSION    			= 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_REPLY      			= 1 ;
+const uint8_t QOS_PRIORITY_RS_DISC_VERSION    			= 1 ;
 
 const uint8_t QOS_PRIORITY_RS_DISC_CONTACT    			= 2 ; // CONTACT and PGPLIST must have
 const uint8_t QOS_PRIORITY_RS_DISC_PGP_LIST       		= 2 ; // same priority.
 const uint8_t QOS_PRIORITY_RS_DISC_SERVICES    			= 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT    			= 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT    			= 1 ;
 
 // File database
 //
@@ -93,11 +92,11 @@ const uint8_t QOS_PRIORITY_RS_STATUS_ITEM     			= 2 ;
 
 // RTT
 //
-const uint8_t QOS_PRIORITY_RS_RTT_PING                  = 9 ;
+const uint8_t QOS_PRIORITY_RS_RTT_PING               = 9 ;
 
 // BanList
 //
-const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM     			= 3 ;
+const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM     			= 2 ;
 
 // Bandwidth Control.
 //
@@ -110,11 +109,10 @@ const uint8_t QOS_PRIORITY_RS_DSDV_DATA     			= 2 ;
 
 // GXS
 //
-const uint8_t QOS_PRIORITY_RS_GXS_NET                   = 6 ;
-
+const uint8_t QOS_PRIORITY_RS_GXS_NET                   = 3 ;
 // GXS Reputation.
-const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM		= 3;
+const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM		= 2;
 
 // Service Info / Control.
-const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM		    = 8;
+const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM		= 7;
 

--- a/libretroshare/src/rsitems/itempriorities.h
+++ b/libretroshare/src/rsitems/itempriorities.h
@@ -25,28 +25,30 @@
 
 // This file centralises QoS priorities for all transfer RsItems. 
 //
-const uint8_t QOS_PRIORITY_UNKNOWN                    = 0 ;
-const uint8_t QOS_PRIORITY_DEFAULT                    = 3 ;
-const uint8_t QOS_PRIORITY_TOP                        = 9 ;
+const uint8_t QOS_PRIORITY_UNKNOWN                      = 0 ;
+const uint8_t QOS_PRIORITY_DEFAULT                      = 3 ;
+const uint8_t QOS_PRIORITY_TOP                          = 9 ;
 
 // Turtle traffic
 //
-const uint8_t QOS_PRIORITY_RS_TURTLE_OPEN_TUNNEL      = 6 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_TUNNEL_OK        = 6 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_REQUEST   = 6 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_REQUEST     = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC_REQUEST = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC_REQUEST= 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP_REQUEST = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_RESULT    = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_DATA        = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC         = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC        = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP         = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_ITEM     = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FORWARD_FILE_DATA= 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_DATA     = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA= 7 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_OPEN_TUNNEL        = 7 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_TUNNEL_OK          = 7 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_REQUEST     = 7 ;
+
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_REQUEST       = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC_REQUEST   = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC_REQUEST  = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP_REQUEST   = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_DATA          = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC           = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC          = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP           = 5 ;
+
+const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_RESULT      = 4 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_ITEM       = 3 ;
+//const uint8_t QOS_PRIORITY_RS_TURTLE_FORWARD_FILE_DATA= 3 ;	// unused
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_DATA       = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA  = 7 ;
 
 // File transfer
 //
@@ -54,24 +56,23 @@ const uint8_t QOS_PRIORITY_RS_FILE_REQUEST   			= 5 ;
 const uint8_t QOS_PRIORITY_RS_FILE_CRC_REQUEST 			= 5 ;	
 const uint8_t QOS_PRIORITY_RS_CHUNK_CRC_REQUEST			= 5 ;	
 const uint8_t QOS_PRIORITY_RS_FILE_MAP_REQUEST 			= 5 ;
-const uint8_t QOS_PRIORITY_RS_CACHE_REQUEST   			= 4 ;
-const uint8_t QOS_PRIORITY_RS_FILE_DATA      			= 3 ;
-const uint8_t QOS_PRIORITY_RS_FILE_CRC         			= 3 ;
+const uint8_t QOS_PRIORITY_RS_FILE_DATA      			= 5 ;
+const uint8_t QOS_PRIORITY_RS_FILE_CRC         			= 5 ;
 const uint8_t QOS_PRIORITY_RS_CHUNK_CRC        			= 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_MAP         			= 3 ;
-const uint8_t QOS_PRIORITY_RS_CACHE_ITEM      			= 3 ;
+const uint8_t QOS_PRIORITY_RS_FILE_MAP         			= 5 ;
+//const uint8_t QOS_PRIORITY_RS_CACHE_ITEM      			= 3 ;	// unused
 
 // Discovery
 //
 const uint8_t QOS_PRIORITY_RS_DISC_HEART_BEAT 			= 8 ;
 const uint8_t QOS_PRIORITY_RS_DISC_ASK_INFO       		= 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_REPLY      			= 1 ;
-const uint8_t QOS_PRIORITY_RS_DISC_VERSION    			= 1 ;
+const uint8_t QOS_PRIORITY_RS_DISC_REPLY      			= 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_VERSION    			= 2 ;
 
 const uint8_t QOS_PRIORITY_RS_DISC_CONTACT    			= 2 ; // CONTACT and PGPLIST must have
 const uint8_t QOS_PRIORITY_RS_DISC_PGP_LIST       		= 2 ; // same priority.
 const uint8_t QOS_PRIORITY_RS_DISC_SERVICES    			= 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT    			= 1 ;
+const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT    			= 2 ;
 
 // File database
 //
@@ -92,11 +93,11 @@ const uint8_t QOS_PRIORITY_RS_STATUS_ITEM     			= 2 ;
 
 // RTT
 //
-const uint8_t QOS_PRIORITY_RS_RTT_PING               = 9 ;
+const uint8_t QOS_PRIORITY_RS_RTT_PING                  = 9 ;
 
 // BanList
 //
-const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM     			= 2 ;
+const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM     			= 3 ;
 
 // Bandwidth Control.
 //
@@ -109,10 +110,11 @@ const uint8_t QOS_PRIORITY_RS_DSDV_DATA     			= 2 ;
 
 // GXS
 //
-const uint8_t QOS_PRIORITY_RS_GXS_NET                   = 3 ;
+const uint8_t QOS_PRIORITY_RS_GXS_NET                   = 6 ;
+
 // GXS Reputation.
-const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM		= 2;
+const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM		= 3;
 
 // Service Info / Control.
-const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM		= 7;
+const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM		    = 8;
 

--- a/libretroshare/src/services/p3gxscircles.h
+++ b/libretroshare/src/services/p3gxscircles.h
@@ -167,7 +167,7 @@ public:
 	bool	      mIsExternal;
 	RsGxsCircleId mRestrictedCircleId ;	// circle ID that circle is restricted to.
 
-    bool      mHasOwnMembershipMessage;  // Do I have a subscribe/unsubscribe message in the circle group? Will be used to determine if we subscribe to the group or not
+    bool      mDoIAuthorAMembershipMsg;  // Do I have a subscribe/unsubscribe message in the circle group? Will be used to determine if we subscribe to the group or not
     uint32_t  mGroupStatus;              // Copy of the group status from the GXS group.
     uint32_t  mGroupSubscribeFlags;		 // Subscribe flags of the group.
 

--- a/libretroshare/src/services/p3gxscircles.h
+++ b/libretroshare/src/services/p3gxscircles.h
@@ -128,7 +128,7 @@ public:
     uint32_t subscription_flags ;	// combination of  GXS_EXTERNAL_CIRCLE_FLAGS_IN_ADMIN_LIST and  GXS_EXTERNAL_CIRCLE_FLAGS_SUBSCRIBED   
 };
 
-enum CircleEntryCacheStatus: uint8_t {
+enum class CircleEntryCacheStatus: uint8_t {
 	UNKNOWN             = 0x00, // Used to detect uninitialized memory
 	NO_DATA_YET         = 0x01, // Used in the constuctor
 	LOADING             = 0x02, // When the token request to load cache has been sent and no data is present
@@ -167,17 +167,18 @@ public:
 	bool	      mIsExternal;
 	RsGxsCircleId mRestrictedCircleId ;	// circle ID that circle is restricted to.
 
-	uint32_t      mGroupStatus;
-	uint32_t      mGroupSubscribeFlags;
+    bool      mHasOwnMembershipMessage;  // Do I have a subscribe/unsubscribe message in the circle group? Will be used to determine if we subscribe to the group or not
+    uint32_t  mGroupStatus;              // Copy of the group status from the GXS group.
+    uint32_t  mGroupSubscribeFlags;		 // Subscribe flags of the group.
 
 #ifdef SUBSCIRCLES
 	std::set<RsGxsCircleId> mUnprocessedCircles;
 	std::set<RsGxsCircleId> mProcessedCircles;
 #endif
-	std::map<RsGxsId,RsGxsCircleMembershipStatus> mMembershipStatus;
+    std::map<RsGxsId,RsGxsCircleMembershipStatus> mMembershipStatus; // Membership status of each ID cited in the group (including the ones posting a message)
 
-	std::set<RsGxsId> mAllowedGxsIds;	// IDs that are allowed in the circle and have requested membership. This is the official members list.
-	std::set<RsPgpId> mAllowedNodes;
+    std::set<RsGxsId> mAllowedGxsIds; // IDs that are allowed in the circle and have requested membership. This is the official members list.
+    std::set<RsPgpId> mAllowedNodes;  // List of friend nodes allowed in the circle (local circles only)
 
 	RsPeerId mOriginator ; // peer who sent the data, in case we need to ask for ids
 };
@@ -338,7 +339,8 @@ public:
 	bool checkCircleCache();
     
 	bool locked_checkCircleCacheForAutoSubscribe(RsGxsCircleCache &cache);
-	bool locked_processLoadingCacheEntry(RsGxsCircleCache &cache);
+    bool locked_processMembershipMessages(RsGxsCircleCache& cache,const std::vector<RsGxsMsgItem*>& items, GxsMsgReq& messages_to_delete,const std::set<RsGxsId>& own_ids);
+    bool locked_processLoadingCacheEntry(RsGxsCircleCache &cache);
 	bool locked_checkCircleCacheForMembershipUpdate(RsGxsCircleCache &cache);
 
 	p3IdService *mIdentities; // Needed for constructing Circle Info,


### PR DESCRIPTION
To be heavily tested. The new strategy is:
- we subscribe to a circle group (means distribute it and its contents) only if we need to, meaning only if we have posted a subscription request, or a un-subscribe request (both are messages).
- otherwise, the circle is not subscribed.
That should totally prevent the spread of circles crafted to contain every possible identity not beyond the direct friend nodes of the node who created the circle.
Only caveat for now: when leaving a circle, we continue spreading it, since we have to post a unsubscribe message to erase the previous subscription request. Ideally we would need a way to safely erase unsubscribe messages at some point.