### PR TITLE
Priority optimization and fixes

### DIFF
--- a/libretroshare/src/ft/ftserver.cc
+++ b/libretroshare/src/ft/ftserver.cc
@@ -1083,6 +1083,8 @@ bool ftServer::sendTurtleItem(const RsPeerId& peerId,const RsFileHash& hash,RsTu
 		if(!encryptItem(item, hash, encrypted_item))
 			return false ;
 
+                encrypted_item->setPriorityLevel(item->priority_level());
+
 		delete item ;
 
 		mTurtleRouter->sendTurtleData(peerId,encrypted_item) ;

--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -308,7 +308,7 @@ static const uint32_t GROUP_STATS_UPDATE_DELAY                =          240; //
 static const uint32_t GROUP_STATS_UPDATE_NB_PEERS             =            2; // number of peers to which the group stats are asked
 static const uint32_t MAX_ALLOWED_GXS_MESSAGE_SIZE            =       199000; // 200,000 bytes including signature and headers
 static const uint32_t MIN_DELAY_BETWEEN_GROUP_SEARCH          =           40; // dont search same group more than every 40 secs.
-static const uint32_t SAFETY_DELAY_FOR_UNSUCCESSFUL_UPDATE    =         1800; // avoid re-sending the same msg list to a peer who asks twice for the same update in less than this time
+static const uint32_t SAFETY_DELAY_FOR_UNSUCCESSFUL_UPDATE    =            0; // avoid re-sending the same msg list to a peer who asks twice for the same update in less than this time
 
 static const uint32_t RS_NXS_ITEM_ENCRYPTION_STATUS_UNKNOWN             = 0x00 ;
 static const uint32_t RS_NXS_ITEM_ENCRYPTION_STATUS_NO_ERROR            = 0x01 ;

--- a/libretroshare/src/gxstunnel/p3gxstunnel.cc
+++ b/libretroshare/src/gxstunnel/p3gxstunnel.cc
@@ -1221,9 +1221,12 @@ bool p3GxsTunnelService::locked_sendClearTunnelData(RsGxsTunnelDHPublicKeyItem *
     std::cerr << "GxsTunnelService::sendClearTunnelData(): try sending item " << (void*)item << " to peer " << item->PeerId() << std::endl;
 #endif
 
-    // make a TurtleGenericData item out of it, and send it in clear.
-    //
+    // make a RsTurtleGenericData item out of it, and send it in clear.
+    // this is compatible with nodes older than 0.6.6
     RsTurtleGenericDataItem *gitem = new RsTurtleGenericDataItem ;
+    // force item priority to QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA to make the DH exchange faster on 0.6.6+ nodes
+    // this will not affect old nodes
+    gitem->setPriorityLevel(QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA);
 
     RsGxsTunnelSerialiser ser ;
 

--- a/libretroshare/src/rsitems/itempriorities.h
+++ b/libretroshare/src/rsitems/itempriorities.h
@@ -25,70 +25,74 @@
 
 // This file centralises QoS priorities for all transfer RsItems. 
 //
-const uint8_t QOS_PRIORITY_UNKNOWN                    = 0 ;
-const uint8_t QOS_PRIORITY_DEFAULT                    = 3 ;
-const uint8_t QOS_PRIORITY_TOP                        = 9 ;
+const uint8_t QOS_PRIORITY_UNKNOWN                      = 0 ;
+const uint8_t QOS_PRIORITY_DEFAULT                      = 3 ;
+const uint8_t QOS_PRIORITY_TOP                          = 9 ;
 
 // Turtle traffic
 //
-const uint8_t QOS_PRIORITY_RS_TURTLE_OPEN_TUNNEL      = 6 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_TUNNEL_OK        = 6 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_REQUEST   = 6 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_REQUEST     = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC_REQUEST = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC_REQUEST= 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP_REQUEST = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_RESULT    = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_DATA        = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC         = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC        = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP         = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_ITEM     = 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FORWARD_FILE_DATA= 3 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_DATA     = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA= 7 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_OPEN_TUNNEL        = 7 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_TUNNEL_OK          = 7 ;
+
+const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_REQUEST     = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_REQUEST       = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP_REQUEST   = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC_REQUEST   = 6 ; // unused
+const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC_REQUEST  = 6 ; // unused
+
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_DATA          = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP           = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC           = 5 ; // unused
+const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC          = 5 ; // unused
+
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA  = 7 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_RESULT      = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_DATA       = 5 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_ITEM       = 3 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FORWARD_FILE_DATA	= 3 ; // unused
 
 // File transfer
 //
-const uint8_t QOS_PRIORITY_RS_FILE_REQUEST   			= 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_CRC_REQUEST 			= 5 ;	
-const uint8_t QOS_PRIORITY_RS_CHUNK_CRC_REQUEST			= 5 ;	
-const uint8_t QOS_PRIORITY_RS_FILE_MAP_REQUEST 			= 5 ;
-const uint8_t QOS_PRIORITY_RS_CACHE_REQUEST   			= 4 ;
-const uint8_t QOS_PRIORITY_RS_FILE_DATA      			= 3 ;
-const uint8_t QOS_PRIORITY_RS_FILE_CRC         			= 3 ;
-const uint8_t QOS_PRIORITY_RS_CHUNK_CRC        			= 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_MAP         			= 3 ;
-const uint8_t QOS_PRIORITY_RS_CACHE_ITEM      			= 3 ;
+const uint8_t QOS_PRIORITY_RS_FILE_REQUEST              = 6 ;
+const uint8_t QOS_PRIORITY_RS_FILE_MAP_REQUEST          = 6 ;
+const uint8_t QOS_PRIORITY_RS_FILE_CRC_REQUEST          = 6 ; // unused 
+const uint8_t QOS_PRIORITY_RS_CHUNK_CRC_REQUEST         = 6 ;
+
+const uint8_t QOS_PRIORITY_RS_FILE_DATA                 = 5 ;
+const uint8_t QOS_PRIORITY_RS_FILE_MAP                  = 5 ;
+const uint8_t QOS_PRIORITY_RS_FILE_CRC                  = 5 ; // unused
+const uint8_t QOS_PRIORITY_RS_CHUNK_CRC                 = 5 ;
+
+const uint8_t QOS_PRIORITY_RS_CACHE_ITEM                = 3 ; // unused
 
 // Discovery
 //
-const uint8_t QOS_PRIORITY_RS_DISC_HEART_BEAT 			= 8 ;
-const uint8_t QOS_PRIORITY_RS_DISC_ASK_INFO       		= 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_REPLY      			= 1 ;
-const uint8_t QOS_PRIORITY_RS_DISC_VERSION    			= 1 ;
+const uint8_t QOS_PRIORITY_RS_DISC_HEART_BEAT        = 8 ;
+const uint8_t QOS_PRIORITY_RS_DISC_ASK_INFO          = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_REPLY             = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_VERSION           = 2 ;
 
-const uint8_t QOS_PRIORITY_RS_DISC_CONTACT    			= 2 ; // CONTACT and PGPLIST must have
-const uint8_t QOS_PRIORITY_RS_DISC_PGP_LIST       		= 2 ; // same priority.
-const uint8_t QOS_PRIORITY_RS_DISC_SERVICES    			= 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT    			= 1 ;
+const uint8_t QOS_PRIORITY_RS_DISC_CONTACT           = 2 ; // CONTACT and PGPLIST must have
+const uint8_t QOS_PRIORITY_RS_DISC_PGP_LIST          = 2 ; // same priority.
+const uint8_t QOS_PRIORITY_RS_DISC_SERVICES          = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT          = 2 ;
 
 // File database
 //
-const uint8_t QOS_PRIORITY_RS_FAST_SYNC_REQUEST         = 7 ;
-const uint8_t QOS_PRIORITY_RS_SLOW_SYNC_REQUEST         = 3 ;
+const uint8_t QOS_PRIORITY_RS_FAST_SYNC_REQUEST      = 7 ;
+const uint8_t QOS_PRIORITY_RS_SLOW_SYNC_REQUEST      = 3 ;
 
 // Heartbeat.
 //
-const uint8_t QOS_PRIORITY_RS_HEARTBEAT_PULSE 			= 8 ;
+const uint8_t QOS_PRIORITY_RS_HEARTBEAT_PULSE        = 8 ;
 
 // Chat/Msgs
 //
-const uint8_t QOS_PRIORITY_RS_CHAT_ITEM       			= 7 ;
-const uint8_t QOS_PRIORITY_RS_CHAT_AVATAR_ITEM       	= 2 ;
-const uint8_t QOS_PRIORITY_RS_MSG_ITEM               	= 2 ;  // depreciated.
-const uint8_t QOS_PRIORITY_RS_MAIL_ITEM               	= 2 ;  // new mail service
-const uint8_t QOS_PRIORITY_RS_STATUS_ITEM     			= 2 ;
+const uint8_t QOS_PRIORITY_RS_CHAT_ITEM              = 7 ;
+const uint8_t QOS_PRIORITY_RS_CHAT_AVATAR_ITEM       = 2 ;
+const uint8_t QOS_PRIORITY_RS_MSG_ITEM               = 2 ;  // depreciated.
+const uint8_t QOS_PRIORITY_RS_MAIL_ITEM              = 2 ;  // new mail service
+const uint8_t QOS_PRIORITY_RS_STATUS_ITEM            = 2 ;
 
 // RTT
 //
@@ -96,23 +100,24 @@ const uint8_t QOS_PRIORITY_RS_RTT_PING               = 9 ;
 
 // BanList
 //
-const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM     			= 2 ;
+const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM           = 3 ;
 
 // Bandwidth Control.
 //
-const uint8_t QOS_PRIORITY_RS_BWCTRL_ALLOWED_ITEM 		= 9 ;
+const uint8_t QOS_PRIORITY_RS_BWCTRL_ALLOWED_ITEM    = 9 ;
 
 // Dsdv Routing
 //
-const uint8_t QOS_PRIORITY_RS_DSDV_ROUTE     			= 4 ;
-const uint8_t QOS_PRIORITY_RS_DSDV_DATA     			= 2 ;
+const uint8_t QOS_PRIORITY_RS_DSDV_ROUTE             = 4 ;
+const uint8_t QOS_PRIORITY_RS_DSDV_DATA              = 2 ;
 
 // GXS
 //
-const uint8_t QOS_PRIORITY_RS_GXS_NET                   = 3 ;
+const uint8_t QOS_PRIORITY_RS_GXS_NET                = 6 ;
+
 // GXS Reputation.
-const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM		= 2;
+const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM     = 3;
 
 // Service Info / Control.
-const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM		= 7;
+const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM      = 8;
 

--- a/libretroshare/src/rsitems/itempriorities.h
+++ b/libretroshare/src/rsitems/itempriorities.h
@@ -23,7 +23,7 @@
 
 #include <stdint.h>
 
-// This file centralises QoS priorities for all transfer RsItems. 
+// This file centralises QoS priorities for all transfer RsItems
 //
 const uint8_t QOS_PRIORITY_UNKNOWN                      = 0 ;
 const uint8_t QOS_PRIORITY_DEFAULT                      = 3 ;
@@ -41,9 +41,9 @@ const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC_REQUEST   = 6 ; // unused
 const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC_REQUEST  = 6 ; // unused
 
 const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_DATA          = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP           = 5 ;
-const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC           = 5 ; // unused
-const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC          = 5 ; // unused
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_MAP           = 6 ;
+const uint8_t QOS_PRIORITY_RS_TURTLE_FILE_CRC           = 6 ; // unused
+const uint8_t QOS_PRIORITY_RS_TURTLE_CHUNK_CRC          = 6 ; // unused
 
 const uint8_t QOS_PRIORITY_RS_TURTLE_GENERIC_FAST_DATA  = 7 ;
 const uint8_t QOS_PRIORITY_RS_TURTLE_SEARCH_RESULT      = 6 ;
@@ -59,65 +59,67 @@ const uint8_t QOS_PRIORITY_RS_FILE_CRC_REQUEST          = 6 ; // unused
 const uint8_t QOS_PRIORITY_RS_CHUNK_CRC_REQUEST         = 6 ;
 
 const uint8_t QOS_PRIORITY_RS_FILE_DATA                 = 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_MAP                  = 5 ;
-const uint8_t QOS_PRIORITY_RS_FILE_CRC                  = 5 ; // unused
-const uint8_t QOS_PRIORITY_RS_CHUNK_CRC                 = 5 ;
+const uint8_t QOS_PRIORITY_RS_FILE_MAP                  = 6 ;
+const uint8_t QOS_PRIORITY_RS_FILE_CRC                  = 6 ; // unused
+const uint8_t QOS_PRIORITY_RS_CHUNK_CRC                 = 6 ;
 
 const uint8_t QOS_PRIORITY_RS_CACHE_ITEM                = 3 ; // unused
 
 // Discovery
 //
-const uint8_t QOS_PRIORITY_RS_DISC_HEART_BEAT        = 8 ;
-const uint8_t QOS_PRIORITY_RS_DISC_ASK_INFO          = 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_REPLY             = 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_VERSION           = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_HEART_BEAT           = 8 ;
+const uint8_t QOS_PRIORITY_RS_DISC_ASK_INFO             = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_REPLY                = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_VERSION              = 2 ;
 
-const uint8_t QOS_PRIORITY_RS_DISC_CONTACT           = 2 ; // CONTACT and PGPLIST must have
-const uint8_t QOS_PRIORITY_RS_DISC_PGP_LIST          = 2 ; // same priority.
-const uint8_t QOS_PRIORITY_RS_DISC_SERVICES          = 2 ;
-const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT          = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_CONTACT              = 2 ; // CONTACT and PGPLIST must have
+const uint8_t QOS_PRIORITY_RS_DISC_PGP_LIST             = 2 ; // same priority
+const uint8_t QOS_PRIORITY_RS_DISC_SERVICES             = 2 ;
+const uint8_t QOS_PRIORITY_RS_DISC_PGP_CERT             = 2 ;
 
 // File database
 //
-const uint8_t QOS_PRIORITY_RS_FAST_SYNC_REQUEST      = 7 ;
-const uint8_t QOS_PRIORITY_RS_SLOW_SYNC_REQUEST      = 3 ;
+const uint8_t QOS_PRIORITY_RS_FAST_SYNC_REQUEST         = 7 ;
+const uint8_t QOS_PRIORITY_RS_SLOW_SYNC_REQUEST         = 3 ;
 
-// Heartbeat.
+// Heartbeat
 //
-const uint8_t QOS_PRIORITY_RS_HEARTBEAT_PULSE        = 8 ;
+const uint8_t QOS_PRIORITY_RS_HEARTBEAT_PULSE           = 8 ;
 
 // Chat/Msgs
 //
-const uint8_t QOS_PRIORITY_RS_CHAT_ITEM              = 7 ;
-const uint8_t QOS_PRIORITY_RS_CHAT_AVATAR_ITEM       = 2 ;
-const uint8_t QOS_PRIORITY_RS_MSG_ITEM               = 2 ;  // depreciated.
-const uint8_t QOS_PRIORITY_RS_MAIL_ITEM              = 2 ;  // new mail service
-const uint8_t QOS_PRIORITY_RS_STATUS_ITEM            = 2 ;
+const uint8_t QOS_PRIORITY_RS_CHAT_ITEM                 = 7 ;
+const uint8_t QOS_PRIORITY_RS_CHAT_AVATAR_ITEM          = 2 ;
+const uint8_t QOS_PRIORITY_RS_MSG_ITEM                  = 2 ;  // deprecated
+const uint8_t QOS_PRIORITY_RS_MAIL_ITEM                 = 2 ;  // new mail service
+const uint8_t QOS_PRIORITY_RS_STATUS_ITEM               = 2 ;
 
 // RTT
 //
-const uint8_t QOS_PRIORITY_RS_RTT_PING               = 9 ;
+const uint8_t QOS_PRIORITY_RS_RTT_PING                  = 9 ;
 
 // BanList
 //
-const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM           = 3 ;
+const uint8_t QOS_PRIORITY_RS_BANLIST_ITEM              = 3 ;
 
-// Bandwidth Control.
+// Bandwidth Control
 //
-const uint8_t QOS_PRIORITY_RS_BWCTRL_ALLOWED_ITEM    = 9 ;
+const uint8_t QOS_PRIORITY_RS_BWCTRL_ALLOWED_ITEM       = 9 ;
 
-// Dsdv Routing
+// DsDv Routing
 //
-const uint8_t QOS_PRIORITY_RS_DSDV_ROUTE             = 4 ;
-const uint8_t QOS_PRIORITY_RS_DSDV_DATA              = 2 ;
+const uint8_t QOS_PRIORITY_RS_DSDV_ROUTE                = 4 ;
+const uint8_t QOS_PRIORITY_RS_DSDV_DATA                 = 2 ;
 
 // GXS
 //
-const uint8_t QOS_PRIORITY_RS_GXS_NET                = 6 ;
+const uint8_t QOS_PRIORITY_RS_GXS_NET                   = 6 ;
 
-// GXS Reputation.
-const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM     = 3;
+// GXS Reputation
+//
+const uint8_t QOS_PRIORITY_RS_GXSREPUTATION_ITEM        = 3 ;
 
-// Service Info / Control.
-const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM      = 8;
+// Service Info / Control
+//
+const uint8_t QOS_PRIORITY_RS_SERVICE_INFO_ITEM         = 8 ;
 

--- a/libretroshare/src/turtle/rsturtleitem.h
+++ b/libretroshare/src/turtle/rsturtleitem.h
@@ -324,7 +324,7 @@ class RsTurtleGenericTunnelItem: public RsTurtleItem
 class RsTurtleGenericDataItem: public RsTurtleGenericTunnelItem
 {
 	public:
-        RsTurtleGenericDataItem() : RsTurtleGenericTunnelItem(RS_TURTLE_SUBTYPE_GENERIC_DATA), data_size(0), data_bytes(0) { setPriorityLevel(QOS_PRIORITY_RS_TURTLE_FILE_REQUEST);}
+        RsTurtleGenericDataItem() : RsTurtleGenericTunnelItem(RS_TURTLE_SUBTYPE_GENERIC_DATA), data_size(0), data_bytes(0) { setPriorityLevel(QOS_PRIORITY_RS_TURTLE_GENERIC_DATA);}
 		virtual ~RsTurtleGenericDataItem() { if(data_bytes != NULL) free(data_bytes) ; }
 
 		virtual bool shouldStampTunnel() const { return true ; }


### PR DESCRIPTION
This PR changes the priority levels of RS items. It also add a few fixes in the related code.

The improvement will be mostly visible when the UP bandwidth is heavily used:
- smoother GXS sync (no more outqueue clogging caused by repeated identical GXS sync requests)
- faster opening of distant chat session
- faster start of file download

In details:
- Tunnel opening items use priority 7
- Turtle control items such as Search request, File request, File Map request, Chunk CRC request use priority 6
- Turtle search result items uses priority 6 
- Turtle data items use priority 5
- GXS items use priority 6
- Diffie–Hellman key exchange distant chat item uses priority 7

Please test and comment

Update 25nov2020:
- Answers to File Map and Chunk CRC requests now also use priority 6. These items are neither numerous nor big, and they are required to complete file transfers.