### PR TITLE
Fix RsGxsDataAccess req delete when failed.

### DIFF
--- a/libretroshare/src/gxs/rsgxsdataaccess.cc
+++ b/libretroshare/src/gxs/rsgxsdataaccess.cc
@@ -833,8 +833,8 @@ void RsGxsDataAccess::processRequests()
 			}
 			else
 			{
-				req->status = FAILED;
 				mPublicToken[req->token] = FAILED;
+				delete req;//req belongs to no one now
 #ifdef DATA_DEBUG
 				RsDbg() << "  Request failed. Marking as FAILED." << std::endl;
 #endif


### PR DESCRIPTION
278,432 bytes in 8,701 blocks are still reachable in loss record 7,348 of 7,383
  in RsGxsDataAccess::requestGroupInfo(unsigned int&, unsigned int, RsTokReqOptions const&, std::__cxx11::list<t_RsGenericIdType<16u, false, (RsGenericIdType)4>, std::allocator<t_RsGenericIdType<16u, false, (RsGenericIdType)4> > > const&) in /libretroshare/src/gxs/rsgxsdataaccess.cc:67
