### PR TITLE
[WIP] using shared_ptrs in MetaData cache

### DIFF
--- a/libretroshare/src/gxs/rsdataservice.cc
+++ b/libretroshare/src/gxs/rsdataservice.cc
@@ -838,7 +838,8 @@ int RsDataService::storeMessage(const std::list<RsNxsMsg*>& msg)
 
         // This is needed so that mLastPost is correctly updated in the group meta when it is re-loaded.
 
-		mMsgMetaDataCache[msgMetaPtr->mGroupId].updateMeta(msgMetaPtr->mMsgId,*msgMetaPtr);
+        if(mUseCache)
+                mMsgMetaDataCache[msgMetaPtr->mGroupId].updateMeta(msgMetaPtr->mMsgId,*msgMetaPtr);
 
         delete *mit;
     }

--- a/libretroshare/src/gxs/rsdataservice.cc
+++ b/libretroshare/src/gxs/rsdataservice.cc
@@ -1690,30 +1690,28 @@ void RsDataService::debug_printCacheSize()
 {
     RS_STACK_MUTEX(mDbMutex);
 
-    uint32_t nb_items,nb_items_on_deadlist;
-    uint64_t total_size,total_size_of_deadlist;
+    uint32_t nb_items;
+    uint64_t total_size;
 
-    mGrpMetaDataCache.debug_computeSize(nb_items, nb_items_on_deadlist, total_size,total_size_of_deadlist);
+    mGrpMetaDataCache.debug_computeSize(nb_items, total_size);
 
-    RsDbg() << "Cache size: " << std::endl;
-    RsDbg() << "   Groups: " << " total: " << nb_items << " (dead: " << nb_items_on_deadlist << "), size: " << total_size << " (Dead: " << total_size_of_deadlist << ")" << std::endl;
+    RsDbg() << "[CACHE] Cache size: " << std::endl;
+    RsDbg() << "[CACHE]    Groups: " << " total: " << nb_items << ", size: " << total_size << std::endl;
 
-    nb_items = 0,nb_items_on_deadlist = 0;
-    total_size = 0,total_size_of_deadlist = 0;
+    nb_items = 0;
+    total_size = 0;
 
     for(auto& it:mMsgMetaDataCache)
     {
-		uint32_t tmp_nb_items,tmp_nb_items_on_deadlist;
-		uint64_t tmp_total_size,tmp_total_size_of_deadlist;
+        uint32_t tmp_nb_items;
+        uint64_t tmp_total_size;
 
-		it.second.debug_computeSize(tmp_nb_items, tmp_nb_items_on_deadlist, tmp_total_size,tmp_total_size_of_deadlist);
+        it.second.debug_computeSize(tmp_nb_items, tmp_total_size);
 
         nb_items += tmp_nb_items;
-        nb_items_on_deadlist += tmp_nb_items_on_deadlist;
         total_size += tmp_total_size;
-        total_size_of_deadlist += tmp_total_size_of_deadlist;
     }
-    RsDbg() << "   Msgs:   " << " total: " << nb_items << " (dead: " << nb_items_on_deadlist << "), size: " << total_size << " (Dead: " << total_size_of_deadlist << ")" << std::endl;
+    RsDbg() << "[CACHE]    Msgs:   " << " total: " << nb_items << ", size: " << total_size << std::endl;
 }
 
 

--- a/libretroshare/src/gxs/rsdataservice.cc
+++ b/libretroshare/src/gxs/rsdataservice.cc
@@ -708,10 +708,8 @@ std::shared_ptr<RsGxsMsgMetaData> RsDataService::locked_getMsgMeta(RetroCursor &
 
     if(ok)
         return msgMeta;
-    else
-        return nullptr;
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -750,10 +748,9 @@ RsNxsMsg* RsDataService::locked_getMessage(RetroCursor &c)
 
     if(ok)
         return msg;
-    else
-        delete msg;
 
-    return NULL;
+    delete msg;
+    return nullptr;
 }
 
 int RsDataService::storeMessage(const std::list<RsNxsMsg*>& msg)

--- a/libretroshare/src/gxs/rsdataservice.cc
+++ b/libretroshare/src/gxs/rsdataservice.cc
@@ -1059,7 +1059,7 @@ bool RsDataService::validSize(RsNxsGrp* grp) const
     return false;
 }
 
-int RsDataService::retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp *> &grp, bool withMeta, bool /* cache */)
+int RsDataService::retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp *> &grp, bool withMeta, bool cache)
 {
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
     rstime::RsScopeTimer timer("");
@@ -1067,8 +1067,8 @@ int RsDataService::retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp *> &grp, bool
     int requestedGroups = grp.size();
 #endif
 
-    if(grp.empty()){
-
+    if(grp.empty())
+    {
         RsStackMutex stack(mDbMutex);
         RetroCursor* c = mDb->sqlQuery(GRP_TABLE_NAME, withMeta ? mGrpColumnsWithMeta : mGrpColumns, "", "");
 
@@ -1076,7 +1076,7 @@ int RsDataService::retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp *> &grp, bool
         {
                 std::vector<RsNxsGrp*> grps;
 
-                locked_retrieveGroups(c, grps, withMeta ? mColGrp_WithMetaOffset : 0);
+                locked_retrieveGroups(c, grps, withMeta ? mColGrp_WithMetaOffset : 0,cache);
                 std::vector<RsNxsGrp*>::iterator vit = grps.begin();
 
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
@@ -1091,8 +1091,9 @@ int RsDataService::retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp *> &grp, bool
                 delete c;
         }
 
-    }else{
-
+    }
+    else
+    {
         RsStackMutex stack(mDbMutex);
         std::map<RsGxsGroupId, RsNxsGrp *>::iterator mit = grp.begin();
 
@@ -1106,7 +1107,7 @@ int RsDataService::retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp *> &grp, bool
             if(c)
             {
                 std::vector<RsNxsGrp*> grps;
-                locked_retrieveGroups(c, grps, withMeta ? mColGrp_WithMetaOffset : 0);
+                locked_retrieveGroups(c, grps, withMeta ? mColGrp_WithMetaOffset : 0,cache);
 
                 if(!grps.empty())
                 {
@@ -1138,7 +1139,7 @@ int RsDataService::retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp *> &grp, bool
     return 1;
 }
 
-void RsDataService::locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>& grps, int metaOffset)
+void RsDataService::locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>& grps, int metaOffset,bool use_cache)
 {
     if(c){
         bool valid = c->moveToFirst();
@@ -1150,7 +1151,7 @@ void RsDataService::locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>
             if(g)
             {
                 if (metaOffset)
-                    g->metaData = new RsGxsGrpMetaData(*locked_getGrpMeta(*c, metaOffset,true));
+                    g->metaData = new RsGxsGrpMetaData(*locked_getGrpMeta(*c, metaOffset,use_cache));
                 else
                     g->metaData = nullptr;
 
@@ -1161,9 +1162,7 @@ void RsDataService::locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>
     }
 }
 
-int RsDataService::retrieveNxsMsgs(
-        const GxsMsgReq &reqIds, GxsMsgResult &msg, bool /* cache */,
-        bool withMeta )
+int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  bool withMeta, bool cache)
 {
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
     rstime::RsScopeTimer timer("");
@@ -1186,9 +1185,7 @@ int RsDataService::retrieveNxsMsgs(
             RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, withMeta ? mMsgColumnsWithMeta : mMsgColumns, KEY_GRP_ID+ "='" + grpId.toStdString() + "'", "");
 
             if(c)
-            {
-                locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0);
-            }
+                locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0,cache);
 
             delete c;
 		}
@@ -1207,7 +1204,7 @@ int RsDataService::retrieveNxsMsgs(
 
                 if(c)
                 {
-                    locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0);
+                    locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0,cache);
                 }
 
                 delete c;
@@ -1230,7 +1227,7 @@ int RsDataService::retrieveNxsMsgs(
     return 1;
 }
 
-void RsDataService::locked_retrieveMessages(RetroCursor *c, std::vector<RsNxsMsg *> &msgs, int metaOffset)
+void RsDataService::locked_retrieveMessages(RetroCursor *c, std::vector<RsNxsMsg *> &msgs, int metaOffset,bool use_cache)
 {
     bool valid = c->moveToFirst();
     while(valid){
@@ -1238,7 +1235,7 @@ void RsDataService::locked_retrieveMessages(RetroCursor *c, std::vector<RsNxsMsg
 
         if(m){
             if (metaOffset)
-                m->metaData = new RsGxsMsgMetaData(*locked_getMsgMeta(*c, metaOffset,false));
+                m->metaData = new RsGxsMsgMetaData(*locked_getMsgMeta(*c, metaOffset,use_cache));
             else
                 m->metaData = nullptr;
 

--- a/libretroshare/src/gxs/rsdataservice.cc
+++ b/libretroshare/src/gxs/rsdataservice.cc
@@ -1265,12 +1265,13 @@ int RsDataService::retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaRes
 
         // if vector empty then request all messages
 
-        t_MetaDataCache<RsGxsMessageId,RsGxsMsgMetaData>& cache(mMsgMetaDataCache[grpId]);
+        // The pointer here is a trick to not initialize a new cache entry when cache is disabled, while keeping the unique variable all along.
+        t_MetaDataCache<RsGxsMessageId,RsGxsMsgMetaData> *cache(mUseCache? (&mMsgMetaDataCache[grpId]) : nullptr);
 
         if(msgIdV.empty())
         {
-            if(mUseCache && cache.isCacheUpToDate())
-                cache.getFullMetaList(msgMeta[grpId]);
+            if(mUseCache && cache->isCacheUpToDate())
+                cache->getFullMetaList(msgMeta[grpId]);
             else
 			{
 				RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, mMsgMetaColumns, KEY_GRP_ID+ "='" + grpId.toStdString() + "'", "");
@@ -1280,7 +1281,7 @@ int RsDataService::retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaRes
                     locked_retrieveMsgMetaList(c, msgMeta[grpId]);
 
                     if(mUseCache)
-                            cache.setCacheUpToDate(true);
+                            cache->setCacheUpToDate(true);
 				}
                 delete c;
 			}
@@ -1297,7 +1298,7 @@ int RsDataService::retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaRes
 			{
 				const RsGxsMessageId& msgId = *sit;
 
-                auto meta = mUseCache?cache.getMeta(msgId): (std::shared_ptr<RsGxsMsgMetaData>());
+                auto meta = mUseCache?cache->getMeta(msgId): (std::shared_ptr<RsGxsMsgMetaData>());
 
                 if(meta)
                     metaSet.push_back(meta);

--- a/libretroshare/src/gxs/rsdataservice.h
+++ b/libretroshare/src/gxs/rsdataservice.h
@@ -105,11 +105,10 @@ public:
 		}
 	}
 
-    void debug_computeSize(uint32_t& nb_items, uint32_t& nb_items_on_deadlist, uint64_t& total_size,uint64_t& total_size_of_deadlist) const
+    void debug_computeSize(uint32_t& nb_items, uint64_t& total_size) const
     {
         nb_items = mMetas.size();
         total_size = 0;
-        total_size_of_deadlist = 0;
 
         for(auto it:mMetas) total_size += it.second->serial_size();
     }

--- a/libretroshare/src/gxs/rsdataservice.h
+++ b/libretroshare/src/gxs/rsdataservice.h
@@ -143,9 +143,7 @@ public:
 	 * @param strictFilter if true do not request any message if reqIds is empty
      * @return error code
 	 */
-	int retrieveNxsMsgs(
-	        const GxsMsgReq& reqIds, GxsMsgResult& msg, bool cache,
-	        bool withMeta = false );
+    int retrieveNxsMsgs( const GxsMsgReq& reqIds, GxsMsgResult& msg,  bool withMeta = false, bool cache=true );
 
     /*!
      * Retrieves groups, if empty, retrieves all grps, if map is not empty
@@ -274,7 +272,7 @@ private:
      * @param c cursor to result set
      * @param msgs messages retrieved from cursor are stored here
      */
-    void locked_retrieveMessages(RetroCursor* c, std::vector<RsNxsMsg*>& msgs, int metaOffset);
+    void locked_retrieveMessages(RetroCursor* c, std::vector<RsNxsMsg*>& msgs, int metaOffset, bool use_cache);
 
     /*!
      * Retrieves all the grp results from a cursor
@@ -282,7 +280,7 @@ private:
      * @param grps groups retrieved from cursor are stored here
      * @param withMeta this initialise the metaData member of the nxsgroups retrieved
      */
-    void locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>& grps, int metaOffset);
+    void locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>& grps, int metaOffset, bool use_cache);
 
     /*!
      * Retrieves all the msg meta results from a cursor

--- a/libretroshare/src/gxs/rsdataservice.h
+++ b/libretroshare/src/gxs/rsdataservice.h
@@ -81,12 +81,7 @@ public:
 
 	void updateMeta(const ID& id,const MetaDataClass& meta)
 	{
-		auto it = mMetas.find(id) ;
-
-		if(it != mMetas.end())
-			*(it->second) = meta ;
-		else
-            mMetas[id] = std::make_shared<MetaDataClass>();
+        mMetas[id] = std::make_shared<MetaDataClass>(meta);     // create a new shared_ptr to possibly replace the previous one
 	}
 
     void clear(const ID& id)

--- a/libretroshare/src/gxs/rsdataservice.h
+++ b/libretroshare/src/gxs/rsdataservice.h
@@ -138,26 +138,23 @@ public:
      * Retrieves all msgs
      * @param reqIds requested msg ids (grpId,msgId), leave msg list empty to get all msgs for the grp
      * @param msg result of msg retrieval
-	 * @param cache IGNORED whether to store results of this retrieval in memory
-	 *	for faster later retrieval
-	 * @param strictFilter if true do not request any message if reqIds is empty
+     * @param withMeta true will also retrieve metadata
      * @return error code
 	 */
-    int retrieveNxsMsgs( const GxsMsgReq& reqIds, GxsMsgResult& msg,  bool withMeta = false, bool cache=true );
+    int retrieveNxsMsgs(const GxsMsgReq& reqIds, GxsMsgResult& msg,  bool withMeta = false);
 
     /*!
      * Retrieves groups, if empty, retrieves all grps, if map is not empty
      * only retrieve entries, if entry cannot be found, it is removed from map
      * @param grp retrieved groups
      * @param withMeta this initialise the metaData member of the nxsgroups retrieved
-     * @param cache whether to store retrieval in mem for faster later retrieval
      * @return error code
      */
-    int retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp*>& grp, bool withMeta, bool cache);
+    int retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp*>& grp, bool withMeta);
 
     /*!
      * Retrieves meta data of all groups stored (most current versions only)
-     * @param cache whether to store retrieval in mem for faster later retrieval
+     * @param grp output group meta data
      * @return error code
      */
     int retrieveGxsGrpMetaData(std::map<RsGxsGroupId, std::shared_ptr<RsGxsGrpMetaData> > &grp);
@@ -166,7 +163,6 @@ public:
      * Retrieves meta data of all groups stored (most current versions only)
      * @param grpIds grpIds for which to retrieve meta data
      * @param msgMeta meta data result as map of grpIds to array of metadata for that grpId
-     * @param cache whether to store retrieval in mem for faster later retrieval
      * @return error code
      */
     int retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaResult& msgMeta);
@@ -272,7 +268,7 @@ private:
      * @param c cursor to result set
      * @param msgs messages retrieved from cursor are stored here
      */
-    void locked_retrieveMessages(RetroCursor* c, std::vector<RsNxsMsg*>& msgs, int metaOffset, bool use_cache);
+    void locked_retrieveMessages(RetroCursor* c, std::vector<RsNxsMsg*>& msgs, int metaOffset);
 
     /*!
      * Retrieves all the grp results from a cursor
@@ -280,7 +276,7 @@ private:
      * @param grps groups retrieved from cursor are stored here
      * @param withMeta this initialise the metaData member of the nxsgroups retrieved
      */
-    void locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>& grps, int metaOffset, bool use_cache);
+    void locked_retrieveGroups(RetroCursor* c, std::vector<RsNxsGrp*>& grps, int metaOffset);
 
     /*!
      * Retrieves all the msg meta results from a cursor
@@ -300,13 +296,13 @@ private:
      * extracts a msg meta item from a cursor at its
      * current position
      */
-    std::shared_ptr<RsGxsMsgMetaData> locked_getMsgMeta(RetroCursor& c, int colOffset, bool use_cache);
+    std::shared_ptr<RsGxsMsgMetaData> locked_getMsgMeta(RetroCursor& c, int colOffset);
 
     /*!
      * extracts a grp meta item from a cursor at its
      * current position
      */
-    std::shared_ptr<RsGxsGrpMetaData> locked_getGrpMeta(RetroCursor& c, int colOffset, bool use_cache);
+    std::shared_ptr<RsGxsGrpMetaData> locked_getGrpMeta(RetroCursor& c, int colOffset);
 
     /*!
      * extracts a msg item from a cursor at its
@@ -448,6 +444,8 @@ private:
 
     t_MetaDataCache<RsGxsGroupId,RsGxsGrpMetaData> mGrpMetaDataCache;
     std::map<RsGxsGroupId,t_MetaDataCache<RsGxsMessageId,RsGxsMsgMetaData> > mMsgMetaDataCache;
+
+    bool mUseCache;
 };
 
 #endif // RSDATASERVICE_H

--- a/libretroshare/src/gxs/rsgds.h
+++ b/libretroshare/src/gxs/rsgds.h
@@ -142,9 +142,7 @@ public:
 	 * @param strictFilter if true do not request any message if reqIds is empty
      * @return error code
 	 */
-	virtual int retrieveNxsMsgs(
-	        const GxsMsgReq& reqIds, GxsMsgResult& msg, bool cache,
-	        bool withMeta = false ) = 0;
+    virtual int retrieveNxsMsgs( const GxsMsgReq& reqIds, GxsMsgResult& msg, bool withMeta = false , bool cache=true) = 0;
 
     /*!
      * Retrieves all groups stored. Caller owns the memory and is supposed to delete the RsNxsGrp pointers after use.

--- a/libretroshare/src/gxs/rsgds.h
+++ b/libretroshare/src/gxs/rsgds.h
@@ -19,8 +19,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef RSGDS_H
-#define RSGDS_H
+
+#pragma once
 
 #include <set>
 #include <map>
@@ -56,18 +56,16 @@ struct MsgLocMetaData {
 	ContentValue val;
 };
 
-typedef std::map<RsGxsGroupId,RsGxsGrpMetaData*> RsGxsGrpMetaTemporaryMap;
-
 /*!
  * This allows modification of local
  * meta data items of a group
  */
 struct GrpLocMetaData {
-	GrpLocMetaData() = default;
-	GrpLocMetaData(const GrpLocMetaData& meta): grpId(meta.grpId), val(meta.val) {}
+    GrpLocMetaData() = default;
+    GrpLocMetaData(const GrpLocMetaData& meta): grpId(meta.grpId), val(meta.val) {}
 
-	RsGxsGroupId grpId;
-	ContentValue val;
+    RsGxsGroupId grpId;
+    ContentValue val;
 };
 
 /*!
@@ -166,7 +164,7 @@ public:
      *            , if grpId is failed to be retrieved it will be erased from map
      * @return error code
      */
-    virtual int retrieveGxsGrpMetaData(RsGxsGrpMetaTemporaryMap& grp) = 0;
+    virtual int retrieveGxsGrpMetaData(std::map<RsGxsGroupId,std::shared_ptr<RsGxsGrpMetaData> >& grp) = 0;
 
     /*!
      * Retrieves meta data of all groups stored (most current versions only)
@@ -274,8 +272,3 @@ public:
     virtual bool validSize(RsNxsGrp* grp) const = 0 ;
 
 };
-
-
-
-
-#endif // RSGDS_H

--- a/libretroshare/src/gxs/rsgds.h
+++ b/libretroshare/src/gxs/rsgds.h
@@ -142,7 +142,7 @@ public:
 	 * @param strictFilter if true do not request any message if reqIds is empty
      * @return error code
 	 */
-    virtual int retrieveNxsMsgs( const GxsMsgReq& reqIds, GxsMsgResult& msg, bool withMeta = false , bool cache=true) = 0;
+    virtual int retrieveNxsMsgs( const GxsMsgReq& reqIds, GxsMsgResult& msg, bool withMeta = false ) = 0;
 
     /*!
      * Retrieves all groups stored. Caller owns the memory and is supposed to delete the RsNxsGrp pointers after use.
@@ -151,7 +151,7 @@ public:
      * @param cache whether to store retrieval in mem for faster later retrieval
      * @return error code
      */
-    virtual int retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp*>& grp, bool withMeta, bool cache) = 0;
+    virtual int retrieveNxsGrps(std::map<RsGxsGroupId, RsNxsGrp*>& grp, bool withMeta) = 0;
 
     /*!
      * Retrieves meta data of all groups stored (most current versions only)
@@ -168,7 +168,6 @@ public:
      * Retrieves meta data of all groups stored (most current versions only)
      * @param grpIds grpIds for which to retrieve meta data
      * @param msgMeta meta data result as map of grpIds to array of metadata for that grpId
-     * @param cache whether to store retrieval in mem for faster later retrieval
      * @return error code
      */
     virtual int retrieveGxsMsgMetaData(const GxsMsgReq& msgIds, GxsMsgMetaResult& msgMeta) = 0;

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -2802,7 +2802,7 @@ void RsGenExchange::publishGrps()
                                 RsNxsGrpDataTemporaryMap oldGrpDatas;
                                 oldGrpDatas.insert(std::make_pair(grpId, (RsNxsGrp*)NULL));
 
-                                if(mDataStore->retrieveNxsGrps(oldGrpDatas,true,false) && oldGrpDatas.size() == 1)
+                                if(mDataStore->retrieveNxsGrps(oldGrpDatas,true,true) && oldGrpDatas.size() == 1)
                                 {
                                     auto oldGrp = oldGrpDatas[grpId];
                                     c->mOldGroupItem = dynamic_cast<RsGxsGrpItem*>(mSerialiser->deserialise(oldGrp->grp.bin_data,&oldGrp->grp.bin_len));
@@ -3330,7 +3330,7 @@ void RsGenExchange::performUpdateValidation()
 	for(auto vit(mGroupUpdates.begin()); vit != mGroupUpdates.end(); ++vit)
 		grpDatas.insert(std::make_pair(vit->newGrp->grpId, (RsNxsGrp*)NULL));
 
-	if(grpDatas.empty() || !mDataStore->retrieveNxsGrps(grpDatas,true,false))
+    if(grpDatas.empty() || !mDataStore->retrieveNxsGrps(grpDatas,true,true))
     {
         if(grpDatas.empty())
 			RsErr() << __PRETTY_FUNCTION__ << " Validation of multiple group updates failed: no group in list!" << std::endl;

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -3038,7 +3038,7 @@ void RsGenExchange::processRecvdMessages()
 			mDataStore->retrieveGxsGrpMetaData(grpMetas);
 
 	    GxsMsgReq msgIds;
-	    RsNxsMsgDataTemporaryList msgs_to_store;
+        std::list<RsNxsMsg*> msgs_to_store;
 
 #ifdef GEN_EXCH_DEBUG
 	    std::cerr << "  updating received messages:" << std::endl;
@@ -3190,7 +3190,7 @@ void RsGenExchange::processRecvdGroups()
     std::cerr << "RsGenExchange::Processing received groups" << std::endl;
 #endif
 	std::list<RsGxsGroupId> grpIds;
-	RsNxsGrpDataTemporaryList grps_to_store;
+    std::list<RsNxsGrp*> grps_to_store;
 
 	// 1 - retrieve the existing groups so as to check what's not new
 	std::vector<RsGxsGroupId> existingGrpIds;
@@ -3305,7 +3305,7 @@ void RsGenExchange::processRecvdGroups()
 			mNotifications.push_back(c);
 		}
 
-		mDataStore->storeGroup(grps_to_store);
+        mDataStore->storeGroup(grps_to_store);  // deletes the data after storing it.
 #ifdef GEN_EXCH_DEBUG
         std::cerr << "  adding the following grp ids to notification: " << std::endl;
         for(std::list<RsGxsGroupId>::const_iterator it(grpIds.begin());it!=grpIds.end();++it)

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -2380,15 +2380,15 @@ void RsGenExchange::publishMsgs()
                 if(rsPeers)
                     mRoutingClues[msg->metaData->mAuthorId].insert(rsPeers->getOwnId()) ;
                 
-				computeHash(msg->msg, msg->metaData->mHash);
-				mDataAccess->addMsgData(msg);
+                computeHash(msg->msg, msg->metaData->mHash); // (csoler) weird choice: hash should also depend on metadata. Fortunately, msg signature
+                                                             //          signs the holw thing (msg + meta)
 
                 mPublishedMsgs[token] = *msg->metaData;
 
                 RsGxsMsgItem *msg_item = dynamic_cast<RsGxsMsgItem*>(mSerialiser->deserialise(msg->msg.bin_data,&msg->msg.bin_len)) ;
                 msg_item->meta = *msg->metaData;
 
-				delete msg ;
+                mDataAccess->addMsgData(msg);   // msg is deleted by addMsgData()
 
 				msgChangeMap[grpId].push_back(msg_item);
 
@@ -2819,7 +2819,6 @@ void RsGenExchange::publishGrps()
                             else
                                 mDataAccess->addGroupData(grp);
 
-                            delete grp ;
 							groups_to_subscribe.push_back(grpId) ;
 					    }
 					    else
@@ -3343,8 +3342,7 @@ void RsGenExchange::performUpdateValidation()
 #ifdef GEN_EXCH_DEBUG
 	std::cerr << "RsGenExchange::performUpdateValidation() " << std::endl;
 #endif
-
-	RsNxsGrpDataTemporaryList grps ;
+    std::list<RsNxsGrp*> grps; // dont use RsNxsGrpDataTemporaryList because updateGrps will delete the groups
 
 	for(auto vit(mGroupUpdates.begin()); vit != mGroupUpdates.end(); ++vit)
 	{

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -59,6 +59,9 @@ static const uint32_t INDEX_AUTHEN_IDENTITY     = 0x00000010; // identity
 static const uint32_t INDEX_AUTHEN_PUBLISH      = 0x00000020; // publish key
 static const uint32_t INDEX_AUTHEN_ADMIN        = 0x00000040; // admin key
 
+static const uint32_t MSG_CLEANUP_PERIOD     = 60*59; // 59 minutes
+static const uint32_t INTEGRITY_CHECK_PERIOD = 60*31; // 31 minutes
+
 #define GXS_MASK "GXS_MASK_HACK"
 
 /*
@@ -131,9 +134,6 @@ static const uint32_t INDEX_AUTHEN_ADMIN        = 0x00000040; // admin key
 //       |
 //       +--- processRoutingClues() ;
 //
-
-static const uint32_t MSG_CLEANUP_PERIOD     = 60*59; // 59 minutes
-static const uint32_t INTEGRITY_CHECK_PERIOD = 60*31; // 31 minutes
 
 RsGenExchange::RsGenExchange(
         RsGeneralDataService* gds, RsNetworkExchangeService* ns,
@@ -1599,8 +1599,8 @@ bool RsGenExchange::getMsgRelatedData( uint32_t token,
             const RsGxsGrpMsgIdPair& msgId = mit->first;
             std::vector<RsGxsMsgItem*> &gxsMsgItems = msgItems[msgId];
             std::vector<RsNxsMsg*>& nxsMsgsV = mit->second;
-            std::vector<RsNxsMsg*>::iterator vit = nxsMsgsV.begin();
-            for(; vit != nxsMsgsV.end(); ++vit)
+
+            for(auto vit=nxsMsgsV.begin(); vit != nxsMsgsV.end(); ++vit)
             {
                 RsNxsMsg*& msg = *vit;
                 RsItem* item = NULL;

--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -1414,7 +1414,7 @@ bool RsGenExchange::retrieveNxsIdentity(const RsGxsGroupId& group_id,RsNxsGrp *&
     grp[group_id]=nullptr;
     std::map<RsGxsGroupId, RsNxsGrp*>::const_iterator grp_it;
 
-    if(! mDataStore->retrieveNxsGrps(grp, true,true) || grp.end()==(grp_it=grp.find(group_id)) || !grp_it->second)
+    if(! mDataStore->retrieveNxsGrps(grp, true) || grp.end()==(grp_it=grp.find(group_id)) || !grp_it->second)
     {
         std::cerr << "(EE) Cannot retrieve group data for group " << group_id << " in service " << mServType << std::endl;
         return false;
@@ -2802,7 +2802,7 @@ void RsGenExchange::publishGrps()
                                 RsNxsGrpDataTemporaryMap oldGrpDatas;
                                 oldGrpDatas.insert(std::make_pair(grpId, (RsNxsGrp*)NULL));
 
-                                if(mDataStore->retrieveNxsGrps(oldGrpDatas,true,true) && oldGrpDatas.size() == 1)
+                                if(mDataStore->retrieveNxsGrps(oldGrpDatas,true) && oldGrpDatas.size() == 1)
                                 {
                                     auto oldGrp = oldGrpDatas[grpId];
                                     c->mOldGroupItem = dynamic_cast<RsGxsGrpItem*>(mSerialiser->deserialise(oldGrp->grp.bin_data,&oldGrp->grp.bin_len));
@@ -3329,7 +3329,7 @@ void RsGenExchange::performUpdateValidation()
 	for(auto vit(mGroupUpdates.begin()); vit != mGroupUpdates.end(); ++vit)
 		grpDatas.insert(std::make_pair(vit->newGrp->grpId, (RsNxsGrp*)NULL));
 
-    if(grpDatas.empty() || !mDataStore->retrieveNxsGrps(grpDatas,true,true))
+    if(grpDatas.empty() || !mDataStore->retrieveNxsGrps(grpDatas,true))
     {
         if(grpDatas.empty())
 			RsErr() << __PRETTY_FUNCTION__ << " Validation of multiple group updates failed: no group in list!" << std::endl;

--- a/libretroshare/src/gxs/rsgxs.h
+++ b/libretroshare/src/gxs/rsgxs.h
@@ -29,8 +29,8 @@
 
 /* data types used throughout Gxs from netservice to genexchange */
 
-typedef std::map<RsGxsGroupId,      std::vector<const RsGxsMsgMetaData*> > GxsMsgMetaResult;
-typedef std::map<RsGxsGrpMsgIdPair, std::vector<const RsGxsMsgMetaData*> > MsgRelatedMetaResult;
+typedef std::map<RsGxsGroupId,      std::vector<std::shared_ptr<RsGxsMsgMetaData> > > GxsMsgMetaResult;
+typedef std::map<RsGxsGrpMsgIdPair, std::vector<std::shared_ptr<RsGxsMsgMetaData> > > MsgRelatedMetaResult;
 
 // Default values that are used throughout GXS code
 

--- a/libretroshare/src/gxs/rsgxsdataaccess.cc
+++ b/libretroshare/src/gxs/rsgxsdataaccess.cc
@@ -860,7 +860,7 @@ bool RsGxsDataAccess::getGroupSerializedData(GroupSerializedDataReq* req)
 	for(std::list<RsGxsGroupId>::iterator lit = grpIdsOut.begin();lit != grpIdsOut.end();++lit)
 		grpData[*lit] = nullptr;
 
-	bool ok = mDataStore->retrieveNxsGrps(grpData, true, true);
+    bool ok = mDataStore->retrieveNxsGrps(grpData, true);
     req->mGroupData.clear();
 
 	std::map<RsGxsGroupId, RsNxsGrp*>::iterator mit = grpData.begin();
@@ -888,7 +888,7 @@ bool RsGxsDataAccess::getGroupData(GroupDataReq* req)
             grpData[*lit] = nullptr;
         }
 
-        bool ok = mDataStore->retrieveNxsGrps(grpData, true, true);
+        bool ok = mDataStore->retrieveNxsGrps(grpData, true);
 
 	std::map<RsGxsGroupId, RsNxsGrp*>::iterator mit = grpData.begin();
 	for(; mit != grpData.end(); ++mit)
@@ -911,7 +911,7 @@ bool RsGxsDataAccess::getGroupSummary(GroupMetaReq* req)
     for(auto lit = grpIdsOut.begin();lit != grpIdsOut.end(); ++lit)
 		grpMeta[*lit] = nullptr;
 
-	mDataStore->retrieveGxsGrpMetaData(grpMeta);
+    mDataStore->retrieveGxsGrpMetaData(grpMeta);
 
     for(auto mit = grpMeta.begin(); mit != grpMeta.end(); ++mit)
 		req->mGroupMetaData.push_back(mit->second);
@@ -954,7 +954,7 @@ bool RsGxsDataAccess::getMsgData(MsgDataReq* req)
 	if((opts.mMsgFlagMask || opts.mStatusMask) && msgIdOut.empty())
 		return true;
 
-	mDataStore->retrieveNxsMsgs(msgIdOut, req->mMsgData, true, true);
+    mDataStore->retrieveNxsMsgs(msgIdOut, req->mMsgData, true);
 	return true;
 }
 
@@ -1439,7 +1439,7 @@ bool RsGxsDataAccess::getMsgRelatedInfo(MsgRelatedInfoReq *req)
             else if(req->Options.mReqType == GXS_REQUEST_TYPE_MSG_RELATED_DATA)
             {
                 GxsMsgResult msgResult;
-                mDataStore->retrieveNxsMsgs(filteredOutMsgIds, msgResult, true, true);
+                mDataStore->retrieveNxsMsgs(filteredOutMsgIds, msgResult, true);
                 req->mMsgDataResult[grpMsgIdPair] = msgResult[grpId];
             }
         }
@@ -1699,7 +1699,7 @@ bool RsGxsDataAccess::getGroupData(const RsGxsGroupId& grpId, RsNxsGrp *& grp_da
 
     grps[grpId] = nullptr ;
 
-    if(mDataStore->retrieveNxsGrps(grps, false, true))	// the false here is very important: it removes the private key parts.
+    if(mDataStore->retrieveNxsGrps(grps, false))	// the false here is very important: it removes the private key parts.
     {
         grp_data = grps.begin()->second;
         return true;

--- a/libretroshare/src/gxs/rsgxsdataaccess.cc
+++ b/libretroshare/src/gxs/rsgxsdataaccess.cc
@@ -339,7 +339,7 @@ bool RsGxsDataAccess::cancelRequest(const uint32_t& token)
 {
 	RsStackMutex stack(mDataMutex); /****** LOCKED *****/
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 	if (!req)
 	{
 		return false;
@@ -377,7 +377,7 @@ bool RsGxsDataAccess::getGroupSummary(const uint32_t& token, std::list<std::shar
 {
 	RS_STACK_MUTEX(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
 	{
@@ -406,7 +406,7 @@ bool RsGxsDataAccess::getGroupData(const uint32_t& token, std::list<RsNxsGrp*>& 
 {
 	RS_STACK_MUTEX(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
 	{
@@ -442,7 +442,7 @@ bool RsGxsDataAccess::getMsgData(const uint32_t& token, NxsMsgDataResult& msgDat
 
 	RsStackMutex stack(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
     {
@@ -468,12 +468,12 @@ bool RsGxsDataAccess::getMsgData(const uint32_t& token, NxsMsgDataResult& msgDat
 	return true;
 }
 
-bool RsGxsDataAccess::getMsgRelatedData(const uint32_t &token, NxsMsgRelatedDataResult &msgData)
+bool RsGxsDataAccess::getMsgRelatedData(const uint32_t& token, NxsMsgRelatedDataResult& msgData)
 {
 
         RsStackMutex stack(mDataMutex);
 
-        GxsRequest* req = locked_retrieveCompetedRequest(token);
+        GxsRequest* req = locked_retrieveCompletedRequest(token);
 
         if(req == nullptr)
         {
@@ -506,7 +506,7 @@ bool RsGxsDataAccess::getMsgSummary(const uint32_t& token, GxsMsgMetaResult& msg
 
 	RsStackMutex stack(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
     {
@@ -533,7 +533,7 @@ bool RsGxsDataAccess::getMsgRelatedSummary(const uint32_t &token, MsgRelatedMeta
 {
 	RsStackMutex stack(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
 	{
@@ -564,7 +564,7 @@ bool RsGxsDataAccess::getMsgRelatedList(const uint32_t &token, MsgRelatedIdResul
 {
 	RsStackMutex stack(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
 	{
@@ -594,7 +594,7 @@ bool RsGxsDataAccess::getMsgIdList(const uint32_t& token, GxsMsgIdResult& msgIds
 {
 	RsStackMutex stack(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
     {
@@ -621,7 +621,7 @@ bool RsGxsDataAccess::getGroupList(const uint32_t& token, std::list<RsGxsGroupId
 {
 	RsStackMutex stack(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req == nullptr)
     {
@@ -648,7 +648,7 @@ bool RsGxsDataAccess::getGroupStatistic(const uint32_t &token, GxsGroupStatistic
 {
     RsStackMutex stack(mDataMutex);
 
-    GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
     if(req == nullptr)
 	{
@@ -672,7 +672,7 @@ bool RsGxsDataAccess::getServiceStatistic(const uint32_t &token, GxsServiceStati
 {
     RsStackMutex stack(mDataMutex);
 
-    GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
     if(req == nullptr)
     {
@@ -691,7 +691,7 @@ bool RsGxsDataAccess::getServiceStatistic(const uint32_t &token, GxsServiceStati
 	locked_clearRequest(token);
     return true;
 }
-GxsRequest* RsGxsDataAccess::locked_retrieveCompetedRequest(const uint32_t& token)
+GxsRequest* RsGxsDataAccess::locked_retrieveCompletedRequest(const uint32_t& token)
 {
     auto it = mCompletedRequests.find(token) ;
 
@@ -1439,7 +1439,7 @@ bool RsGxsDataAccess::getMsgRelatedInfo(MsgRelatedInfoReq *req)
             else if(req->Options.mReqType == GXS_REQUEST_TYPE_MSG_RELATED_DATA)
             {
                 GxsMsgResult msgResult;
-                mDataStore->retrieveNxsMsgs(filteredOutMsgIds, msgResult, false, true);
+                mDataStore->retrieveNxsMsgs(filteredOutMsgIds, msgResult, true, true);
                 req->mMsgDataResult[grpMsgIdPair] = msgResult[grpId];
             }
         }
@@ -1637,7 +1637,7 @@ bool RsGxsDataAccess::checkRequestStatus( uint32_t token, GxsRequestStatus& stat
 {
 	RS_STACK_MUTEX(mDataMutex);
 
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 #ifdef DATA_DEBUG
     RsDbg() << "CheckRequestStatus: token=" << token ;
@@ -1733,7 +1733,7 @@ void RsGxsDataAccess::tokenList(std::list<uint32_t>& tokens)
 
 bool RsGxsDataAccess::locked_updateRequestStatus( uint32_t token, RsTokenService::GxsRequestStatus status )
 {
-	GxsRequest* req = locked_retrieveCompetedRequest(token);
+    GxsRequest* req = locked_retrieveCompletedRequest(token);
 
 	if(req) req->status = status;
 	else return false;

--- a/libretroshare/src/gxs/rsgxsdataaccess.h
+++ b/libretroshare/src/gxs/rsgxsdataaccess.h
@@ -511,6 +511,8 @@ private:
 
     std::set<std::pair<uint32_t,GxsRequest*> > mRequestQueue;
     std::map<uint32_t, GxsRequest*> mCompletedRequests;
+
+    bool mUseMetaCache;
 };
 
 #endif // RSGXSDATAACCESS_H

--- a/libretroshare/src/gxs/rsgxsdataaccess.h
+++ b/libretroshare/src/gxs/rsgxsdataaccess.h
@@ -276,7 +276,7 @@ private:
      * @param token the value of the token for the request object handle wanted
      * @return the request associated to this token
      */
-    GxsRequest* locked_retrieveCompetedRequest(const uint32_t& token);
+    GxsRequest* locked_retrieveCompletedRequest(const uint32_t& token);
 
     /*!
      * Add a gxs request to queue

--- a/libretroshare/src/gxs/rsgxsdataaccess.h
+++ b/libretroshare/src/gxs/rsgxsdataaccess.h
@@ -28,8 +28,8 @@
 #include "rsgds.h"
 
 
-typedef std::map< RsGxsGroupId, std::map<RsGxsMessageId, const RsGxsMsgMetaData*> > MsgMetaFilter;
-typedef std::map< RsGxsGroupId, RsGxsGrpMetaData* > GrpMetaFilter;
+typedef std::map< RsGxsGroupId, std::map<RsGxsMessageId, std::shared_ptr<RsGxsMsgMetaData> > > MsgMetaFilter;
+typedef std::map< RsGxsGroupId, std::shared_ptr<RsGxsGrpMetaData> > GrpMetaFilter;
 
 bool operator<(const std::pair<uint32_t,GxsRequest*>& p1,const std::pair<uint32_t,GxsRequest*>& p2);
 
@@ -220,7 +220,7 @@ public:
      * @param token request token to be redeemed
      * @param groupInfo
      */
-    bool getGroupSummary(const uint32_t &token, std::list<const RsGxsGrpMetaData*>& groupInfo);
+    bool getGroupSummary(const uint32_t &token, std::list<std::shared_ptr<RsGxsGrpMetaData> > &groupInfo);
 
     /*!
      *
@@ -478,7 +478,7 @@ private:
      * @param meta meta containing currently defined options for msg
      * @return true if msg meta passes all options
      */
-    bool checkMsgFilter(const RsTokReqOptions& opts, const RsGxsMsgMetaData* meta) const;
+    bool checkMsgFilter(const RsTokReqOptions& opts, const std::shared_ptr<RsGxsMsgMetaData>& meta) const;
 
     /*!
      * This applies the options to the meta to find out if the given group satisfies
@@ -487,7 +487,7 @@ private:
      * @param meta meta containing currently defined options for group
      * @return true if group meta passes all options
      */
-    bool checkGrpFilter(const RsTokReqOptions& opts, const RsGxsGrpMetaData* meta) const;
+    bool checkGrpFilter(const RsTokReqOptions& opts, const std::shared_ptr<RsGxsGrpMetaData> &meta) const;
 
 
     /*!

--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -3551,7 +3551,7 @@ void RsGxsNetService::locked_genSendMsgsTransaction(NxsTransaction* tr)
 #endif
 #endif
 
-    mDataStore->retrieveNxsMsgs(msgIds, msgs, false, false);
+    mDataStore->retrieveNxsMsgs(msgIds, msgs, false);
 
     NxsTransaction* newTr = new NxsTransaction();
     newTr->mFlag = NxsTransaction::FLAG_STATE_WAITING_CONFIRM;

--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -637,7 +637,7 @@ void RsGxsNetService::syncWithPeers()
 
     for(RsGxsGrpMetaTemporaryMap::iterator mit = grpMeta.begin(); mit != grpMeta.end(); ++mit)
     {
-	    RsGxsGrpMetaData* meta = mit->second;
+        const auto& meta = mit->second;
 
 	    // This was commented out because we want to know how many messages are available for unsubscribed groups.
 
@@ -674,7 +674,7 @@ void RsGxsNetService::syncWithPeers()
         RsGxsGrpMetaTemporaryMap::const_iterator mmit = toRequest.begin();
         for(; mmit != toRequest.end(); ++mmit)
         {
-            const RsGxsGrpMetaData* meta = mmit->second;
+            const auto& meta = mmit->second;
             const RsGxsGroupId& grpId = mmit->first;
             RsGxsCircleId encrypt_to_this_circle_id ;
 
@@ -928,7 +928,7 @@ void RsGxsNetService::handleRecvSyncGrpStatistics(RsNxsSyncGrpStatsItem *grs)
 
 	    mDataStore->retrieveGxsGrpMetaData(grpMetas);
 
-	    const RsGxsGrpMetaData* grpMeta = grpMetas[grs->grpId];
+        const auto& grpMeta = grpMetas[grs->grpId];
 
 	if(grpMeta == NULL)
             {
@@ -959,7 +959,7 @@ void RsGxsNetService::handleRecvSyncGrpStatistics(RsNxsSyncGrpStatsItem *grs)
 #endif
 	    mDataStore->retrieveGxsMsgMetaData(reqIds, result);
 
-	    const std::vector<const RsGxsMsgMetaData*>& vec(result[grs->grpId]) ;
+        const auto& vec(result[grs->grpId]) ;
 
 	    if(vec.empty())	// that means we don't have any, or there isn't any, but since the default is always 0, no need to send.
 		    return ;
@@ -2196,7 +2196,7 @@ void RsGxsNetService::updateServerSyncTS()
 
 		RS_STACK_MUTEX(mNxsMutex) ;
 
-		const RsGxsGrpMetaData* grpMeta = mit->second;
+        const auto& grpMeta = mit->second;
 #ifdef TO_REMOVE
 		// That accounts for modification of the meta data.
 
@@ -2924,7 +2924,7 @@ void RsGxsNetService::locked_genReqMsgTransaction(NxsTransaction* tr)
     grpMetaMap[grpId] = NULL;
 
     mDataStore->retrieveGxsGrpMetaData(grpMetaMap);
-    const RsGxsGrpMetaData* grpMeta = grpMetaMap[grpId];
+    const auto& grpMeta = grpMetaMap[grpId];
 
     if(grpMeta == NULL) // this should not happen, but just in case...
     {
@@ -2956,17 +2956,16 @@ void RsGxsNetService::locked_genReqMsgTransaction(NxsTransaction* tr)
     reqIds[grpId] = std::set<RsGxsMessageId>();
     GxsMsgMetaResult result;
     mDataStore->retrieveGxsMsgMetaData(reqIds, result);
-    std::vector<const RsGxsMsgMetaData*> &msgMetaV = result[grpId];
+    auto& msgMetaV = result[grpId];
 
 #ifdef NXS_NET_DEBUG_1
     GXSNETDEBUG_PG(item->PeerId(),grpId) << "  retrieving grp message list..." << std::endl;
     GXSNETDEBUG_PG(item->PeerId(),grpId) << "  grp locally contains " << msgMetaV.size() << " messsages." << std::endl;
 #endif
-    std::vector<const RsGxsMsgMetaData*>::const_iterator vit = msgMetaV.begin();
     std::set<RsGxsMessageId> msgIdSet;
 
     // put ids in set for each searching
-    for(; vit != msgMetaV.end(); ++vit)
+    for(auto vit=msgMetaV.begin(); vit != msgMetaV.end(); ++vit)
         msgIdSet.insert((*vit)->mMsgId);
 
     msgMetaV.clear();
@@ -3230,7 +3229,7 @@ void RsGxsNetService::locked_genReqGrpTransaction(NxsTransaction* tr)
         RsNxsSyncGrpItem*& grpSyncItem = *llit;
         const RsGxsGroupId& grpId = grpSyncItem->grpId;
 
-		std::map<RsGxsGroupId, RsGxsGrpMetaData*>::const_iterator metaIter = grpMetaMap.find(grpId);
+        auto metaIter = grpMetaMap.find(grpId);
         bool haveItem = false;
         bool latestVersion = false;
 
@@ -4050,7 +4049,7 @@ void RsGxsNetService::handleRecvSyncGroup(RsNxsSyncGrpReqItem *item)
 
     for(auto mit = grp.begin(); mit != grp.end(); ++mit)
     {
-	    const RsGxsGrpMetaData* grpMeta = mit->second;
+        const auto& grpMeta = mit->second;
 
 	    // Only send info about subscribed groups.
 
@@ -4369,7 +4368,7 @@ void RsGxsNetService::handleRecvSyncMessage(RsNxsSyncMsgReqItem *item,bool item_
     grpMetas[item->grpId] = NULL;
 
     mDataStore->retrieveGxsGrpMetaData(grpMetas);
-    const RsGxsGrpMetaData* grpMeta = grpMetas[item->grpId];
+    const auto& grpMeta = grpMetas[item->grpId];
 
     if(grpMeta == NULL)
     {
@@ -4402,7 +4401,7 @@ void RsGxsNetService::handleRecvSyncMessage(RsNxsSyncMsgReqItem *item,bool item_
 
     GxsMsgMetaResult metaResult;
     mDataStore->retrieveGxsMsgMetaData(req, metaResult);
-    std::vector<const RsGxsMsgMetaData*>& msgMetas = metaResult[item->grpId];
+    auto& msgMetas = metaResult[item->grpId];
 
 #ifdef NXS_NET_DEBUG_0
     GXSNETDEBUG_PG(item->PeerId(),item->grpId) << "   retrieving message meta data." << std::endl;
@@ -4432,7 +4431,7 @@ void RsGxsNetService::handleRecvSyncMessage(RsNxsSyncMsgReqItem *item,bool item_
     {
 	    for(auto vit = msgMetas.begin();vit != msgMetas.end(); ++vit)
 		{
-			const RsGxsMsgMetaData* m = *vit;
+            const auto& m = *vit;
 
             // Check reputation
 
@@ -4577,7 +4576,7 @@ void RsGxsNetService::locked_pushMsgRespFromList(std::list<RsNxsItem*>& itemL, c
 	}
 }
 
-bool RsGxsNetService::canSendMsgIds(std::vector<const RsGxsMsgMetaData*>& msgMetas, const RsGxsGrpMetaData& grpMeta, const RsPeerId& sslId,RsGxsCircleId& should_encrypt_id)
+bool RsGxsNetService::canSendMsgIds(std::vector<std::shared_ptr<RsGxsMsgMetaData> >& msgMetas, const RsGxsGrpMetaData& grpMeta, const RsPeerId& sslId,RsGxsCircleId& should_encrypt_id)
 {
 #ifdef NXS_NET_DEBUG_4
     GXSNETDEBUG_PG(sslId,grpMeta.mGroupId) << "RsGxsNetService::canSendMsgIds() CIRCLE VETTING" << std::endl;
@@ -4929,7 +4928,7 @@ void RsGxsNetService::sharePublishKeysPending()
 
         // Find the publish keys in the retrieved info
 
-        const RsGxsGrpMetaData *grpMeta = grpMetaMap[mit->first] ;
+        const auto& grpMeta = grpMetaMap[mit->first] ;
 
         if(grpMeta == NULL)
         {
@@ -5014,7 +5013,7 @@ void RsGxsNetService::handleRecvPublishKeys(RsNxsGroupPublishKeyItem *item)
 
 	// update the publish keys in this group meta info
 
-	const RsGxsGrpMetaData *grpMeta = grpMetaMap[item->grpId] ;
+    const auto& grpMeta = grpMetaMap[item->grpId] ;
 	if (!grpMeta) {
 		std::cerr << "(EE) RsGxsNetService::handleRecvPublishKeys() grpMeta not found." << std::endl;
 		return ;

--- a/libretroshare/src/gxs/rsgxsnetservice.cc
+++ b/libretroshare/src/gxs/rsgxsnetservice.cc
@@ -926,7 +926,7 @@ void RsGxsNetService::handleRecvSyncGrpStatistics(RsNxsSyncGrpStatsItem *grs)
 	RsGxsGrpMetaTemporaryMap grpMetas;
 	    grpMetas[grs->grpId] = NULL;
 
-	    mDataStore->retrieveGxsGrpMetaData(grpMetas);
+        mDataStore->retrieveGxsGrpMetaData(grpMetas);
 
         const auto& grpMeta = grpMetas[grs->grpId];
 
@@ -957,7 +957,7 @@ void RsGxsNetService::handleRecvSyncGrpStatistics(RsNxsSyncGrpStatsItem *grs)
 #ifdef NXS_NET_DEBUG_6
 	    GXSNETDEBUG_PG(grs->PeerId(),grs->grpId) << "  retrieving message information." << std::endl;
 #endif
-	    mDataStore->retrieveGxsMsgMetaData(reqIds, result);
+        mDataStore->retrieveGxsMsgMetaData(reqIds, result);
 
         const auto& vec(result[grs->grpId]) ;
 
@@ -2115,7 +2115,7 @@ void RsGxsNetService::updateServerSyncTS()
 	{
 		RS_STACK_MUTEX(mNxsMutex) ;
 		// retrieve all grps and update TS
-		mDataStore->retrieveGxsGrpMetaData(gxsMap);
+        mDataStore->retrieveGxsGrpMetaData(gxsMap);
 
 		// (cyril) This code was previously removed because it sounded inconsistent: the list of grps normally does not need to be updated when
 		// new posts arrive. The two (grp list and msg list) are handled independently. Still, when group meta data updates are received,
@@ -3311,7 +3311,7 @@ void RsGxsNetService::locked_genSendGrpsTransaction(NxsTransaction* tr)
 	}
 
 	if(!grps.empty())
-		mDataStore->retrieveNxsGrps(grps, false, false);
+        mDataStore->retrieveNxsGrps(grps, false);
 	else
 	{
 #ifdef NXS_NET_DEBUG_1
@@ -5525,7 +5525,7 @@ bool RsGxsNetService::search(const Sha1CheckSum& hashed_group_id,unsigned char *
 		RsNxsGrpDataTemporaryMap grpDataMap;
 		{
 			RS_STACK_MUTEX(mNxsMutex) ;
-			mDataStore->retrieveNxsGrps(grpDataMap, true, true);
+            mDataStore->retrieveNxsGrps(grpDataMap, true);
             mLastCacheReloadTS = time(NULL);
 		}
 

--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -626,6 +626,8 @@ private:
     std::map<TurtleRequestId,RsGxsGroupId> mSearchRequests;
     std::map<RsGxsGroupId,GroupRequestRecord> mSearchedGroups ;
     rstime_t mLastCacheReloadTS ;
+
+    bool mUseMetaCache;
 };
 
 #endif // RSGXSNETSERVICE_H

--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -399,7 +399,7 @@ private:
      * @return false, if you cannot send to this peer, true otherwise
      */
     bool canSendGrpId(const RsPeerId& sslId, const RsGxsGrpMetaData& grpMeta, std::vector<GrpIdCircleVet>& toVet, bool &should_encrypt);
-    bool canSendMsgIds(std::vector<const RsGxsMsgMetaData*>& msgMetas, const RsGxsGrpMetaData&, const RsPeerId& sslId, RsGxsCircleId &should_encrypt_id);
+    bool canSendMsgIds(std::vector<std::shared_ptr<RsGxsMsgMetaData> > &msgMetas, const RsGxsGrpMetaData&, const RsPeerId& sslId, RsGxsCircleId &should_encrypt_id);
 
     /*!
      * \brief checkPermissionsForFriendGroup

--- a/libretroshare/src/gxs/rsgxsrequesttypes.cc
+++ b/libretroshare/src/gxs/rsgxsrequesttypes.cc
@@ -156,13 +156,6 @@ GroupDataReq::~GroupDataReq()
 	rsstd::delete_all(mGroupData.begin(), mGroupData.end());
 }
 
-MsgMetaReq::~MsgMetaReq()
-{
-	for (GxsMsgMetaResult::iterator it = mMsgMetaData.begin(); it != mMsgMetaData.end(); ++it) {
-		rsstd::delete_all(it->second.begin(), it->second.end());
-	}
-}
-
 MsgDataReq::~MsgDataReq()
 {
 	for (NxsMsgDataResult::iterator it = mMsgData.begin(); it != mMsgData.end(); ++it) {
@@ -172,12 +165,8 @@ MsgDataReq::~MsgDataReq()
 
 MsgRelatedInfoReq::~MsgRelatedInfoReq()
 {
-	for (MsgRelatedMetaResult::iterator metaIt = mMsgMetaResult.begin(); metaIt != mMsgMetaResult.end(); ++metaIt) {
-		rsstd::delete_all(metaIt->second.begin(), metaIt->second.end());
-	}
-	for (NxsMsgRelatedDataResult::iterator dataIt = mMsgDataResult.begin(); dataIt != mMsgDataResult.end(); ++dataIt) {
+    for (NxsMsgRelatedDataResult::iterator dataIt = mMsgDataResult.begin(); dataIt != mMsgDataResult.end(); ++dataIt)
 		rsstd::delete_all(dataIt->second.begin(), dataIt->second.end());
-	}
 }
 std::ostream& MessageSetFlagReq::print(std::ostream& o) const
 {

--- a/libretroshare/src/gxs/rsgxsrequesttypes.h
+++ b/libretroshare/src/gxs/rsgxsrequesttypes.h
@@ -55,7 +55,7 @@ public:
     virtual std::ostream& print(std::ostream& o) const override;
 public:
 	std::list<RsGxsGroupId> mGroupIds;
-	std::list<const RsGxsGrpMetaData*> mGroupMetaData;
+    std::list<std::shared_ptr<RsGxsGrpMetaData> > mGroupMetaData;
 };
 
 class GroupIdReq : public GxsRequest
@@ -98,7 +98,7 @@ public:
 class MsgMetaReq : public GxsRequest
 {
 public:
-	virtual ~MsgMetaReq();
+    virtual ~MsgMetaReq() = default;
 
 	virtual std::ostream& print(std::ostream& o) const override;
 

--- a/libretroshare/src/gxs/rsgxsutil.cc
+++ b/libretroshare/src/gxs/rsgxsutil.cc
@@ -233,7 +233,7 @@ bool RsGxsIntegrityCheck::check(uint16_t service_type, RsGixs *mgixs, RsGeneralD
 
     // first take out all the groups
     std::map<RsGxsGroupId, RsNxsGrp*> grp;
-    mds->retrieveNxsGrps(grp, true, true);
+    mds->retrieveNxsGrps(grp, true, false);
     GxsMsgReq msgIds;
     GxsMsgReq grps;
 
@@ -334,7 +334,7 @@ bool RsGxsIntegrityCheck::check(uint16_t service_type, RsGixs *mgixs, RsGeneralD
     // now messages
     GxsMsgResult msgs;
 
-    mds->retrieveNxsMsgs(grps, msgs, false, true);
+    mds->retrieveNxsMsgs(grps, msgs, true,false);
 
     // Check msg ids and messages. Go through all message IDs referred to by the db call
     // and verify that the message belongs to the nxs msg data that was just retrieved.

--- a/libretroshare/src/gxs/rsgxsutil.cc
+++ b/libretroshare/src/gxs/rsgxsutil.cc
@@ -233,7 +233,7 @@ bool RsGxsIntegrityCheck::check(uint16_t service_type, RsGixs *mgixs, RsGeneralD
 
     // first take out all the groups
     std::map<RsGxsGroupId, RsNxsGrp*> grp;
-    mds->retrieveNxsGrps(grp, true, false);
+    mds->retrieveNxsGrps(grp, true);
     GxsMsgReq msgIds;
     GxsMsgReq grps;
 
@@ -334,7 +334,7 @@ bool RsGxsIntegrityCheck::check(uint16_t service_type, RsGixs *mgixs, RsGeneralD
     // now messages
     GxsMsgResult msgs;
 
-    mds->retrieveNxsMsgs(grps, msgs, true,false);
+    mds->retrieveNxsMsgs(grps, msgs, true);
 
     // Check msg ids and messages. Go through all message IDs referred to by the db call
     // and verify that the message belongs to the nxs msg data that was just retrieved.

--- a/libretroshare/src/gxs/rsgxsutil.cc
+++ b/libretroshare/src/gxs/rsgxsutil.cc
@@ -111,7 +111,7 @@ bool RsGxsCleanUp::clean(RsGxsGroupId& next_group_to_check,std::vector<RsGxsGrou
 
             for(; mit != result.end(); ++mit)
             {
-                std::vector<const RsGxsMsgMetaData*>& metaV = mit->second;
+                auto& metaV = mit->second;
 
                 // First, make a map of which message have a child message. This allows to only delete messages that dont have child messages.
                 // A more accurate way to go would be to compute the time of the oldest message and possibly delete all the branch, but in the
@@ -125,7 +125,7 @@ bool RsGxsCleanUp::clean(RsGxsGroupId& next_group_to_check,std::vector<RsGxsGrou
 
                 for( uint32_t i=0;i<metaV.size();++i)
                 {
-                    const RsGxsMsgMetaData* meta = metaV[i];
+                    const auto& meta = metaV[i];
 
                     bool have_kids = (messages_with_kids.find(meta->mMsgId)!=messages_with_kids.end());
 

--- a/libretroshare/src/gxs/rsgxsutil.h
+++ b/libretroshare/src/gxs/rsgxsutil.h
@@ -102,10 +102,10 @@ public:
     }
 };
 
-typedef std::map<RsGxsGroupId,RsGxsGrpMetaData*>                	  RsGxsGrpMetaTemporaryMap;
-typedef t_RsGxsGenericDataTemporaryMap<RsGxsGroupId,RsNxsGrp>         RsNxsGrpDataTemporaryMap;
+typedef std::map<RsGxsGroupId,            std::shared_ptr<RsGxsGrpMetaData> >   RsGxsGrpMetaTemporaryMap; // This map doesn't need to delete elements since it holds
+typedef std::map<RsGxsGroupId,std::vector<std::shared_ptr<RsGxsMsgMetaData> > > RsGxsMsgMetaTemporaryMap; // shared_ptr's.
 
-typedef t_RsGxsGenericDataTemporaryMapVector<RsGxsMsgMetaData>        RsGxsMsgMetaTemporaryMap ;
+typedef t_RsGxsGenericDataTemporaryMap<RsGxsGroupId,RsNxsGrp>         RsNxsGrpDataTemporaryMap;
 typedef t_RsGxsGenericDataTemporaryMapVector<RsNxsMsg>                RsNxsMsgDataTemporaryMap ;
 
 typedef t_RsGxsGenericDataTemporaryList<RsNxsGrp>                     RsNxsGrpDataTemporaryList ;

--- a/libretroshare/src/gxstrans/p3gxstrans.cc
+++ b/libretroshare/src/gxstrans/p3gxstrans.cc
@@ -389,7 +389,7 @@ void p3GxsTrans::GxsTransIntegrityCleanupThread::run()
     std::list<RsGxsTransId> received_msgs ;
 
     GxsMsgResult msgs;
-    mDs->retrieveNxsMsgs(grps, msgs, false, true);
+    mDs->retrieveNxsMsgs(grps, msgs, true, false);
 
     for(GxsMsgResult::iterator mit = msgs.begin();mit != msgs.end(); ++mit)
     {

--- a/libretroshare/src/gxstrans/p3gxstrans.cc
+++ b/libretroshare/src/gxstrans/p3gxstrans.cc
@@ -361,7 +361,7 @@ void p3GxsTrans::GxsTransIntegrityCleanupThread::run()
     // first take out all the groups
 
     std::map<RsGxsGroupId, RsNxsGrp*> grp;
-    mDs->retrieveNxsGrps(grp, true, true);
+    mDs->retrieveNxsGrps(grp, true);
 
 #ifdef DEBUG_GXSTRANS
     std::cerr << "GxsTransIntegrityCleanupThread::run()" << std::endl;
@@ -389,7 +389,7 @@ void p3GxsTrans::GxsTransIntegrityCleanupThread::run()
     std::list<RsGxsTransId> received_msgs ;
 
     GxsMsgResult msgs;
-    mDs->retrieveNxsMsgs(grps, msgs, true, false);
+    mDs->retrieveNxsMsgs(grps, msgs, true);
 
     for(GxsMsgResult::iterator mit = msgs.begin();mit != msgs.end(); ++mit)
     {

--- a/libretroshare/src/retroshare/rsgxsifacetypes.h
+++ b/libretroshare/src/retroshare/rsgxsifacetypes.h
@@ -66,6 +66,7 @@ struct RsGroupMetaData : RsSerializable
     virtual ~RsGroupMetaData() {}
 
     void operator =(const RsGxsGrpMetaData& rGxsMeta);
+    RsGroupMetaData(const RsGxsGrpMetaData& rGxsMeta) { operator=(rGxsMeta); }
 
     RsGxsGroupId mGroupId;
     std::string mGroupName;
@@ -138,7 +139,9 @@ struct RsMsgMetaData : RsSerializable
 	RsMsgMetaData() : mPublishTs(0), mMsgFlags(0), mMsgStatus(0), mChildTs(0) {}
 
     virtual ~RsMsgMetaData() {}
+
     void operator =(const RsGxsMsgMetaData& rGxsMeta);
+    RsMsgMetaData(const RsGxsMsgMetaData& rGxsMeta) { operator=(rGxsMeta); }
 
     RsGxsGroupId mGroupId;
     RsGxsMessageId mMsgId;

--- a/retroshare-gui/src/gui/feeds/GxsForumMsgItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsForumMsgItem.cpp
@@ -216,8 +216,8 @@ void GxsForumMsgItem::loadGroup()
 
 void GxsForumMsgItem::loadMessage()
 {
-#ifdef DEBUG_ITEM
-	std::cerr << "GxsForumMsgItem::loadMessage()";
+#ifndef DEBUG_ITEM
+    std::cerr << "GxsForumMsgItem::loadMessage(): messageId=" << messageId() << " groupId=" << groupId() ;
 	std::cerr << std::endl;
 #endif
 


### PR DESCRIPTION
Replaced GxsMetaData pointers by shared_ptrs in dataaccess and dataservice, so that we can easily disable caching, more freely get rid of cache items, and have a simpler memory management scheme