### PR TITLE
Fix ValGrind error in PGPHandler::locked_writePrivateTrustDatabase

### DIFF
--- a/libretroshare/src/pgp/pgphandler.cc
+++ b/libretroshare/src/pgp/pgphandler.cc
@@ -1864,6 +1864,8 @@ bool PGPHandler::locked_writePrivateTrustDatabase()
 		return false;
 	}
 	PrivateTrustPacket trustpacket ;
+	/* Clear PrivateTrustPacket struct to suppress valgrind warnings due to the compiler extra padding*/
+	memset(&trustpacket, 0, sizeof(PrivateTrustPacket));
 
 	for( std::map<RsPgpId,PGPCertificateInfo>::iterator it =
 	     _public_keyring_map.begin(); it!=_public_keyring_map.end(); ++it )


### PR DESCRIPTION
Syscall param write(buf) points to uninitialised byte(s)
  in PGPHandler::locked_writePrivateTrustDatabase() in /libretroshare/
src/pgp/pgphandler.cc:1885
  1: write in /usr/lib/libc-2.32.so
  2: _IO_file_write@@GLIBC_2.2.5 in /usr/lib/libc-2.32.so
  3: new_do_write in /usr/lib/libc-2.32.so
  4: _IO_do_write@@GLIBC_2.2.5 in /usr/lib/libc-2.32.so
  5: _IO_file_close_it@@GLIBC_2.2.5 in /usr/lib/libc-2.32.so
  6: fclose@@GLIBC_2.2.5 in /usr/lib/libc-2.32.so
  7: PGPHandler::locked_writePrivateTrustDatabase() in /libretroshare/
src/pgp/pgphandler.cc:1885
  8: PGPHandler::locked_syncTrustDatabase() in /libretroshare/src/pgp/
pgphandler.cc:1987
  9: PGPHandler::syncDatabase() in /libretroshare/src/pgp/pgphandler.cc:
1909
  10: AuthGPG::threadTick() in /libretroshare/src/pqi/authgpg.cc:207
  11: RsTickingThread::run() in /libretroshare/src/util/rsthreads.h:314
  12: RsThread::wrapRun() in /libretroshare/src/util/rsthreads.cc:116
  13: RsThread::rsthread_init(void*) in /libretroshare/src/util/
rsthreads.cc:84
  14: start_thread in /usr/lib/libpthread-2.32.so
  15: clone in /usr/lib/libc-2.32.so
Address 0xcb70379 is 9 bytes inside a block of size 4,096 alloc'd  1:
malloc in /build/valgrind/src/valgrind-3.16.1/coregrind/m_replacemalloc/
vg_replace_malloc.c:307
  2: _IO_file_doallocate in /usr/lib/libc-2.32.so
  3: _IO_doallocbuf in /usr/lib/libc-2.32.so
  4: _IO_file_overflow@@GLIBC_2.2.5 in /usr/lib/libc-2.32.so
  5: _IO_file_xsputn@@GLIBC_2.2.5 in /usr/lib/libc-2.32.so
  6: fwrite in /usr/lib/libc-2.32.so
  7: PGPHandler::locked_writePrivateTrustDatabase() in /libretroshare/
src/pgp/pgphandler.cc:1877
  8: PGPHandler::locked_syncTrustDatabase() in /libretroshare/src/pgp/
pgphandler.cc:1987
  9: PGPHandler::syncDatabase() in /libretroshare/src/pgp/pgphandler.cc:
1909
  10: AuthGPG::threadTick() in /libretroshare/src/pqi/authgpg.cc:207
  11: RsTickingThread::run() in /libretroshare/src/util/rsthreads.h:314
  12: RsThread::wrapRun() in /libretroshare/src/util/rsthreads.cc:116
  13: RsThread::rsthread_init(void*) in /libretroshare/src/util/
rsthreads.cc:84
  14: start_thread in /usr/lib/libpthread-2.32.so
  15: clone in /usr/lib/libc-2.32.so
Uninitialised value was created by a stack allocation  1:
PGPHandler::locked_writePrivateTrustDatabase() in /libretroshare/src/
pgp/pgphandler.cc:1855