### PR TITLE
display RTT stats with 3 decimals

### DIFF
--- a/retroshare-gui/src/gui/statistics/RttStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.cpp
@@ -121,7 +121,7 @@ RttStatisticsGraph::RttStatisticsGraph(QWidget *parent)
 
     src->setCollectionTimeLimit(10*60*1000) ; // 10 mins
     src->setCollectionTimePeriod(1000) ;     // collect every second
-    src->setDigits(1) ;
+    src->setDigits(3) ;
     src->start() ;
 
     setSource(src) ;


### PR DESCRIPTION
Displays RTT statistics with 3 decimals, instead of 1 decimal only.
We need more accuracy, as RTT is reduced now after mutex changes.
Common practice is milliseconds, but I don't know how to do that, so I just increased the number of decimals to 3.
