### PR TITLE
Fix: DHT cannot bootstrap if bdboot.txt is corrupted.

### DIFF
--- a/libbitdht/src/bitdht/bdmanager.cc
+++ b/libbitdht/src/bitdht/bdmanager.cc
@@ -64,8 +64,8 @@
 #define QUERY_UPDATE_PERIOD 8 	// under refresh period - so it'll happen at the MAX_REFRESH_PERIOD
 
 
-bdNodeManager::bdNodeManager(bdNodeId *id, std::string dhtVersion, std::string bootfile, const std::string& filterfile,bdDhtFunctions *fns)
-    :bdNode(id, dhtVersion, bootfile, filterfile, fns, this)
+bdNodeManager::bdNodeManager(bdNodeId *id, std::string dhtVersion, std::string bootfile, std::string bootfilebak, const std::string& filterfile, bdDhtFunctions *fns)
+	:bdNode(id, dhtVersion, bootfile, bootfilebak,filterfile, fns, this)
 {
 	mMode = BITDHT_MGR_STATE_OFF;
 	mDhtFns = fns;

--- a/libbitdht/src/bitdht/bdmanager.h
+++ b/libbitdht/src/bitdht/bdmanager.h
@@ -90,7 +90,7 @@ class bdQueryPeer
 class bdNodeManager: public bdNode, public BitDhtInterface
 {
 	public:
-        bdNodeManager(bdNodeId *id, std::string dhtVersion, std::string bootfile, const std::string &filterfile, bdDhtFunctions *fns);
+		bdNodeManager(bdNodeId *id, std::string dhtVersion, std::string bootfile, std::string bootfilebak, const std::string &filterfile, bdDhtFunctions *fns);
 
 
 void 	iteration();

--- a/libbitdht/src/bitdht/bdnode.cc
+++ b/libbitdht/src/bitdht/bdnode.cc
@@ -67,12 +67,12 @@
 
 #define HISTORY_PERIOD  60
 
-bdNode::bdNode(bdNodeId *ownId, std::string dhtVersion, const std::string& bootfile, const std::string& filterfile, bdDhtFunctions *fns, bdNodeManager *manager)
+bdNode::bdNode(bdNodeId *ownId, std::string dhtVersion, const std::string& bootfile, const std::string &bootfilebak, const std::string& filterfile, bdDhtFunctions *fns, bdNodeManager *manager)
     :mNodeSpace(ownId, fns),
           mFilterPeers(filterfile,ownId, BITDHT_FILTER_REASON_OWNID, fns, manager),
           mQueryMgr(NULL),
           mConnMgr(NULL),
-          mOwnId(*ownId), mDhtVersion(dhtVersion), mStore(bootfile, fns), mFns(fns),
+		  mOwnId(*ownId), mDhtVersion(dhtVersion), mStore(bootfile, bootfilebak, fns), mFns(fns),
           mFriendList(ownId), mHistory(HISTORY_PERIOD)
 {
 	init(); /* (uses this pointers) stuff it - do it here! */

--- a/libbitdht/src/bitdht/bdnode.h
+++ b/libbitdht/src/bitdht/bdnode.h
@@ -117,7 +117,7 @@ class bdNode: public bdNodePublisher
 {
 	public:
 
-    bdNode(bdNodeId *id, std::string dhtVersion, const std::string& bootfile, const std::string& filterfile,
+	bdNode(bdNodeId *id, std::string dhtVersion, const std::string& bootfile, const std::string& bootfilebak, const std::string& filterfile,
 		bdDhtFunctions *fns, bdNodeManager* manager);
 
 	void init(); /* sets up the self referential classes (mQueryMgr & mConnMgr) */

--- a/libbitdht/src/bitdht/bdstore.cc
+++ b/libbitdht/src/bitdht/bdstore.cc
@@ -29,7 +29,7 @@
 
 //#define DEBUG_STORE 1
 
-bdStore::bdStore(std::string file, bdDhtFunctions *fns)
+bdStore::bdStore(std::string file, std::string backupfile, bdDhtFunctions *fns)
 	:mFns(fns)
 {
 #ifdef DEBUG_STORE
@@ -39,6 +39,7 @@ bdStore::bdStore(std::string file, bdDhtFunctions *fns)
 
 	/* read data from file */
 	mStoreFile = file;
+	mStoreFileBak = backupfile;
 
 	reloadFromStore();
 }
@@ -52,12 +53,24 @@ int bdStore::clear()
 
 int bdStore::reloadFromStore()
 {
+	int result = reloadFromStore(mStoreFile);
+	if( result != 0 && store.size() > 0){
+		return result;
+	} else if(mStoreFileBak != "") { //Nothing loaded, try the backup file
+		return reloadFromStore(mStoreFileBak);
+	} else {
+		return 0;
+	}
+}
+
+int bdStore::reloadFromStore(std::string file)
+{
 	clear();
 
-	FILE *fd = fopen(mStoreFile.c_str(), "r");
+	FILE *fd = fopen(file.c_str(), "r");
 	if (!fd)
 	{
-		fprintf(stderr, "Failed to Open File: %s ... No Peers\n", mStoreFile.c_str());
+		fprintf(stderr, "Failed to Open File: %s ... No Peers\n", file.c_str());
 		return 0;
 	}
 		

--- a/libbitdht/src/bitdht/bdstore.h
+++ b/libbitdht/src/bitdht/bdstore.h
@@ -30,10 +30,11 @@ class bdStore
 {
 public:
 
-    bdStore(std::string file, bdDhtFunctions *fns);
+    bdStore(std::string file, std::string backupfile, bdDhtFunctions *fns);
 
     int 	reloadFromStore(); /* for restarts */
-    int	filterIpList(const std::list<struct sockaddr_in> &filteredIPs);
+    int 	reloadFromStore(std::string file);
+    int		filterIpList(const std::list<struct sockaddr_in> &filteredIPs);
     int 	clear();
 
     int 	getPeer(bdPeer *peer);
@@ -43,6 +44,7 @@ public:
 
 protected:
     std::string mStoreFile;
+    std::string mStoreFileBak;
     std::list<bdPeer> store;
     int mIndex;
     bdDhtFunctions *mFns;

--- a/libbitdht/src/udp/udpbitdht.cc
+++ b/libbitdht/src/udp/udpbitdht.cc
@@ -53,7 +53,7 @@
 
 /*************************************/
 
-UdpBitDht::UdpBitDht(UdpPublisher *pub, bdNodeId *id, std::string appVersion, std::string bootstrapfile, const std::string& filteredipfile, bdDhtFunctions *fns)
+UdpBitDht::UdpBitDht(UdpPublisher *pub, bdNodeId *id, std::string appVersion, std::string bootstrapfile, std::string bootstrapfilebak, const std::string& filteredipfile, bdDhtFunctions *fns)
 	:UdpSubReceiver(pub), dhtMtx(true)//, mFns(fns)
 {
 	std::string usedVersion;
@@ -72,7 +72,7 @@ UdpBitDht::UdpBitDht(UdpPublisher *pub, bdNodeId *id, std::string appVersion, st
 
 	/* setup nodeManager */
 	bdStackMutex stack(dhtMtx); /********** MUTEX LOCKED *************/
-    mBitDhtManager = new bdNodeManager(id, usedVersion, bootstrapfile, filteredipfile, fns);
+	mBitDhtManager = new bdNodeManager(id, usedVersion, bootstrapfile, bootstrapfilebak, filteredipfile, fns);
 }
 
 

--- a/libbitdht/src/udp/udpbitdht.h
+++ b/libbitdht/src/udp/udpbitdht.h
@@ -45,7 +45,7 @@ class UdpBitDht: public UdpSubReceiver, public bdThread, public BitDhtInterface
 {
 	public:
 
-    UdpBitDht(UdpPublisher *pub, bdNodeId *id, std::string dhtVersion, std::string bootstrapfile, const std::string& filteredipfile,bdDhtFunctions *fns);
+	UdpBitDht(UdpPublisher *pub, bdNodeId *id, std::string dhtVersion, std::string bootstrapfile, std::string bootstrapfilebak, const std::string& filteredipfile,bdDhtFunctions *fns);
 virtual ~UdpBitDht();
 
 

--- a/libretroshare/src/dht/p3bitdht.cc
+++ b/libretroshare/src/dht/p3bitdht.cc
@@ -113,8 +113,8 @@ virtual int dhtInfoCallback(const bdId *id, uint32_t type, uint32_t flags, std::
 };
 
 
-p3BitDht::p3BitDht(const RsPeerId& id, pqiConnectCb *cb, p3NetMgr *nm, 
-            UdpStack *udpstack, std::string bootstrapfile,const std::string& filteredipfile)
+p3BitDht::p3BitDht(const RsPeerId& id, pqiConnectCb *cb, p3NetMgr *nm,
+			UdpStack *udpstack, std::string bootstrapfile, std::string bootstrapfilebak, const std::string& filteredipfile)
 	:p3Config(), pqiNetAssistConnect(id, cb), mNetMgr(nm), dhtMtx("p3BitDht")
 {
 #ifdef RS_USE_DHT_STUNNER
@@ -163,7 +163,7 @@ p3BitDht::p3BitDht(const RsPeerId& id, pqiConnectCb *cb, p3NetMgr *nm,
 #endif
 
 	/* create dht */
-    mUdpBitDht = new UdpBitDht(udpstack, &mOwnDhtId, dhtVersion, bootstrapfile, filteredipfile,mDhtFns);
+	mUdpBitDht = new UdpBitDht(udpstack, &mOwnDhtId, dhtVersion, bootstrapfile, bootstrapfilebak, filteredipfile,mDhtFns);
 	udpstack->addReceiver(mUdpBitDht);
 
 	/* setup callback to here */

--- a/libretroshare/src/dht/p3bitdht.h
+++ b/libretroshare/src/dht/p3bitdht.h
@@ -141,7 +141,7 @@ class p3BitDht: public p3Config, public pqiNetAssistConnect, public RsDht
 {
 public:
     p3BitDht(const RsPeerId& id, pqiConnectCb *cb, p3NetMgr *nm,
-             UdpStack *udpstack, std::string bootstrapfile, const std::string &filteredipfile);
+			 UdpStack *udpstack, std::string bootstrapfile, std::string bootstrapfilebak, const std::string &filteredipfile);
 
 
     virtual	~p3BitDht();

--- a/libretroshare/src/rsserver/rsinit.cc
+++ b/libretroshare/src/rsserver/rsinit.cc
@@ -989,6 +989,13 @@ int RsServer::StartupRetroShare()
 		bootstrapfile += "/";
 	bootstrapfile += BITDHT_BOOTSTRAP_FILENAME;
 
+	std::string installfile = "";
+#ifndef __ANDROID__
+	installfile = RsAccounts::systemDataDirectory();
+	installfile += "/";
+	installfile += BITDHT_BOOTSTRAP_FILENAME;
+#endif
+
     std::string filteredipfile = RsAccounts::AccountDirectory();
     if (filteredipfile != "")
         filteredipfile += "/";
@@ -1029,10 +1036,6 @@ int RsServer::StartupRetroShare()
 			bdbootRF.close();
 		}
 #else
-		std::string installfile = RsAccounts::systemDataDirectory();
-		installfile += "/";
-		installfile += BITDHT_BOOTSTRAP_FILENAME;
-
 		std::cerr << "Checking for Installation DHT bootstrap file " << installfile << std::endl;
 		if ((installfile != "") && (RsDirUtil::checkFile(installfile,tmp_size)))
 		{
@@ -1080,7 +1083,7 @@ int RsServer::StartupRetroShare()
 		// NEXT BITDHT.
 
 
-		mBitDht = new p3BitDht(ownId, mLinkMgr, mNetMgr, mDhtStack, bootstrapfile, filteredipfile);
+		mBitDht = new p3BitDht(ownId, mLinkMgr, mNetMgr, mDhtStack, bootstrapfile, installfile, filteredipfile);
 
 		// NEXT THE RELAY (NEED to keep a reference for installing RELAYS)
 		UdpRelayReceiver *mRelay = new UdpRelayReceiver(mDhtStack);


### PR DESCRIPTION
If the bdboot.txt file is broken in profile folder, attempt to load the data from the file installed with RS.