### PR TITLE
bandwith management optimization

### DIFF
--- a/libretroshare/src/pqi/pqihandler.cc
+++ b/libretroshare/src/pqi/pqihandler.cc
@@ -406,8 +406,8 @@ int     pqihandler::UpdateRates()
 	RsDbg() << "UPDATE_RATES pqihandler::UpdateRates mod_index " << mod_index << " out_max_bw " << out_max_bw << " remaining out bw " << out_remaining_bw << std::endl;
 #endif
 
-	/* Allocate only half the remaining out bw, if any, to make it smoother */
-	out_max_bw = out_max_bw + out_remaining_bw / 2;
+	/* Allocate only 50 pct the remaining out bw, if any, to make the transition more smooth */
+	out_max_bw = out_max_bw + 0.5 * out_remaining_bw;
 
 	/* Calculate the optimal in_max value, taking into account avail_in and the in bw requested by modules */
 
@@ -437,8 +437,8 @@ int     pqihandler::UpdateRates()
 	RsDbg() << "UPDATE_RATES pqihandler::UpdateRates mod_index " << mod_index << " in_max_bw " << in_max_bw << " remaining in bw " << in_remaining_bw << std::endl;
 #endif
 
-	// allocate all remaining in bw
-	in_max_bw = in_max_bw + in_remaining_bw;
+	// allocate only 75 pct of the remaining in bw, to make the transition more smooth
+	in_max_bw = in_max_bw + 0.75 * in_remaining_bw;
 
 	// store current total in and out used bw 
 	locked_StoreCurrentRates(used_bw_in, used_bw_out);
@@ -474,8 +474,8 @@ int     pqihandler::UpdateRates()
 		{
 			if (rateMap_it->second.mAllowedOut > 0)
 			{	
-				if (out_max_bw > 0.95 * rateMap_it->second.mAllowedOut)
-        	                        mod -> pqi -> setMaxRate(false, 0.95 * rateMap_it->second.mAllowedOut);
+				if (out_max_bw > rateMap_it->second.mAllowedOut)
+        	                        mod -> pqi -> setMaxRate(false, rateMap_it->second.mAllowedOut);
 				else
 					mod -> pqi -> setMaxRate(false, out_max_bw);
 			}

--- a/libretroshare/src/pqi/pqistreamer.cc
+++ b/libretroshare/src/pqi/pqistreamer.cc
@@ -550,14 +550,12 @@ int	pqistreamer::handleoutgoing_locked()
 
 	    if ((!(mBio->cansend(0))) || (maxbytes < sentbytes))
 	    {
-
-#ifdef DEBUG_PACKET_SLICING
-		    if (maxbytes < sentbytes)
-			    std::cerr << "pqistreamer::handleoutgoing_locked() Stopped sending: bio not ready. maxbytes=" << maxbytes << ", sentbytes=" << sentbytes << std::endl;
-		    else
-			    std::cerr << "pqistreamer::handleoutgoing_locked() Stopped sending: sentbytes=" << sentbytes << ", max=" << maxbytes << std::endl;
+#ifdef DEBUG_PQISTREAMER
+		if (sentbytes > maxbytes)
+			RsDbg() << "PQISTREAMER pqistreamer::handleoutgoing_locked() stopped sending max reached, sentbytes " << std::dec << sentbytes << " maxbytes " << maxbytes;
+		else
+			RsDbg() << "PQISTREAMER pqistreamer::handleoutgoing_locked() stopped sending bio not ready, sentbytes " << std::dec << sentbytes << " maxbytes " << maxbytes;
 #endif
-
 		    return 0;
 	    }
 	    // send a out_pkt., else send out_data. unless there is a pending packet. The strategy is to
@@ -1019,12 +1017,11 @@ continue_packet:
     if(maxin > readbytes && mBio->moretoread(0))
 	    goto start_packet_read ;
 
-#ifdef DEBUG_TRANSFERS
-    if (readbytes >= maxin)
-    {
-	    std::cerr << "pqistreamer::handleincoming() Stopped reading as readbytes >= maxin. Read " << readbytes << " bytes ";
-	    std::cerr << std::endl;
-    }
+#ifdef DEBUG_PQISTREAMER
+	if (readbytes > maxin)
+		RsDbg() << "PQISTREAMER pqistreamer::handleincoming() stopped reading max reached, readbytes " << std::dec << readbytes << " maxin " << maxin;
+	else
+		RsDbg() << "PQISTREAMER pqistreamer::handleincoming() stopped reading no more to read, readbytes " << std::dec << readbytes << " maxin " << maxin;
 #endif
 
     return 0;
@@ -1157,18 +1154,19 @@ int     pqistreamer::outAllowedBytes_locked()
 	// this is used to take into account a possible excess of data sent during the previous round
 	mCurrSent -= int(dt * maxout);
 
+	// we dont allow negative value, any quota not used during the previous round is therefore lost
 	if (mCurrSent < 0)
 		mCurrSent = 0;
 
 	mCurrSentTS = t;
 
-	// now calculate the max amount of data allowed to be sent during the next round
-	// we limit this quota to what should be sent at most during mAvgDtOut, taking into account the excess of data possibly sent during the previous round
+	// now calculate the amount of data allowed to be sent during the next round
+	// we take into account the possible excess (but not deficit) of the previous round
+	// (this is handled differently when reading data, see below)
 	double quota = mAvgDtOut * maxout - mCurrSent;
 
 #ifdef DEBUG_PQISTREAMER
-	uint64_t t_now = 1000 * getCurrentTS();
-	std::cerr << std::dec << t_now << " DEBUG_PQISTREAMER pqistreamer::outAllowedBytes_locked PeerId " << this->PeerId().toStdString() << " dt " << (int)(1000 * dt) << "ms, mAvgDtOut " << (int)(1000 * mAvgDtOut) << "ms, maxout " << (int)(maxout) << " bytes/s, mCurrSent " << mCurrSent << " bytes, quota " << (int)(quota) << " bytes" << std::endl;
+	RsDbg() << "PQISTREAMER pqistreamer::outAllowedBytes_locked() dt " << std::dec << (int)(1000 * dt) << "ms, mAvgDtOut " << (int)(1000 * mAvgDtOut) << "ms, maxout " << (int)(maxout) << " bytes/s, mCurrSent " << mCurrSent << " bytes, quota " << (int)(quota) << " bytes";
 #endif
 
 	return quota;
@@ -1198,26 +1196,26 @@ int     pqistreamer::inAllowedBytes()
 
 	double maxin = getMaxRate(true) * 1024.0;
 
-	// this is used to take into account a possible excess of data received during the previous round
+	// this is used to take into account a possible excess/deficit of data received during the previous round
 	mCurrRead -= int(dt * maxin);
 
-	if (mCurrRead < 0)
-		mCurrRead = 0;
+	// we allow negative value up to the average amount of data received during one round
+	// in that case we will use this credit during the next around
+	if (mCurrRead < - mAvgDtIn * maxin)
+		mCurrRead = - mAvgDtIn * maxin;
 
 	mCurrReadTS = t;
 
-	// now calculate the max amount of data allowed to be received during the next round
-	// we limit this quota to what should be received at most during mAvgDtOut, taking into account the excess of data possibly received during the previous round
+	// we now calculate the max amount of data allowed to be received during the next round
+	// we take into account the excess/deficit of the previous round
 	double quota = mAvgDtIn * maxin - mCurrRead;
 
 #ifdef DEBUG_PQISTREAMER
-	uint64_t t_now = 1000 * getCurrentTS();
-	std::cerr << std::dec << t_now << " DEBUG_PQISTREAMER pqistreamer::inAllowedBytes PeerId " << this->PeerId().toStdString() << " dt " << (int)(1000 * dt) << "ms, mAvgDtIn " << (int)(1000 * mAvgDtIn) << "ms, maxin " << (int)(maxin) << " bytes/s, mCurrRead " << mCurrRead << " bytes, quota " << (int)(quota) << " bytes" << std::endl;
+	RsDbg() << "PQISTREAMER pqistreamer::inAllowedBytes() dt " << std::dec << (int)(1000 * dt) << "ms, mAvgDtIn " << (int)(1000 * mAvgDtIn) << "ms, maxin " << (int)(maxin) << " bytes/s, mCurrRead " << mCurrRead << " bytes, quota " << (int)(quota) << " bytes";
 #endif
 
 	return quota;
 }
-
 
 void    pqistreamer::outSentBytes_locked(uint32_t outb)
 {


### PR DESCRIPTION
This PR tries to improve the BW management.
A is sending data to B at a rate near the maximum down set by B.
When A sends more data than B can accept because of its down bandwidth limit, the operating system automatically increases the TCP Received buffer size on B.
This results in an increasing latency, up to several seconds, for any packet traveling from A to B, including high priority packets like RTT or Chat items.

How we fix that:
1. pqistreamer was not correctly handling the irregularity observed in traffic flow: sometimes B was discarding some down BW that should have been kept for the next round of data polling. There is now a credit mechanism for that.
2. in pqihandler the unused down bandwidth was not fully allocated to peers, only 50 pct was. That was supposed to make the operation more smooth but actually resulted in the BW not being fully used, which made issue #1 above even worse.
3. in pqihandler also, in order to avoid overwhelming B reception capacity we now limit the up BW on A side to 95 pct of the down limit provided by B via the BwCtrl service.

Please test and comment