### PR TITLE
Fix JSON API mime type

### DIFF
--- a/libretroshare/src/jsonapi/jsonapi.cpp
+++ b/libretroshare/src/jsonapi/jsonapi.cpp
@@ -101,7 +101,7 @@ JsonApiServer::corsOptionsHeaders =
 	ss << jAns; \
 	std::string&& ans(ss.str()); \
 	auto headers = corsHeaders; \
-	headers.insert({ "Content-Type", "text/json" }); \
+	headers.insert({ "Content-Type", "application/json" }); \
 	headers.insert({ "Content-Length", std::to_string(ans.length()) }); \
 	session->close(RET_CODE, ans, headers)
 


### PR DESCRIPTION
Most clients expect application/json which is standard, instead
of text/json.

I spent 2 hours debugging Reactor's WebClient which just didn't want text/json. Sigh 😫