### PR TITLE
Fix bug in pqihandler preventing UP BW management when bwctrl service is OFF

### DIFF
--- a/libretroshare/src/pqi/pqihandler.cc
+++ b/libretroshare/src/pqi/pqihandler.cc
@@ -470,18 +470,11 @@ int     pqihandler::UpdateRates()
 
 		// for our up bandwidth we take into account the max down provided by peers via BwCtrl
 		// because we don't want to clog our outqueues, the TCP buffers, and the peers inbound queues
+		mod -> pqi -> setMaxRate(false, out_max_bw);
 		if ((rateMap_it = rateMap.find(mod->pqi->PeerId())) != rateMap.end())
-		{
 			if (rateMap_it->second.mAllowedOut > 0)
-			{	
 				if (out_max_bw > rateMap_it->second.mAllowedOut)
         	                        mod -> pqi -> setMaxRate(false, rateMap_it->second.mAllowedOut);
-				else
-					mod -> pqi -> setMaxRate(false, out_max_bw);
-			}
-			else
-				mod -> pqi -> setMaxRate(false, out_max_bw);
-		}
 	}
 
 #ifdef UPDATE_RATES_DEBUG


### PR DESCRIPTION
When bandwidth ctrl service was OFF, there was no call to setMaxRate(false, out_max_bw), and the max UP BW was never updated. 
Even worse, if RS was started with bandwidth ctrl OFF, the max UP BW remained at the start value of 0, making impossible almost any network activity.
