### PR TITLE
Optimization of TR and SR lifespan

### DIFF
--- a/libretroshare/src/turtle/p3turtle.cc
+++ b/libretroshare/src/turtle/p3turtle.cc
@@ -78,9 +78,9 @@ void TS_dumpState() ;
 //    - I updated forward probabilities to higher values, and min them to 1/nb_connected_friends to prevent blocking tunnels.
 //
 static const rstime_t TUNNEL_REQUESTS_LIFE_TIME                = 600 ; /// life time for tunnel requests in the cache.
-static const rstime_t TUNNEL_REQUESTS_RESULT_TIME              =  10 ; /// maximum time during which we process/forward results for known tunnel requests
+static const rstime_t TUNNEL_REQUESTS_RESULT_TIME              =  20 ; /// maximum time during which we process/forward results for known tunnel requests
 static const rstime_t SEARCH_REQUESTS_LIFE_TIME                = 600 ; /// life time for search requests in the cache
-static const rstime_t SEARCH_REQUESTS_RESULT_TIME              =  10 ; /// maximum time during which we process/forward results for known search requests
+static const rstime_t SEARCH_REQUESTS_RESULT_TIME              =  20 ; /// maximum time during which we process/forward results for known search requests
 static const rstime_t REGULAR_TUNNEL_DIGGING_TIME              = 300 ; /// maximum interval between two tunnel digging campaigns.
 static const rstime_t MAXIMUM_TUNNEL_IDLE_TIME                 =  60 ; /// maximum life time of an unused tunnel.
 static const rstime_t EMPTY_TUNNELS_DIGGING_TIME               =  50 ; /// look into tunnels regularly every 50 sec.

--- a/libretroshare/src/turtle/p3turtle.cc
+++ b/libretroshare/src/turtle/p3turtle.cc
@@ -1170,7 +1170,9 @@ void p3turtle::handleSearchResult(RsTurtleSearchResultItem *item)
 		// Nevertheless results received for Search Requests older than SEARCH_REQUESTS_RESULT_TIME are considered obsolete and discarded
 		if (time(NULL) > it->second.time_stamp + SEARCH_REQUESTS_RESULT_TIME)
 		{
+#ifdef P3TURTLE_DEBUG
 			RsDbg() << "TURTLE p3turtle::handleSearchResult Search Request is known, but result arrives too late, dropping";
+#endif
 			return;
 		}
 
@@ -1889,7 +1891,9 @@ void p3turtle::handleTunnelResult(RsTurtleTunnelOkItem *item)
 		// Nevertheless results received for Tunnel Requests older than TUNNEL_REQUESTS_RESULT_TIME are considered obsolete and discarded
 		if (time(NULL) > it->second.time_stamp + TUNNEL_REQUESTS_RESULT_TIME)
 		{
+#ifdef P3TURTLE_DEBUG
 			RsDbg() << "TURTLE p3turtle::handleTunnelResult Tunnel Request is known, but result arrives too late, dropping";
+#endif
 			return;
 		}
 


### PR DESCRIPTION
The purpose of this very simple PR is to improve the management of TR and SR

Tests show that TR and RS bounce a lot in RS network. After being cleared from the cache when their lifespan is reached (at the moment 240 seconds) they come again from somewhere else. We consider them as new and we propagate them again. This can last for hours.

Furthermore sometimes very old TR finally give a positive answer after having bounced everywhere, and a tunnel is opened. Such zombie tunnels don't carry any data and are killed after 1 minute inactivity. In the mean time they will have filled our statistics with garbage and created unneeded traffic between peers.

So in this PR:
- First we increase the lifespan of TR and SR in the turtle cache from 240 to 600 seconds. Keeping known TR & SR in cache during a longer period will help avoid duplicates caused by requests bouncing all over the network. Of course the caches will be initially a little bit bigger, but it does not hurt performance at all.
- Second we drastically reduce the time during which we take into account or forward to our friends the answers we receive to known TR & SR. The previous value of 240 seconds is now reduced to 10 seconds only. Any tunnel result or search result received more than 10 seconds after we put it in cache will be ignored and discarded. 
