### PR TITLE
Fix list overwrite in RsGxsNetService::requestGrp

### DIFF
--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -584,7 +584,7 @@ private:
     std::vector<AuthorPending*> mPendingResp;
     std::vector<GrpCircleVetting*> mPendingCircleVets;
     std::map<RsGxsGroupId,std::set<RsPeerId> > mPendingPublishKeyRecipients ;
-    std::map<RsPeerId, std::list<RsGxsGroupId> > mExplicitRequest;
+	std::map<RsPeerId, std::set<RsGxsGroupId> > mExplicitRequest;
     std::map<RsPeerId, std::set<RsGxsGroupId> > mPartialMsgUpdates ;
 
     // nxs sync optimisation


### PR DESCRIPTION
When requestGrp was called with different groups for same peer multiple
  times between ticks the list was overridden and groups from previous
  call overridden by the new, as a result some requested groups may be
  never really requested. Fix the bug by using a set instead of a list
  so the newly requested groups are uniquely added to the set without
  removing the previously added.