### PR TITLE
Fix define_default_value in android scripts

### DIFF
--- a/build_scripts/Android/prepare-toolchain-clang.sh
+++ b/build_scripts/Android/prepare-toolchain-clang.sh
@@ -28,7 +28,7 @@ function define_default_value()
 	VAR_NAME="${1}"
 	DEFAULT_VALUE="${2}"
 
-	[ -z "${!VAR_NAME}" ] && export ${VAR_NAME}="${DEFAULT_VALUE}"
+	[ -z "${!VAR_NAME}" ] && export ${VAR_NAME}="${DEFAULT_VALUE}" || true
 }
 
 ## You are supposed to provide the following variables according to your system setup

--- a/build_scripts/Android/start_gdbserver.sh
+++ b/build_scripts/Android/start_gdbserver.sh
@@ -36,7 +36,7 @@ function define_default_value()
 	VAR_NAME="${1}"
 	DEFAULT_VALUE="${2}"
 
-	[ -z "${!VAR_NAME}" ] && export ${VAR_NAME}="${DEFAULT_VALUE}"
+	[ -z "${!VAR_NAME}" ] && export ${VAR_NAME}="${DEFAULT_VALUE}" || true
 }
 
 define_default_value ANDROID_APK_PACKAGE "org.retroshare.service"


### PR DESCRIPTION
define_default_value wrongly reported error if the variable was already
  defined, causing the scripts to fail under bash -e, fix it by
  reporting corret exit value