### PR TITLE
Disable animation in file transfer tree view widgets

### DIFF
--- a/retroshare-gui/src/gui/FileTransfer/SearchDialog.ui
+++ b/retroshare-gui/src/gui/FileTransfer/SearchDialog.ui
@@ -223,6 +223,9 @@
       <property name="sortingEnabled">
        <bool>true</bool>
       </property>
+      <property name="animated">
+       <bool>false</bool>
+      </property>
       <column>
        <property name="text">
         <string>KeyWords</string>
@@ -260,6 +263,9 @@
          </property>
          <property name="sortingEnabled">
           <bool>true</bool>
+         </property>
+         <property name="animated">
+          <bool>false</bool>
          </property>
          <column>
           <property name="text">

--- a/retroshare-gui/src/gui/FileTransfer/SharedFilesDialog.ui
+++ b/retroshare-gui/src/gui/FileTransfer/SharedFilesDialog.ui
@@ -366,6 +366,9 @@ border-image: url(:/images/closepressed.png)
          <property name="sortingEnabled">
           <bool>true</bool>
          </property>
+         <property name="animated">
+          <bool>false</bool>
+         </property>
          <attribute name="headerStretchLastSection">
           <bool>false</bool>
          </attribute>

--- a/retroshare-gui/src/gui/FileTransfer/TransfersDialog.ui
+++ b/retroshare-gui/src/gui/FileTransfer/TransfersDialog.ui
@@ -213,6 +213,9 @@
              <property name="sortingEnabled">
               <bool>true</bool>
              </property>
+             <property name="animated">
+              <bool>false</bool>
+             </property>
              <property name="allColumnsShowFocus">
               <bool>false</bool>
              </property>
@@ -279,6 +282,9 @@
               </property>
               <property name="sortingEnabled">
                <bool>true</bool>
+              </property>
+              <property name="animated">
+               <bool>false</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Speed up folder expansion by disabling animation.