### PR TITLE
Implement pull request mechanism in RsGxsNetService

### DIFF
--- a/libretroshare/src/gxs/rsgenexchange.cc
+++ b/libretroshare/src/gxs/rsgenexchange.cc
@@ -2286,8 +2286,9 @@ bool RsGenExchange::processGrpMask(const RsGxsGroupId& grpId, ContentValue &grpC
 
 void RsGenExchange::publishMsgs()
 {
+	bool atLeastOneMessageCreatedSuccessfully = false;
 
-	RS_STACK_MUTEX(mGenMtx) ;
+	RS_STACK_MUTEX(mGenMtx);
 
 	rstime_t now = time(NULL);
 
@@ -2464,6 +2465,8 @@ void RsGenExchange::publishMsgs()
 				// add to published to allow acknowledgement
 				mMsgNotify.insert(std::make_pair(mit->first, std::make_pair(grpId, msgId)));
 				mDataAccess->updatePublicRequestStatus(mit->first, RsTokenService::COMPLETE);
+
+				atLeastOneMessageCreatedSuccessfully = true;
 			}
 			else
 			{
@@ -2497,6 +2500,8 @@ void RsGenExchange::publishMsgs()
 
 			mNotifications.push_back(ch);
 		}
+
+	if(atLeastOneMessageCreatedSuccessfully) mNetService->requestPull();
 }
 
 RsGenExchange::ServiceCreate_Return RsGenExchange::service_CreateGroup(RsGxsGrpItem* /* grpItem */,

--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -250,6 +250,14 @@ public:
 
 	void threadTick() override; /// @see RsTickingThread
 
+
+	/// @see RsNetworkExchangeService
+	void pullFromPeers(std::set<RsPeerId> peers = std::set<RsPeerId>()) override;
+
+	/// @see RsNetworkExchangeService
+	std::error_condition requestPull(
+	        std::set<RsPeerId> peers = std::set<RsPeerId>() ) override;
+
 private:
 
     /*!
@@ -461,22 +469,6 @@ private:
     void locked_pushMsgRespFromList(std::list<RsNxsItem*>& itemL, const RsPeerId& sslId, const RsGxsGroupId &grp_id, const uint32_t& transN);
     
 	void checkDistantSyncState();
-
-	/**
-	 * @brief Pull new stuff from peers
-	 * @param peers peers to pull from, if empty all available peers are pulled
-	 */
-	void pullFromPeers(std::set<RsPeerId> peers = std::set<RsPeerId>());
-
-	/**
-	 * @brief request online peers to pull updates from our node ASAP
-	 * @param peers peers to which request pull from, if empty all available
-	 * peers are requested to pull
-	 * @return success or error details
-	 * TODO: should this be exposed via RsNetworkExchangeService?
-	 */
-	std::error_condition requestPull(
-	        std::set<RsPeerId> peers = std::set<RsPeerId>() );
 
     void syncGrpStatistics();
     void addGroupItemToList(NxsTransaction*& tr,

--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -423,6 +423,8 @@ private:
      */
     void handleRecvPublishKeys(RsNxsGroupPublishKeyItem*) ;
 
+	void handlePullRequest(std::unique_ptr<RsNxsPullRequestItem> item);
+
     /** E: item handlers **/
 
 
@@ -459,7 +461,23 @@ private:
     void locked_pushMsgRespFromList(std::list<RsNxsItem*>& itemL, const RsPeerId& sslId, const RsGxsGroupId &grp_id, const uint32_t& transN);
     
 	void checkDistantSyncState();
-    void syncWithPeers();
+
+	/**
+	 * @brief Pull new stuff from peers
+	 * @param peers peers to pull from, if empty all available peers are pulled
+	 */
+	void pullFromPeers(std::set<RsPeerId> peers = std::set<RsPeerId>());
+
+	/**
+	 * @brief request online peers to pull updates from our node ASAP
+	 * @param peers peers to which request pull from, if empty all available
+	 * peers are requested to pull
+	 * @return success or error details
+	 * TODO: should this be exposed via RsNetworkExchangeService?
+	 */
+	std::error_condition requestPull(
+	        std::set<RsPeerId> peers = std::set<RsPeerId>() );
+
     void syncGrpStatistics();
     void addGroupItemToList(NxsTransaction*& tr,
     		const RsGxsGroupId& grpId, uint32_t& transN,
@@ -559,7 +577,7 @@ private:
     void cleanRejectedMessages();
     void processObserverNotifications();
 
-	void generic_sendItem(RsNxsItem *si);
+	void generic_sendItem(rs_owner_ptr<RsItem> si);
 	RsItem *generic_recvItem();
 
 private:

--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -252,7 +252,8 @@ public:
 
 
 	/// @see RsNetworkExchangeService
-	void pullFromPeers(std::set<RsPeerId> peers = std::set<RsPeerId>()) override;
+	std::error_condition checkUpdatesFromPeers(
+	        std::set<RsPeerId> peers = std::set<RsPeerId>() ) override;
 
 	/// @see RsNetworkExchangeService
 	std::error_condition requestPull(

--- a/libretroshare/src/gxs/rsnxs.h
+++ b/libretroshare/src/gxs/rsnxs.h
@@ -325,4 +325,20 @@ public:
 				return RsReputationLevel::NEUTRAL;
 		}
 	}
+
+	/**
+	 * @brief Pull new stuff from peers
+	 * @param peers peers to pull from, if empty all available peers are pulled
+	 */
+	virtual void pullFromPeers(
+	        std::set<RsPeerId> peers = std::set<RsPeerId>() ) = 0;
+
+	/**
+	 * @brief request online peers to pull updates from our node ASAP
+	 * @param peers peers to which request pull from, if empty all available
+	 * peers are requested to pull
+	 * @return success or error details
+	 */
+	virtual std::error_condition requestPull(
+	        std::set<RsPeerId> peers = std::set<RsPeerId>() ) = 0;
 };

--- a/libretroshare/src/gxs/rsnxs.h
+++ b/libretroshare/src/gxs/rsnxs.h
@@ -26,7 +26,7 @@
 
 #include <set>
 #include <string>
-#include <stdlib.h>
+#include <cstdlib>
 #include <list>
 #include <map>
 

--- a/libretroshare/src/gxs/rsnxs.h
+++ b/libretroshare/src/gxs/rsnxs.h
@@ -327,10 +327,10 @@ public:
 	}
 
 	/**
-	 * @brief Pull new stuff from peers
-	 * @param peers peers to pull from, if empty all available peers are pulled
+	 * @brief Check if new stuff is available from peers
+	 * @param peers peers to check, if empty all available peers are checked
 	 */
-	virtual void pullFromPeers(
+	virtual std::error_condition checkUpdatesFromPeers(
 	        std::set<RsPeerId> peers = std::set<RsPeerId>() ) = 0;
 
 	/**

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -507,7 +507,8 @@ HEADERS +=	util/folderiterator.h \
     util/cxx11retrocompat.h \
     util/cxx14retrocompat.h \
     util/cxx17retrocompat.h \
-            util/rsurl.h
+    util/cxx23retrocompat.h \
+    util/rsurl.h
 
 SOURCES +=	ft/ftchunkmap.cc \
 			ft/ftcontroller.cc \

--- a/libretroshare/src/retroshare/rsgxsforums.h
+++ b/libretroshare/src/retroshare/rsgxsforums.h
@@ -450,6 +450,17 @@ public:
 	        const std::string& matchString,
 	        std::vector<RsGxsSearchResult>& searchResults ) = 0;
 
+	/**
+	 * @brief Request Synchronization with available peers
+	 * Usually syncronization already happen automatically so be carefull
+	 * to call this method only if necessary.
+	 * It has been thinked for use cases like mobile phone where internet
+	 * connection is intermittent and calling this may be useful when a system
+	 * event about connection being available or about to go offline is received
+	 * @jsonapi{development}
+	 * @return Success or error details
+	 */
+	virtual std::error_condition requestSynchronization() = 0;
 
 	////////////////////////////////////////////////////////////////////////////
 	/* Following functions are deprecated and should not be considered a stable

--- a/libretroshare/src/rsitems/itempriorities.h
+++ b/libretroshare/src/rsitems/itempriorities.h
@@ -3,7 +3,9 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2011-2011 by Cyril Soler <csoler@users.sourceforge.net>           *
+ * Copyright (C) 2011-2018 Cyril Soler <csoler@users.sourceforge.net>          *
+ * Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>       *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -21,7 +23,9 @@
  *******************************************************************************/
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
+
+using RsItemPriority = uint8_t;
 
 // This file centralises QoS priorities for all transfer RsItems
 //

--- a/libretroshare/src/rsitems/rsitem.h
+++ b/libretroshare/src/rsitems/rsitem.h
@@ -3,7 +3,8 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright (C) 2018  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2018-2021  Gioacchino Mazzurco <gio@eigenlab.org>             *
+ * Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>       *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -28,6 +29,9 @@
 #include "serialiser/rsserializer.h"
 #include "serialiser/rsserializable.h"
 #include "util/stacktrace.h"
+#include "rsitems/itempriorities.h"
+#include "rsitems/rsserviceids.h"
+
 
 #include <typeinfo>
 
@@ -42,8 +46,13 @@ struct RsItem : RsMemoryManagement::SmallObject, RsSerializable
 
 	virtual ~RsItem();
 
-	/// TODO: Do this make sense with the new serialization system?
-	virtual void clear() = 0;
+	/** TODO: Does the existence of this method make sense with the new
+	 * serialization system? **/
+	virtual void clear()
+	{
+		RS_ERR("Called without being overridden, report to developers");
+		print_stacktrace();
+	}
 
 	/// @deprecated use << ostream operator instead
 	RS_DEPRECATED_FOR("<< ostream operator")
@@ -70,14 +79,21 @@ struct RsItem : RsMemoryManagement::SmallObject, RsSerializable
 	uint8_t PacketType();
 	uint8_t PacketSubType() const;
 
+	/** For Service Packets, @deprecated use the costructor with priority
+	 * paramether instead */
+	RS_DEPRECATED RsItem(uint8_t ver, uint16_t service, uint8_t subtype);
+
 	/// For Service Packets
-	RsItem(uint8_t ver, uint16_t service, uint8_t subtype);
+	RsItem( uint8_t ver, RsServiceType service, uint8_t subtype,
+	        RsItemPriority prio );
+
 	uint16_t PacketService() const; /* combined Packet class/type (mid 16bits) */
 	void setPacketService(uint16_t service);
 
 	inline uint8_t priority_level() const { return _priority_level ;}
 	inline void setPriorityLevel(uint8_t l) { _priority_level = l ;}
 
+#ifdef RS_DEAD_CODE
 	/*
 	 * TODO: This default implementation should be removed and childs structs
 	 * implement ::serial_process(...) as soon as all the codebase is ported to
@@ -90,11 +106,12 @@ struct RsItem : RsMemoryManagement::SmallObject, RsSerializable
 		        "overriding Class is: ", typeid(*this).name() );
 		print_stacktrace();
 	}
+#endif //def RS_DEAD_CODE
 
 protected:
 	uint32_t type;
 	RsPeerId peerId;
-	uint8_t _priority_level;
+	RsItemPriority _priority_level;
 };
 
 /// TODO: Do this make sense with the new serialization system?
@@ -108,8 +125,16 @@ public:
 	uint32_t getRawLength() { return len; }
 	void * getRawData() { return data; }
 
-	virtual void clear() {}
+//	virtual void clear() override {}
 	virtual std::ostream &print(std::ostream &out, uint16_t indent = 0);
+
+	virtual void serial_process(RsGenericSerializer::SerializeJob,
+	                            RsGenericSerializer::SerializeContext&) override
+	{
+		RS_ERR( "called by an item using new serialization system ",
+		        typeid(*this).name() );
+		print_stacktrace();
+	}
 
 private:
 	void *data;

--- a/libretroshare/src/rsitems/rsnxsitems.cc
+++ b/libretroshare/src/rsitems/rsnxsitems.cc
@@ -64,6 +64,12 @@ RsItem *RsNxsSerialiser::create_item(uint16_t service_id,uint8_t item_subtype) c
     if(service_id != SERVICE_TYPE)
         return NULL ;
 
+	switch(static_cast<RsNxsSubtype>(item_subtype))
+	{
+	case RsNxsSubtype::PULL_REQUEST:
+		return new RsNxsPullRequestItem(static_cast<RsServiceType>(service_id));
+	}
+
     switch(item_subtype)
     {
         case RS_PKT_SUBTYPE_NXS_SYNC_GRP_REQ_ITEM:   return new RsNxsSyncGrpReqItem(SERVICE_TYPE) ;

--- a/libretroshare/src/rsitems/rsnxsitems.h
+++ b/libretroshare/src/rsitems/rsnxsitems.h
@@ -35,8 +35,12 @@
 #include "serialiser/rstlvkeys.h"
 #include "gxs/rsgxsdata.h"
 
-// These items have "flag type" numbers, but this is not used.
+enum class RsNxsSubtype : uint8_t
+{
+	PULL_REQUEST = 0x90 /// @see RsNxsPullRequestItem
+};
 
+// These items have "flag type" numbers, but this is not used.
 // TODO: refactor as C++11 enum class
 const uint8_t RS_PKT_SUBTYPE_NXS_SYNC_GRP_REQ_ITEM    = 0x01;
 const uint8_t RS_PKT_SUBTYPE_NXS_SYNC_GRP_ITEM        = 0x02;
@@ -50,10 +54,6 @@ const uint8_t RS_PKT_SUBTYPE_NXS_MSG_ITEM             = 0x20;
 const uint8_t RS_PKT_SUBTYPE_NXS_TRANSAC_ITEM         = 0x40;
 const uint8_t RS_PKT_SUBTYPE_NXS_GRP_PUBLISH_KEY_ITEM = 0x80;
 
-enum class RsNxsSubtype : uint8_t
-{
-	PULL_REQUEST = 0x90 /// @see RsNxsPullRequestItem
-};
 
 #ifdef RS_DEAD_CODE
 // possibility create second service to deal with this functionality
@@ -525,8 +525,9 @@ class RsNxsSerialiser : public RsServiceSerializer
 {
 public:
 
-	explicit RsNxsSerialiser(uint16_t servtype) : RsServiceSerializer(servtype), SERVICE_TYPE(servtype) {}
-	virtual ~RsNxsSerialiser() {}
+	explicit RsNxsSerialiser(uint16_t servtype):
+	    RsServiceSerializer(servtype), SERVICE_TYPE(servtype) {}
+	virtual ~RsNxsSerialiser() = default;
 
 
     virtual RsItem *create_item(uint16_t service_id,uint8_t item_subtype) const ;

--- a/libretroshare/src/serialiser/rsserial.cc
+++ b/libretroshare/src/serialiser/rsserial.cc
@@ -3,7 +3,9 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2007-2008 by Robert Fernie <retroshare@lunamutt.com>              *
+ * Copyright (C) 2007-2008  Robert Fernie <retroshare@lunamutt.com>            *
+ * Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>       *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -20,20 +22,19 @@
  *                                                                             *
  *******************************************************************************/
 
-#include "serialiser/rsbaseserial.h"
-
-#include "util/rsthreads.h"
-#include "util/rsstring.h"
-#include "util/rsprint.h"
-
-#include "rsitems/rsitem.h"
-#include "rsitems/itempriorities.h"
-
-#include <math.h>
+#include <cmath>
 #include <map>
 #include <vector>
 #include <iostream>
 #include <typeinfo>
+
+#include "serialiser/rsbaseserial.h"
+#include "util/cxx23retrocompat.h"
+#include "util/rsthreads.h"
+#include "util/rsstring.h"
+#include "util/rsprint.h"
+#include "rsitems/rsitem.h"
+#include "rsitems/itempriorities.h"
 
 
 /***
@@ -166,10 +167,16 @@ uint8_t    RsItem::PacketSubType() const
 	/* For Service Packets */	
 RsItem::RsItem(uint8_t ver, uint16_t service, uint8_t subtype)
 {
-	_priority_level = QOS_PRIORITY_UNKNOWN ;	// This value triggers PQIInterface to complain about undefined priorities
+	// This value triggers PQIInterface to complain about undefined priorities
+	_priority_level = QOS_PRIORITY_UNKNOWN;
 	type = (ver << 24) + (service << 8) + subtype;
-	return;
 }
+
+RsItem::RsItem( uint8_t ver, RsServiceType service, uint8_t subtype,
+        RsItemPriority prio ):
+    type(static_cast<uint32_t>(
+             (ver << 24) + (std::to_underlying(service) << 8) + subtype )),
+    _priority_level(prio) {}
 
 uint16_t    RsItem::PacketService() const
 {

--- a/libretroshare/src/services/p3gxsforums.cc
+++ b/libretroshare/src/services/p3gxsforums.cc
@@ -900,10 +900,19 @@ bool p3GxsForums::markRead(const RsGxsGrpMsgIdPair& msgId, bool read)
 bool p3GxsForums::subscribeToForum(const RsGxsGroupId& groupId, bool subscribe )
 {
 	uint32_t token;
-    if( !RsGenExchange::subscribeToGroup(token, groupId, subscribe) || waitToken(token) != RsTokenService::COMPLETE ) return false;
+	if( !RsGenExchange::subscribeToGroup(token, groupId, subscribe) ||
+	        waitToken(token) != RsTokenService::COMPLETE ) return false;
 
-    RsGxsGroupId grp;
-    acknowledgeGrp(token,grp);
+	RsGxsGroupId grp;
+	acknowledgeGrp(token, grp);
+
+	/* Since subscribe has been requested, the caller is most probably
+	 * interested in getting the group messages ASAP so pull from peers without
+	 * waiting GXS sync timer.
+	 * Do it here as this is meaningful or not depending on the service.
+	 * Do it only after the token has been completed otherwise the pull have no
+	 * effect. */
+	if(subscribe) RsGenExchange::netService()->pullFromPeers();
 
 	return true;
 }

--- a/libretroshare/src/services/p3gxsforums.cc
+++ b/libretroshare/src/services/p3gxsforums.cc
@@ -1159,6 +1159,12 @@ std::error_condition p3GxsForums::setPostKeepForever(
 	}
 }
 
+std::error_condition p3GxsForums::requestSynchronization()
+{
+	RsGenExchange::netService()->pullFromPeers();
+	return RsGenExchange::netService()->requestPull();
+}
+
 /* so we need the same tick idea as wiki for generating dummy forums
  */
 

--- a/libretroshare/src/services/p3gxsforums.cc
+++ b/libretroshare/src/services/p3gxsforums.cc
@@ -907,12 +907,12 @@ bool p3GxsForums::subscribeToForum(const RsGxsGroupId& groupId, bool subscribe )
 	acknowledgeGrp(token, grp);
 
 	/* Since subscribe has been requested, the caller is most probably
-	 * interested in getting the group messages ASAP so pull from peers without
-	 * waiting GXS sync timer.
+	 * interested in getting the group messages ASAP so check updates from peers
+	 * without waiting GXS sync timer.
 	 * Do it here as this is meaningful or not depending on the service.
 	 * Do it only after the token has been completed otherwise the pull have no
 	 * effect. */
-	if(subscribe) RsGenExchange::netService()->pullFromPeers();
+	if(subscribe) RsGenExchange::netService()->checkUpdatesFromPeers();
 
 	return true;
 }
@@ -1161,7 +1161,8 @@ std::error_condition p3GxsForums::setPostKeepForever(
 
 std::error_condition p3GxsForums::requestSynchronization()
 {
-	RsGenExchange::netService()->pullFromPeers();
+	auto errc = RsGenExchange::netService()->checkUpdatesFromPeers();
+	if(errc) return errc;
 	return RsGenExchange::netService()->requestPull();
 }
 

--- a/libretroshare/src/services/p3gxsforums.h
+++ b/libretroshare/src/services/p3gxsforums.h
@@ -175,6 +175,8 @@ public:
 	        rs_owner_ptr<uint8_t>& resultData, uint32_t& resultSize ) override;
 #endif
 
+	std::error_condition requestSynchronization() override;
+
     /// implementation of rsGxsGorums
     ///
 	bool getGroupData(const uint32_t &token, std::vector<RsGxsForumGroup> &groups) override;

--- a/libretroshare/src/util/cxx23retrocompat.h
+++ b/libretroshare/src/util/cxx23retrocompat.h
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * RetroShare C++23 backwards compatibility utilities                          *
+ *                                                                             *
+ * libretroshare: retroshare core library                                      *
+ *                                                                             *
+ * Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>       *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+#pragma once
+
+#include <utility>
+
+#if ! defined(__cpp_lib_to_underlying)
+namespace std
+{
+template <class Enum>
+constexpr underlying_type_t<Enum> to_underlying(Enum e) noexcept
+{ return static_cast<std::underlying_type_t<Enum>>(e); }
+}
+#endif // ! defined(__cpp_lib_to_underlying)


### PR DESCRIPTION
This could be used to request the online peers to pull updates from us
  ASAP, as an example when a group is created a pull request can be
  emitted too so the online peers pull the groups from us ASAP instead
  of waiting for the usual 60 seconds. A mechanism like this is
  especially useful on mobile phones where the internet connection is
  usually turned on only in a few moments (as an example while the user
  is interacting with the app).
Cleanup a few old corners in the code keeping retro-compatibility and
  make the code more welcoming to new developers.
Put a bunch of dead code under #ifdef.