### PR TITLE
Include CORS headers in response for rsEvents/registerEventsHandler

### DIFF
--- a/libretroshare/src/jsonapi/jsonapi.cpp
+++ b/libretroshare/src/jsonapi/jsonapi.cpp
@@ -361,11 +361,9 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 	        [this](const std::shared_ptr<rb::Session> session)
 	{
 		const std::weak_ptr<rb::Service> weakService(mService);
-		const std::multimap<std::string, std::string> headers
-		{
-			{ "Connection", "keep-alive" },
-			{ "Content-Type", "text/event-stream" }
-		};
+		auto headers = corsHeaders;
+		headers.insert({ "Connection", "keep-alive" });
+		headers.insert({ "Content-Type", "text/event-stream" });
 		session->yield(rb::OK, headers);
 
 		size_t reqSize = static_cast<size_t>(


### PR DESCRIPTION
Firefox and some Webkit based browsers block calls made to `rsEvents/registerEventsHandler` because it is missing CORS headers in it's responses.