### PR TITLE
Avoid JSON operations on RsGxsIdGroup::mPgpIdSign

### DIFF
--- a/libretroshare/src/retroshare/rsidentity.h
+++ b/libretroshare/src/retroshare/rsidentity.h
@@ -4,7 +4,8 @@
  * libretroshare: retroshare core library                                      *
  *                                                                             *
  * Copyright (C) 2012  Robert Fernie <retroshare@lunamutt.com>                 *
- * Copyright (C) 2019  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2019-2021  Gioacchino Mazzurco <gio@eigenlab.org>             *
+ * Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>       *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -131,23 +132,25 @@ struct RsGxsIdGroup : RsSerializable
 	//                                 ???                 160 bits.
 
 	Sha1CheckSum mPgpIdHash;
-	// Need a signature as proof - otherwise anyone could add others Hashes.
-	// This is a string, as the length is variable.
-	std::string mPgpIdSign;   
 
-	// Recognition Strings. MAX# defined above.
+	/** Need a signature as proof - otherwise anyone could add others Hashes.
+	 * This is a string, as the length is variable.
+	 * TODO: Thing like this should actually be a byte array (pointer+size),
+	 * using an std::string breaks the JSON serialization, as a workaround this
+	 * field is ignored by JSON serial operations */
+	std::string mPgpIdSign;
+
+	/// Unused
 	RS_DEPRECATED std::list<std::string> mRecognTags;
 
-    // Avatar
-    RsGxsImage mImage ;
-    rstime_t mLastUsageTS ;
+	RsGxsImage mImage; /// Avatar
+	rstime_t mLastUsageTS;
 
-    // Not Serialised - for GUI's benefit.
-    bool mPgpLinked;
-    bool mPgpKnown;
-    bool mIsAContact;	// change that into flags one day
-    RsPgpId mPgpId;
-    GxsReputation mReputation;
+	bool mPgpLinked;
+	bool mPgpKnown;
+	bool mIsAContact;
+	RsPgpId mPgpId;
+	GxsReputation mReputation;
 
 	/// @see RsSerializable
 	void serial_process( RsGenericSerializer::SerializeJob j,

--- a/libretroshare/src/rsitems/rsgxsiditems.h
+++ b/libretroshare/src/rsitems/rsgxsiditems.h
@@ -3,7 +3,9 @@
  *                                                                             *
  * libretroshare: retroshare core library                                      *
  *                                                                             *
- * Copyright 2012-2012 by Robert Fernie <retroshare@lunamutt.com>              *
+ * Copyright (C) 2012  Robert Fernie <retroshare@lunamutt.com>                 *
+ * Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>                  *
+ * Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>       *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -19,8 +21,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#ifndef RS_GXS_IDENTITY_ITEMS_H
-#define RS_GXS_IDENTITY_ITEMS_H
+#pragma once
 
 #include <map>
 
@@ -57,15 +58,20 @@ public:
     bool toGxsIdGroup(RsGxsIdGroup &group, bool moveImage);
 
     Sha1CheckSum mPgpIdHash;
-    // Need a signature as proof - otherwise anyone could add others Hashes.
-    // This is a string, as the length is variable.
-    std::string mPgpIdSign;
 
-    // Recognition Strings. MAX# defined above.
-    std::list<std::string> mRecognTags;
+	/** Need a signature as proof - otherwise anyone could add others Hashes.
+	 * This is a string, as the length is variable.
+	 * TODO: this should actually be a byte array (pointer+size), using an
+	 * std::string breaks the JSON serialization.
+	 * Be careful refactoring this as it may break retrocompatibility as this
+	 * item is sent over the network */
+	std::string mPgpIdSign;
 
-    // Avatar
-    RsTlvImage mImage ;
+	/// Unused
+	RS_DEPRECATED std::list<std::string> mRecognTags;
+
+	/// Avatar
+	RsTlvImage mImage;
 };
 
 struct RsGxsIdLocalInfoItem : public RsGxsIdItem
@@ -89,5 +95,3 @@ public:
 
     virtual RsItem *create_item(uint16_t service_id,uint8_t item_subtype) const ;
 };
-
-#endif /* RS_GXS_IDENTITY_ITEMS_H */

--- a/libretroshare/src/services/p3idservice.cc
+++ b/libretroshare/src/services/p3idservice.cc
@@ -2,7 +2,8 @@
  * libretroshare/src/services: p3idservice.cc                                  *
  *                                                                             *
  * Copyright (C) 2012-2014  Robert Fernie <retroshare@lunamutt.com>            *
- * Copyright (C) 2017-2019  Gioacchino Mazzurco <gio@altermundi.net>           *
+ * Copyright (C) 2017-2021  Gioacchino Mazzurco <gio@altermundi.net>           *
+ * Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>       *
  *                                                                             *
  * This program is free software: you can redistribute it and/or modify        *
  * it under the terms of the GNU Lesser General Public License as              *
@@ -4960,7 +4961,21 @@ void RsGxsIdGroup::serial_process(
 {
 	RS_SERIAL_PROCESS(mMeta);
 	RS_SERIAL_PROCESS(mPgpIdHash);
-	RS_SERIAL_PROCESS(mPgpIdSign);
+	switch(j)
+	{
+	/* mPgpIdSign is declared as std::string but it is a disguised raw memory
+	 * chunk, serializing it as plain string breaks JSON and eventually
+	 * teminals if it get printed, it should have been declared as a raw memory
+	 * chunk in the first place, but as of today just ignoring it in *JSON and
+	 * PRINT operations seems a reasonable workaround */
+	case RsGenericSerializer::SerializeJob::PRINT: // [[fallthrough]]
+	case RsGenericSerializer::SerializeJob::TO_JSON: // [[fallthrough]]
+	case RsGenericSerializer::SerializeJob::FROM_JSON:
+		break;
+	default:
+		RS_SERIAL_PROCESS(mPgpIdSign);
+		break;
+	}
 	RS_SERIAL_PROCESS(mImage);
 	RS_SERIAL_PROCESS(mLastUsageTS);
 	RS_SERIAL_PROCESS(mPgpKnown);


### PR DESCRIPTION
The field is actually a raw memory chunk even if declared as an
  std::string as result the produced JSON is broken and JSON API clients
  cannot parse the output of methods like rsIdentity/getIdentitiesInfo
A proper fix would be refactoring the whole code to use a proper raw
  memory buffer for that field but given there is no usage for a raw PGP
  signature on a client app as RetroShare library already verify it internally
  workaround the issue by just ignoring that field in JSON serial operations.

Workaround https://github.com/RetroShare/RetroShare/issues/2431