### PR TITLE
Filter html img tags that points to local files

### DIFF
--- a/retroshare-gui/src/util/HandleRichText.h
+++ b/retroshare-gui/src/util/HandleRichText.h
@@ -82,6 +82,7 @@ public:
 protected:
 	void embedHtml(QTextDocument *textDocument, QDomDocument &doc, QDomElement &currentElement, EmbedInHtml& embedInfos, ulong flag);
 	void replaceAnchorWithImg(QDomDocument& doc, QDomElement &element, QTextDocument *textDocument, const RetroShareLink &link);
+	void filterEmbeddedImages(QDomDocument &doc, QDomElement &currentElement);
 
 	virtual bool   canReplaceAnchor(QDomDocument &doc, QDomElement &element, const RetroShareLink &link);
 	virtual void   anchorTextForImg(QDomDocument &doc, QDomElement &element, const RetroShareLink &link, QString &text);


### PR DESCRIPTION
It was already filtered in RsTextBrowser, but some UI elements do not use it, so they were not filtered:
 - toasters
 - chat history browser