### PR TITLE
Fixes crash after: (EE) asked to create an invalidated profile that a…

### DIFF
--- a/retroshare-gui/src/gui/common/FriendListModel.cpp
+++ b/retroshare-gui/src/gui/common/FriendListModel.cpp
@@ -1052,7 +1052,12 @@ std::map<RsPgpId,uint32_t>::const_iterator RsFriendListModel::createInvalidatedP
 
     if(rsPeers->getGPGDetails(pgp_id,hprof.profile_info))
     {
-        std::cerr << "(EE) asked to create an invalidated profile that already exists!" << std::endl;
+        std::cerr << "(EE) asked to create an invalidated profile that already exists: " << pgp_id << std::endl;
+
+        pgp_indices[pgp_id] = mProfiles.size();
+        mProfiles.push_back(hprof);
+        it2 = pgp_indices.find(pgp_id);
+
         return it2;
     }
 


### PR DESCRIPTION
Fixes crash after: (EE) asked to create an invalidated profile that already exists

createInvalidatedProfile returned with iterator.end() in some cases.
updateInternalData dereferenced the result without checking it first.
It overindexed an array, read some memory trash, then wrote it into an another array.

Closes #2463