### PR TITLE
Fix NotifyQt::askForPassword QInputDialog is not created in GUI Thread.

### DIFF
--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -21,6 +21,7 @@
 #include <QColorDialog>
 #include <QDesktopServices>
 #include <QIcon>
+#include <QInputDialog>
 #include <QMessageBox>
 #include <QPixmap>
 #include <QStatusBar>
@@ -1688,4 +1689,20 @@ void MainWindow::setCompactStatusMode(bool compact)
 	hashingstatus->setCompactMode(compact);
 	ratesstatus->setCompactMode(compact);
 	//opModeStatus: TODO Show only ???
+}
+
+Gui_InputDialogReturn MainWindow::guiInputDialog(const QString& windowTitle, const QString& labelText, QLineEdit::EchoMode textEchoMode, bool modal)
+{
+
+	QInputDialog dialog(this);
+	dialog.setWindowTitle(windowTitle);
+	dialog.setLabelText(labelText);
+	dialog.setTextEchoMode(textEchoMode);
+	dialog.setModal(modal);
+
+	Gui_InputDialogReturn ret;
+	ret.execReturn = dialog.exec();
+	ret.textValue = dialog.textValue();
+
+	return ret;
 }

--- a/retroshare-gui/src/gui/MainWindow.h
+++ b/retroshare-gui/src/gui/MainWindow.h
@@ -21,6 +21,7 @@
 #ifndef _MainWindow_H
 #define _MainWindow_H
 
+#include <QLineEdit>
 #include <QSystemTrayIcon>
 #include <set>
 
@@ -73,6 +74,14 @@ class MessengerWindow;
 #ifdef UNFINISHED
 class ApplicationWindow;
 #endif
+
+
+struct Gui_InputDialogReturn
+{
+	int execReturn;
+	QString textValue;
+};
+Q_DECLARE_METATYPE(Gui_InputDialogReturn);
 
 class MainWindow : public RWindow
 {
@@ -192,7 +201,7 @@ public:
     }
 
     static bool hiddenmode;
-	
+
 public slots:
     void receiveNewArgs(QStringList args);
     void displayErrorMessage(int,int,const QString&) ;
@@ -210,9 +219,35 @@ public slots:
     void showBandwidthGraph();
 
     void toggleStatusToolTip(bool toggle);
+
+	/**
+	 * @brief Create a QInputDialog. This must be called in MainWindow thread because Widgets must be created in the GUI thread.
+	 * Here an exemple how to call it:
+	 *
+	 * bool sameThread = QThread::currentThread() == qApp->thread();
+	 * Gui_InputDialogReturn ret;
+	 * qRegisterMetaType<Gui_InputDialogReturn>("Gui_InputDialogReturn");
+	 * QMetaObject::invokeMethod( MainWindow::getInstance()
+	 *                          , "guiInputDialog"
+	 *                          , sameThread ? Qt::DirectConnection : Qt::BlockingQueuedConnection
+	 *                          , Q_RETURN_ARG(Gui_InputDialogReturn, ret)
+	 *                          , Q_ARG(QString,             windowTitle)
+	 *                          , Q_ARG(QString,             labelText)
+	 *                          , Q_ARG(QLineEdit::EchoMode, textEchoMode)
+	 *                          , Q_ARG(bool,                modal)
+	 *                           );
+	 *
+	 * @param windowTitle: the window title (caption).
+	 * @param labelText: label's text which describes what needs to be input.
+	 * @param textEchoMode: the echo mode for the text value.
+	 * @param modal: pop up the dialog as modal or modeless.
+	 * @return Gui_InputDialogReturn ( Accepted(1)|Rejected(0), text value for the input dialog)
+	 */
+	Gui_InputDialogReturn guiInputDialog(const QString& windowTitle, const QString& labelText, QLineEdit::EchoMode textEchoMode, bool modal);
+
 protected:
     /** Default Constructor */
-    MainWindow(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+    MainWindow(QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
 
     void closeEvent(QCloseEvent *);
     

--- a/retroshare-gui/src/gui/notifyqt.cpp
+++ b/retroshare-gui/src/gui/notifyqt.cpp
@@ -21,12 +21,6 @@
 #include "gui/common/FilesDefs.h"
 #include <retroshare/rsgxsifacehelper.h>
 
-#include <QInputDialog>
-#include <QMessageBox>
-#include <QTimer>
-//#include <QMutexLocker>
-#include <QDesktopWidget>
-
 #include "notifyqt.h"
 #include <retroshare/rsnotify.h>
 #include <retroshare/rspeers.h>
@@ -54,6 +48,13 @@
 #include "SoundManager.h"
 
 #include "retroshare/rsplugin.h"
+
+#include <QDesktopWidget>
+#include <QInputDialog>
+#include <QMessageBox>
+//#include <QMutexLocker>
+#include <QThread>
+#include <QTimer>
 
 /*****
  * #define NOTIFY_DEBUG
@@ -223,37 +224,51 @@ bool NotifyQt::askForPassword(const std::string& title, const std::string& key_d
 {
 	RsAutoUpdatePage::lockAllEvents() ;
 
-	QInputDialog dialog;
+	QString windowTitle;
 	if (title == "") {
-		dialog.setWindowTitle(tr("Passphrase required"));
+		windowTitle = tr("Passphrase required");
 	} else if (title == "AuthSSLimpl::SignX509ReqWithGPG()") {
-		dialog.setWindowTitle(tr("You need to sign your node's certificate."));
+		windowTitle = tr("You need to sign your node's certificate.");
 	} else if (title == "p3IdService::service_CreateGroup()") {
-		dialog.setWindowTitle(tr("You need to sign your forum/chatrooms identity."));
+		windowTitle = tr("You need to sign your forum/chatrooms identity.");
 	} else {
-		dialog.setWindowTitle(QString::fromStdString(title));
+		windowTitle = QString::fromStdString(title);
 	}
 
-	dialog.setLabelText((prev_is_bad ? QString("%1<br/><br/>").arg(tr("Wrong password !")) : QString()) + QString("<b>%1</b><br/>Profile: <i>%2</i>\n").arg(tr("Please enter your Retroshare passphrase"), QString::fromUtf8(key_details.c_str())));
-	dialog.setTextEchoMode(QLineEdit::Password);
-	dialog.setModal(true);
+	QString labelText = ( prev_is_bad ? QString("%1<br/><br/>").arg(tr("Wrong password !")) : QString() )
+	                    + QString("<b>%1</b><br/>Profile: <i>%2</i>\n")
+	                             .arg( tr("Please enter your Retroshare passphrase")
+	                                 , QString::fromUtf8(key_details.c_str()) );
+	QLineEdit::EchoMode textEchoMode = QLineEdit::Password;
+	bool modal = true;
 
-	int ret = dialog.exec();
+	bool sameThread = QThread::currentThread() == qApp->thread();
+	Gui_InputDialogReturn ret;
+	qRegisterMetaType<Gui_InputDialogReturn>("Gui_InputDialogReturn");
+	QMetaObject::invokeMethod( MainWindow::getInstance()
+	                         , "guiInputDialog"
+	                         , sameThread ? Qt::DirectConnection : Qt::BlockingQueuedConnection
+	                         , Q_RETURN_ARG(Gui_InputDialogReturn, ret)
+	                         , Q_ARG(QString,             windowTitle)
+	                         , Q_ARG(QString,             labelText)
+	                         , Q_ARG(QLineEdit::EchoMode, textEchoMode)
+	                         , Q_ARG(bool,                modal)
+	                          );
 
-    cancelled = false ;
+	cancelled = false ;
 
 	RsAutoUpdatePage::unlockAllEvents() ;
 
-    if (ret == QDialog::Rejected) {
-        password.clear() ;
-        cancelled = true ;
-        return true ;
-    }
+	if (ret.execReturn == QDialog::Rejected) {
+		password.clear() ;
+		cancelled = true ;
+		return true ;
+	}
 
-    if (ret == QDialog::Accepted) {
-		 password = dialog.textValue().toUtf8().constData();
-		 return true;
-    }
+	if (ret.execReturn == QDialog::Accepted) {
+		password = ret.textValue.toUtf8().constData();
+		return true;
+	}
 
 	return false;
 }


### PR DESCRIPTION
To test without it, change in:
/retroshare-gui/src/gui/GenCertDialog.cpp:665
QTimer::singleShot(30000, []() { rsNotify->clearPgpPassphrase(); } );
to
QTimer::singleShot(**100**, []() { rsNotify->clearPgpPassphrase(); } );

And create a new node.