### PR TITLE
Forum deep search support wildcard* search

### DIFF
--- a/libretroshare/src/deep_search/forumsindex.cpp
+++ b/libretroshare/src/deep_search/forumsindex.cpp
@@ -46,7 +46,9 @@ std::error_condition DeepForumsIndex::search(
 	// End of prefix configuration.
 
 	// And parse the query.
-	Xapian::Query query = queryparser.parse_query(queryStr);
+	using XQP = Xapian::QueryParser;
+	Xapian::Query query = queryparser.parse_query(
+	            queryStr, XQP::FLAG_WILDCARD | XQP::FLAG_DEFAULT );
 
 	// Use an Enquire object on the database to run the query.
 	Xapian::Enquire enquire(db);


### PR DESCRIPTION
Xapian have support for wildcard search
  wild* matches wild, wildcard, wildcat, wilderness
  but it need to be enabled by passing a specific flag to the query
  parser, this is very useful for forum search so enable it in addition
  to default Xapian search capabilities