### PR TITLE
Fixed to display the right index for Image Page

### DIFF
--- a/retroshare-gui/src/gui/Posted/BoardPostDisplayWidget.cpp
+++ b/retroshare-gui/src/gui/Posted/BoardPostDisplayWidget.cpp
@@ -182,6 +182,7 @@ void BoardPostDisplayWidgetBase::baseSetup()
     if(redacted)
     {
         commentButton()->setDisabled(true);
+        shareButton()->setDisabled(true);
         voteUpButton()->setDisabled(true);
         voteDownButton()->setDisabled(true);
         fromLabel()->setId(mPost.mMeta.mAuthorId);

--- a/retroshare-gui/src/gui/Posted/PostedCreatePostDialog.ui
+++ b/retroshare-gui/src/gui/Posted/PostedCreatePostDialog.ui
@@ -143,7 +143,7 @@
              <item row="0" column="1">
               <widget class="QStackedWidget" name="stackedWidgetPicture">
                <property name="currentIndex">
-                <number>1</number>
+                <number>0</number>
                </property>
                <widget class="QWidget" name="PageAttach">
                 <layout class="QGridLayout" name="PageAttach_GL">


### PR DESCRIPTION
* Fixed to display the right index for Image Page
* Fixed to disable share button when Identity is banned.