### PR TITLE
Add support to build via CMake

### DIFF
--- a/libbitdht/CMakeLists.txt
+++ b/libbitdht/CMakeLists.txt
@@ -1,0 +1,19 @@
+# RetroShare decentralized communication platform
+#
+# Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>
+# Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+cmake_minimum_required (VERSION 2.8.12)
+project(libbitdht)
+
+file(
+	GLOB BITDHT_SOURCES
+	src/bitdht/*.c src/bitdht/*.cc src/udp/*.cc src/util/*.cc )
+
+add_library(${PROJECT_NAME} ${BITDHT_SOURCES})
+
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src )

--- a/libretroshare/CMakeLists.txt
+++ b/libretroshare/CMakeLists.txt
@@ -1,0 +1,243 @@
+# RetroShare decentralized communication platform
+#
+# Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>
+# Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+cmake_minimum_required (VERSION 3.18.0)
+project(retroshare)
+
+# sqlcipher
+option(
+	RS_SQLCIPHER
+	"SQLCipher encryption for GXS database"
+	ON )
+
+# rs_gxs_send_all
+option(
+	RS_GXS_SEND_ALL
+	"GXS distribute all available messages on request, indipendently from \
+	local sync timer"
+	ON )
+
+# bitdht
+option(
+	RS_BITDHT
+	"Use bitdht (BitTorrent DHT own implementation) to look for online peers"
+	ON )
+
+# use_dht_stunner
+option(
+	RS_BITDHT_STUNNER
+	"Use bitdht (BitTorrent DHT own implementation) for NAT type discovery and \
+	attempt the STUN (Session Traversal Utilities for NAT)"
+	ON )
+
+# use_dht_stunner_ext_ip
+option(
+	RS_BITDHT_STUNNER_EXT_IP
+	"Use bitdht (BitTorrent DHT own implementation) stunner to figure out our \
+	external IP. As this purely relying on random DHT peers that answer our \
+	request, it can easily be abused. Therefore, it is turned off by default."
+	OFF )
+
+# rs_jsonapi
+option(
+	RS_JSON_API
+	"Use restbed to expose libretroshare as JSON API via HTTP"
+	OFF )
+
+# rs_deep_forums_index
+option(
+	RS_FORUM_DEEP_INDEX
+	"Xapian based full text index and search of GXS forums"
+	OFF )
+
+# rs_broadcast_discovery
+option(
+	RS_BRODCAST_DISCOVERY
+	"Local area network peer discovery via udp-discovery-cpp"
+	ON )
+
+# rs_dh_init_check
+option(
+	RS_DH_PRIME_INIT_CHECK
+	"Check Diffie Hellman prime at each startup. This is not necessary and on \
+	all Android mobile phones tested this take at least one minute at startup \
+	which is untolerable for most phone users."
+	ON )
+
+option(
+	RS_MINIUPNPC
+	"Forward ports in NAT router via miniupnpc"
+	ON
+)
+
+include(CMakeDependentOption)
+cmake_dependent_option(
+	RS_LIBUPNP
+	"Forward ports in NAT router via libupnp (unstable)"
+	OFF
+	"NOT RS_MINIUPNPC"
+	OFF
+)
+
+option(
+	RS_LIBRETROSHARE_STATIC
+	"Build RetroShare static library"
+	ON
+)
+
+cmake_dependent_option(
+	RS_LIBRETROSHARE_SHARED
+	"Build RetroShare shared library"
+	OFF
+	"NOT RS_LIBRETROSHARE_STATIC"
+	OFF
+)
+
+# rs_deprecatedwarning
+option(
+	RS_WARN_DEPRECATED
+	"Print warning about RetroShare deprecated components usage during build"
+	ON
+)
+
+# rs_cppwarning
+option(
+	RS_WARN_LESS
+	"Silence a few at the moment very common warnings about RetroShare \
+	components during build"
+	OFF
+)
+
+# rs_v07_changes
+option(
+	RS_V07_BREAKING_CHANGES
+	"Enable retro-compatibility breaking changes planned for RetroShare 0.7.0"
+	OFF
+)
+
+set(
+	RS_DATA_DIR
+	"${CMAKE_INSTALL_PREFIX}/share/retroshare"
+	CACHE STRING
+	"Path where to install RetroShare system wide data" )
+
+################################################################################
+
+include(src/CMakeLists.txt)
+list(TRANSFORM RS_SOURCES PREPEND src/)
+
+if(RS_LIBRETROSHARE_STATIC)
+	add_library(${PROJECT_NAME} STATIC ${RS_SOURCES})
+endif(RS_LIBRETROSHARE_STATIC)
+
+if(RS_LIBRETROSHARE_SHARED)
+	add_library(${PROJECT_NAME} SHARED ${RS_SOURCES})
+
+	## Ensure statically linked libraries such as openpgpsdk are compiled with
+	## PIC Which is needed for shared library
+	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif(RS_LIBRETROSHARE_SHARED)
+
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src )
+
+
+find_package(OpenSSL REQUIRED)
+target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+
+################################################################################
+
+add_subdirectory(../openpgpsdk ${CMAKE_BINARY_DIR}/openpgpsdk)
+target_link_libraries(${PROJECT_NAME} PRIVATE openpgpsdk)
+
+if(RS_BITDHT)
+	add_compile_definitions(RS_USE_BITDHT)
+	add_subdirectory(../libbitdht ${CMAKE_BINARY_DIR}/libbitdht)
+	target_link_libraries(${PROJECT_NAME} PRIVATE libbitdht)
+endif(RS_BITDHT)
+
+## TODO: Check if https://github.com/rbock/sqlpp11 or
+## https://github.com/rbock/sqlpp17 may improve GXS code
+if(RS_SQLCIPHER)
+	find_library(RS_SQL_LIB "sqlcipher" REQUIRED)
+	find_path(
+		RS_SQL_LIB_INCLUDE "sqlcipher/sqlite3.h"
+		PATH_SUFFIXES "include" "includes"
+		REQUIRED )
+	target_include_directories(
+		${PROJECT_NAME}
+		PRIVATE "${RS_SQL_LIB_INCLUDE}/sqlcipher" )
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${RS_SQL_LIB})
+else()
+	add_compile_definitions(NO_SQLCIPHER)
+	find_package(SQLite3 REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PRIVATE SQLite::SQLite3)
+endif()
+
+add_compile_definitions(
+	SQLITE_HAS_CODEC
+	RS_ENABLE_GXS
+	GXS_ENABLE_SYNC_MSGS
+	RS_USE_GXS_DISTANT_SYNC
+	RS_GXS_TRANS
+	V07_NON_BACKWARD_COMPATIBLE_CHANGE_001
+	V07_NON_BACKWARD_COMPATIBLE_CHANGE_002
+	V07_NON_BACKWARD_COMPATIBLE_CHANGE_003 )
+
+if(RS_V07_BREAKING_CHANGES)
+	add_compile_definitions(
+		V07_NON_BACKWARD_COMPATIBLE_CHANGE_004
+		V07_NON_BACKWARD_COMPATIBLE_CHANGE_UNNAMED )
+endif()
+
+if(RS_MINIUPNPC)
+	add_compile_definitions(RS_USE_LIBMINIUPNPC)
+endif(RS_MINIUPNPC)
+
+if(RS_LIBUPNP)
+	add_compile_definitions(RS_USE_LIBUPNP)
+endif(RS_LIBUPNP)
+
+if(RS_GXS_SEND_ALL)
+	add_compile_definitions(RS_GXS_SEND_ALL)
+endif(RS_GXS_SEND_ALL)
+
+if(RS_BRODCAST_DISCOVERY)
+	add_subdirectory(
+	../supportlibs/udp-discovery-cpp/
+	${CMAKE_BINARY_DIR}/supportlibs/udp-discovery-cpp/ )
+	target_link_libraries(${PROJECT_NAME} PRIVATE udp-discovery)
+
+	## Temporary work around target_include_directories should be added upstream
+	include_directories(../supportlibs/udp-discovery-cpp/)
+endif(RS_BRODCAST_DISCOVERY)
+
+if(NOT RS_WARN_DEPRECATED)
+	add_compile_definitions(RS_NO_WARN_DEPRECATED)
+	target_compile_options(
+		${PROJECT_NAME} PRIVATE
+		-Wno-deprecated -Wno-deprecated-declarations )
+endif(RS_WARN_DEPRECATED)
+
+if(RS_WARN_LESS)
+	add_compile_definitions(RS_NO_WARN_CPP)
+	
+	target_compile_options(
+		${PROJECT_NAME} PRIVATE
+		-Wno-cpp -Wno-inconsistent-missing-override )
+endif(RS_WARN_LESS)
+
+################################################################################
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	add_compile_definitions(RS_DATA_DIR="${RS_DATA_DIR}")
+endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+
+## Useful to debug CMake
+#set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/libretroshare/src/CMakeLists.txt
+++ b/libretroshare/src/CMakeLists.txt
@@ -1,0 +1,346 @@
+# RetroShare decentralized communication platform
+#
+# Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>
+# Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+list(
+	APPEND RS_SOURCES
+	chat/distantchat.cc
+	chat/p3chatservice.cc
+	chat/rschatitems.cc
+	chat/distributedchat.cc
+	crypto/chacha20.cpp
+	crypto/hashstream.cc
+	crypto/rsaes.cc
+	crypto/rscrypto.cpp )
+
+if(RS_BITDHT)
+	list(
+		APPEND RS_SOURCES
+		dht/connectstatebox.cc
+		dht/p3bitdht.cc
+		dht/p3bitdht_interface.cc
+		dht/p3bitdht_peernet.cc
+		dht/p3bitdht_peers.cc
+		dht/p3bitdht_relay.cc )
+endif(RS_BITDHT)
+
+list(
+	APPEND RS_SOURCES
+	file_sharing/filelist_io.cc
+	file_sharing/rsfilelistitems.cc
+	file_sharing/file_tree.cc
+	file_sharing/directory_updater.cc
+	file_sharing/p3filelists.cc
+	file_sharing/hash_cache.cc
+	file_sharing/dir_hierarchy.cc
+	file_sharing/directory_storage.cc
+	ft/ftchunkmap.cc
+	ft/ftfilecreator.cc
+	ft/ftfileprovider.cc
+	ft/ftfilesearch.cc
+	ft/ftturtlefiletransferitem.cc
+	ft/fttransfermodule.cc
+	ft/ftcontroller.cc
+	ft/ftdatamultiplex.cc
+	ft/ftextralist.cc
+	ft/ftserver.cc )
+
+list(
+	APPEND RS_SOURCES
+	grouter/groutermatrix.cc
+	grouter/grouteritems.cc
+	grouter/p3grouter.cc )
+
+list(
+	APPEND RS_SOURCES
+	gxs/rsgxsdata.cc
+	gxs/rsgxsrequesttypes.cc
+	gxs/gxssecurity.cc
+	gxs/gxstokenqueue.cc
+	gxs/rsdataservice.cc
+	gxs/rsgxsdataaccess.cc
+	gxs/rsgxsnetutils.cc
+	gxs/rsgxsnettunnel.cc
+	gxs/rsgxsutil.cc
+	gxs/rsnxsobserver.cpp
+	gxs/rsgenexchange.cc
+	gxs/rsgxsnetservice.cc )
+
+list(
+	APPEND RS_SOURCES
+	gxstrans/p3gxstransitems.cc
+	gxstrans/p3gxstrans.cc )
+
+list(
+	APPEND RS_SOURCES
+	gxstunnel/rsgxstunnelitems.cc
+	gxstunnel/p3gxstunnel.cc )
+
+if(RS_JSON_API)
+	list(
+		APPEND RS_SOURCES
+		jsonapi/jsonapi.cpp )
+endif(RS_JSON_API)
+
+list(
+	APPEND RS_SOURCES
+	pgp/pgpkeyutil.cc
+	pgp/pgpauxutils.cc
+	pgp/pgphandler.cc
+	pgp/rscertificate.cc )
+
+#./plugins/dlfcn_win32.cc
+#./plugins/dlfcn_win32.h
+#./plugins/pluginmanager.h
+#./plugins/rscacheservice.h
+#./plugins/rspqiservice.h
+#./plugins/pluginmanager.cc
+
+list(
+	APPEND RS_SOURCES
+	pqi/pqibin.cc
+	pqi/pqiipset.cc
+	pqi/pqiloopback.cc
+	pqi/pqimonitor.cc
+	pqi/pqipersongrp.cc
+	pqi/pqiqos.cc
+	pqi/pqiqosstreamer.cc
+	pqi/pqisslproxy.cc
+	pqi/pqistore.cc
+	pqi/authgpg.cc
+	pqi/p3cfgmgr.cc
+	pqi/p3notify.cc
+	pqi/p3servicecontrol.cc
+	pqi/pqinetstatebox.cc
+	pqi/pqiperson.cc
+	pqi/pqiservice.cc
+	pqi/pqissllistener.cc
+	pqi/pqissludp.cc
+	pqi/pqithreadstreamer.cc
+	pqi/sslfns.cc
+	pqi/authssl.cc
+	pqi/p3historymgr.cc
+	pqi/p3linkmgr.cc
+	pqi/pqihandler.cc
+	pqi/pqistreamer.cc
+	pqi/p3netmgr.cc
+	pqi/p3peermgr.cc
+	pqi/pqinetwork.cc
+	pqi/pqissl.cc
+	pqi/pqisslpersongrp.cc )
+
+#./pqi/pqissli2psam3.cpp
+#./pqi/pqissli2psam3.h
+
+list(
+	APPEND RS_SOURCES
+	rsitems/rsbanlistitems.cc
+	rsitems/rsbwctrlitems.cc
+	rsitems/rsconfigitems.cc
+	rsitems/rsfiletransferitems.cc
+	rsitems/rsgxscommentitems.cc
+	rsitems/rsgxsforumitems.cc
+	rsitems/rsgxsiditems.cc
+	rsitems/rsgxsrecognitems.cc
+	rsitems/rsgxsreputationitems.cc
+	rsitems/rsgxsupdateitems.cc
+	rsitems/rshistoryitems.cc
+	rsitems/rsrttitems.cc
+	rsitems/rsserviceinfoitems.cc )
+
+#./rsitems/rswikiitems.cc
+#./rsitems/rswikiitems.h
+#./rsitems/rswireitems.h
+
+list(
+	APPEND RS_SOURCES
+	rsitems/rsgxschannelitems.cc
+	rsitems/rsgxscircleitems.cc
+	rsitems/rsgxsitems.cc
+	rsitems/rsmsgitems.cc )
+
+#./rsitems/rsphotoitems.cc
+#./rsitems/rsphotoitems.h
+#./rsitems/rsposteditems.cc
+#./rsitems/rsposteditems.h
+#./rsitems/rswireitems.cc
+
+list(
+	APPEND RS_SOURCES
+	rsitems/rsnxsitems.cc )
+
+list(
+	APPEND RS_SOURCES
+	rsserver/p3status.cc
+	rsserver/p3face-config.cc
+	rsserver/p3face-info.cc
+	rsserver/p3history.cc
+	rsserver/p3serverconfig.cc
+	rsserver/rsloginhandler.cc
+	rsserver/p3face-server.cc
+	rsserver/p3msgs.cc
+	rsserver/p3peers.cc
+	rsserver/rsaccounts.cc
+	rsserver/rsinit.cc )
+
+list(
+	APPEND RS_SOURCES
+	serialiser/rsbaseserial.cc
+	serialiser/rsserializable.cc
+	serialiser/rstlvaddrs.cc
+	serialiser/rstlvbanlist.cc
+	serialiser/rstlvbase.cc
+	serialiser/rstlvbinary.cc
+	serialiser/rstlvfileitem.cc
+	serialiser/rstlvgenericmap.inl
+	serialiser/rstlvgenericparam.cc
+	serialiser/rstlvidset.cc
+	serialiser/rstlvimage.cc
+	serialiser/rstlvitem.cc
+	serialiser/rstlvkeys.cc
+	serialiser/rstlvkeyvalue.cc
+	serialiser/rstlvstring.cc
+	serialiser/rsserializer.cc
+	serialiser/rstypeserializer.cc
+	serialiser/rsserial.cc )
+
+# ./services/autoproxy
+#./services/autoproxy/p3i2psam3.cpp
+#./services/autoproxy/p3i2psam3.h
+
+list(
+	APPEND RS_SOURCES
+	services/autoproxy/rsautoproxymonitor.cc
+	services/p3bwctrl.cc
+	services/p3heartbeat.cc
+	services/p3service.cc
+	services/p3serviceinfo.cc
+	services/p3statusservice.cc
+	services/p3banlist.cc
+	services/p3rtt.cc
+	services/rseventsservice.cc
+	services/p3gxscircles.cc
+	services/p3gxscommon.cc
+	services/p3gxsreputation.cc
+	services/p3msgservice.cc
+	services/p3idservice.cc
+	services/p3gxschannels.cc
+	services/p3gxsforums.cc )
+
+#./services/p3wiki.cc
+#./services/p3wiki.h
+#./services/p3wire.cc
+#./services/p3wire.h
+
+#./services/p3photoservice.cc
+#./services/p3photoservice.h
+#./services/p3postbase.cc
+#./services/p3postbase.h
+#./services/p3posted.cc
+#./services/p3posted.h
+
+if(RS_BRODCAST_DISCOVERY)
+	list(
+		APPEND RS_SOURCES
+		services/broadcastdiscoveryservice.cc )
+endif(RS_BRODCAST_DISCOVERY)
+
+list(
+	APPEND RS_SOURCES
+	tcponudp/tcppacket.cc
+	tcponudp/tcpstream.cc
+	tcponudp/tou.cc
+	tcponudp/udppeer.cc
+	tcponudp/bss_tou.cc
+	tcponudp/udprelay.cc
+	tcponudp/udpstunner.cc )
+	
+list(
+	APPEND RS_SOURCES
+	turtle/rsturtleitem.cc
+	turtle/p3turtle.cc )
+
+list(
+	APPEND RS_SOURCES
+#	util/contentvalue.cc
+#	util/exampletst.c
+#	util/rsdbbind.cc
+#	util/rsdiscspace.cc
+	util/rsexpr.cc
+	util/rsprint.cc
+#	util/rsrecogn.cc
+#	util/rssharedptr.h
+#	util/rstickevent.cc
+	util/rstime.cc
+	util/smallobject.cc
+#	util/retrodb.cc
+	util/rsbase64.cc
+	util/rsjson.cc
+#	util/rskbdinput.cc
+	util/rsrandom.cc
+	util/rsstring.cc
+	util/rsurl.cc
+	util/folderiterator.cc
+	util/rsdir.cc
+	util/dnsresolver.cc
+	util/extaddrfinder.cc
+	util/rsdebug.cc
+	util/rsdnsutils.cc
+	util/rsnet.cc
+	util/rsnet_ss.cc
+	util/rsthreads.cc )
+
+#	util/i2pcommon.cpp
+# util/i2pcommon.h
+
+if(RS_FORUM_DEEP_INDEX)
+	list(
+		APPEND RS_SOURCES
+		deep_search/commonutils.cpp
+		deep_search/forumsindex.cpp )
+endif(RS_FORUM_DEEP_INDEX)
+
+
+#./deep_search/filesflacindexer.hpp
+#./deep_search/filesoggindexer.hpp
+#./deep_search/filestaglibindexer.hpp
+#./deep_search/filesindex.cpp
+#./deep_search/filesindex.hpp
+#./deep_search/channelsindex.cpp
+#./deep_search/channelsindex.hpp
+
+list(
+	APPEND RS_SOURCES
+	gossipdiscovery/gossipdiscoveryitems.cc
+	gossipdiscovery/p3gossipdiscovery.cc )
+
+if(RS_MINIUPNPC)
+list(
+	APPEND RS_SOURCES
+	rs_upnp/upnphandler_miniupnp.cc )
+endif(RS_MINIUPNPC)
+
+#./rs_upnp/UPnPBase.cpp
+#./rs_upnp/upnphandler_libupnp.cc
+#./rs_upnp/upnptest.cc
+#./rs_upnp/upnputil.cc
+
+#./rs_android/LocalArray.h
+#./rs_android/README-ifaddrs-android.adoc
+#./rs_android/ScopedFd.h
+#./rs_android/androidcoutcerrcatcher.hpp
+#./rs_android/errorconditionwrap.cpp
+#./rs_android/ifaddrs-android.h
+#./rs_android/org
+#./rs_android/org/retroshare
+#./rs_android/org/retroshare/service
+#./rs_android/org/retroshare/service/AssetHelper.java
+#./rs_android/org/retroshare/service/ErrorConditionWrap.java
+#./rs_android/org/retroshare/service/RetroShareServiceAndroid.java
+#./rs_android/retroshareserviceandroid.cpp
+#./rs_android/retroshareserviceandroid.hpp
+#./rs_android/rsjni.cpp
+#./rs_android/rsjni.hpp

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -205,7 +205,7 @@ linux-* {
     LIBS *= -ldl
 
 	DEFINES *= PLUGIN_DIR=\"\\\"$${PLUGIN_DIR}\\\"\"
-	DEFINES *= DATA_DIR=\"\\\"$${DATA_DIR}\\\"\"
+        DEFINES *= RS_DATA_DIR=\"\\\"$${RS_DATA_DIR}\\\"\"
 }
 
 linux-g++ {
@@ -289,7 +289,7 @@ mac {
 		#LIBS += -lsqlite3
 
 		DEFINES *= PLUGIN_DIR=\"\\\"$${PLUGIN_DIR}\\\"\"
-		DEFINES *= DATA_DIR=\"\\\"$${DATA_DIR}\\\"\"
+                DEFINES *= RS_DATA_DIR=\"\\\"$${RS_DATA_DIR}\\\"\"
 }
 
 ################################# FreeBSD ##########################################

--- a/libretroshare/src/rsserver/rsaccounts.cc
+++ b/libretroshare/src/rsserver/rsaccounts.cc
@@ -841,14 +841,15 @@ static bool checkAccount(const std::string &accountdir, AccountDetails &account,
 
 	/* Use RetroShare's exe dir */
 	dataDirectory = ".";
-#elif defined(ANDROID)
+#elif defined(__ANDROID__)
+	// TODO: This is probably not really used on Android
 	dataDirectory = PathBaseDirectory()+"/usr/share/retroshare";
-#elif defined(DATA_DIR)
+#elif defined(RS_DATA_DIR)
 	// cppcheck-suppress ConfigurationNotChecked
-	dataDirectory = DATA_DIR;
+	dataDirectory = RS_DATA_DIR;
 	// For all other OS the data directory must be set in libretroshare.pro
 #else
-#	error "For your target OS automatic data dir discovery is not supported, cannot compile if DATA_DIR variable not set."
+#	error "For your target OS automatic data dir discovery is not supported, cannot compile if RS_DATA_DIR variable not set."
 #endif
 
 	if (!check)

--- a/libretroshare/src/services/broadcastdiscoveryservice.cc
+++ b/libretroshare/src/services/broadcastdiscoveryservice.cc
@@ -245,7 +245,7 @@ bool BroadcastDiscoveryService::isMulticastListeningEnabled()
 	            env, "isHeld" );
 
 	return mAndroidWifiMulticastLock.Call(env, isHeld);
-#else if // def __ANDROID__
+#else // def __ANDROID__
 	return true;
 #endif // def __ANDROID__
 }

--- a/openpgpsdk/CMakeLists.txt
+++ b/openpgpsdk/CMakeLists.txt
@@ -1,0 +1,27 @@
+# RetroShare decentralized communication platform
+#
+# Copyright (C) 2021  Gioacchino Mazzurco <gio@eigenlab.org>
+# Copyright (C) 2021  Asociación Civil Altermundi <info@altermundi.net>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+cmake_minimum_required (VERSION 3.12.0)
+project(openpgpsdk)
+
+find_package(ZLIB REQUIRED)
+find_package(BZip2 REQUIRED)
+find_package(OpenSSL REQUIRED)
+
+file(GLOB SOURCES src/openpgpsdk/*.c)
+add_library(${PROJECT_NAME} ${SOURCES})
+
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
+	PRIVATE ${OPENSSL_INCLUDE_DIR}
+	PRIVATE ${BZIP2_INCLUDE_DIRS}
+	PRIVATE ${ZLIB_INCLUDE_DIRS} )
+
+target_link_libraries(
+	${PROJECT_NAME}
+	OpenSSL::SSL OpenSSL::Crypto BZip2::BZip2 ZLIB::ZLIB )

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -816,5 +816,4 @@ contains(RS_UPNP_LIB, upnp):DEFINES*=RS_USE_LIBUPNP
 isEmpty(BIN_DIR)   : BIN_DIR   = $${RS_BIN_DIR}
 isEmpty(INC_DIR)   : INC_DIR   = $${RS_INCLUDE_DIR}
 isEmpty(LIBDIR)    : LIBDIR    = $${QMAKE_LIBDIR}
-isEmpty(DATA_DIR)  : DATA_DIR  = $${RS_DATA_DIR}
 isEmpty(PLUGIN_DIR): PLUGIN_DIR= $${RS_PLUGIN_DIR}


### PR DESCRIPTION
Initial CMake support for libretroshare
    
libretroshare (not all build options yet) and it's dependencies can now be built using CMake instead of qmake.
Even Qt itself deprecated qmake, which is not developed anymore, as build system and it was making many things much more difficult and requiring an enormous amount of black magic to support a wide range of platforms.
libretroshare can now easly be build as static or shared library with simple commands and a maintaniable build system:
```
cmake \
        -D RS_LIBRETROSHARE_STATIC=OFF -D RS_LIBRETROSHARE_SHARED=ON \
        -S $YOUR_RS_SOURCE_DIR/libretroshare/ -B .
make
```
