### PR TITLE
Fix font size for gxs group category

### DIFF
--- a/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
@@ -247,6 +247,7 @@ void GroupTreeWidget::itemActivated(QTreeWidgetItem *item, int column)
 QTreeWidgetItem *GroupTreeWidget::addCategoryItem(const QString &name, const QIcon &icon, bool expand, int sortOrder /*= -1*/)
 {
 	QFont font;
+	font.setPointSize(11);
 	RSTreeWidgetItem *item = new RSTreeWidgetItem();
 	ui->treeWidget->addTopLevelItem(item);
 	// To get StyleSheet for Items
@@ -254,6 +255,7 @@ QTreeWidgetItem *GroupTreeWidget::addCategoryItem(const QString &name, const QIc
 	ui->treeWidget->style()->polish(ui->treeWidget);
 
 	item->setText(GTW_COLUMN_NAME, name);
+	item->setData(GTW_COLUMN_NAME,Qt::FontRole,font);
 	item->setData(GTW_COLUMN_DATA, ROLE_NAME, name);
 	font = item->font(GTW_COLUMN_NAME);
 	font.setBold(true);
@@ -262,7 +264,7 @@ QTreeWidgetItem *GroupTreeWidget::addCategoryItem(const QString &name, const QIc
 
 	int S = QFontMetricsF(font).height();
 
-	item->setSizeHint(GTW_COLUMN_NAME, QSize(S*1.9, S*1.9));
+	item->setSizeHint(GTW_COLUMN_NAME, QSize(S*2.1, S*2.1));
 	item->setData(GTW_COLUMN_NAME, Qt::TextColorRole, textColorCategory());
 	item->setData(GTW_COLUMN_DATA, ROLE_COLOR, GROUPTREEWIDGET_COLOR_CATEGORY);
 


### PR DESCRIPTION
Now it looks better then before
![image](https://user-images.githubusercontent.com/9952056/147352177-6921fbc7-82f4-4aa8-a735-71c247d89be7.png)![image](https://user-images.githubusercontent.com/9952056/147282347-8f7f67f6-1ff2-4a69-9058-c38a09fb02fd.png)

i added this changes but maybe not best method else needs to be fixed by @PhenomRetroShare 

	QFont font;
	font.setPointSize(11);
	item->setData(GTW_COLUMN_NAME,Qt::FontRole,font);