### PR TITLE
fixed bug caused in RsNxsPullItem

### DIFF
--- a/libretroshare/src/gxs/rsgxsnetservice.h
+++ b/libretroshare/src/gxs/rsgxsnetservice.h
@@ -432,7 +432,11 @@ private:
      */
     void handleRecvPublishKeys(RsNxsGroupPublishKeyItem*) ;
 
-	void handlePullRequest(std::unique_ptr<RsNxsPullRequestItem> item);
+    /*!
+     * Handles a nxs pull request item from a given friend/tunnel
+     * @param item contaims keys/grp info
+     */
+    void handlePullRequest(RsNxsPullRequestItem *item);
 
     /** E: item handlers **/
 

--- a/libretroshare/src/pqi/pqisslproxy.cc
+++ b/libretroshare/src/pqi/pqisslproxy.cc
@@ -586,9 +586,9 @@ bool pqisslproxy::connect_parameter(uint32_t type, const std::string &value)
 	
 	        if (type == NET_PARAM_CONNECT_DOMAIN_ADDRESS)
 	        {
-	                std::string out;
-	                rs_sprintf(out, "pqisslproxy::connect_parameter() Peer: %s DOMAIN_ADDRESS: %s", PeerId().toStdString().c_str(), value.c_str());
 #ifdef PROXY_DEBUG_LOG
+                    std::string out;
+	                rs_sprintf(out, "pqisslproxy::connect_parameter() Peer: %s DOMAIN_ADDRESS: %s", PeerId().toStdString().c_str(), value.c_str());
 	                rslog(RSL_WARNING, pqisslproxyzone, out);
 #endif
 	                mDomainAddress = value;

--- a/libretroshare/src/rsitems/rsnxsitems.cc
+++ b/libretroshare/src/rsitems/rsnxsitems.cc
@@ -64,12 +64,6 @@ RsItem *RsNxsSerialiser::create_item(uint16_t service_id,uint8_t item_subtype) c
     if(service_id != SERVICE_TYPE)
         return NULL ;
 
-	switch(static_cast<RsNxsSubtype>(item_subtype))
-	{
-	case RsNxsSubtype::PULL_REQUEST:
-		return new RsNxsPullRequestItem(static_cast<RsServiceType>(service_id));
-	}
-
     switch(item_subtype)
     {
         case RS_PKT_SUBTYPE_NXS_SYNC_GRP_REQ_ITEM:   return new RsNxsSyncGrpReqItem(SERVICE_TYPE) ;
@@ -82,6 +76,7 @@ RsItem *RsNxsSerialiser::create_item(uint16_t service_id,uint8_t item_subtype) c
         case RS_PKT_SUBTYPE_NXS_GRP_PUBLISH_KEY_ITEM:return new RsNxsGroupPublishKeyItem(SERVICE_TYPE) ;
         case RS_PKT_SUBTYPE_NXS_ENCRYPTED_DATA_ITEM: return new RsNxsEncryptedDataItem(SERVICE_TYPE) ;
         case RS_PKT_SUBTYPE_NXS_SYNC_GRP_STATS_ITEM: return new RsNxsSyncGrpStatsItem(SERVICE_TYPE) ;
+        case RS_PKT_SUBTYPE_NXS_SYNC_PULL_REQUEST_ITEM: return new RsNxsPullRequestItem(SERVICE_TYPE) ;
 
         default:
                 return NULL;

--- a/libretroshare/src/rsitems/rsnxsitems.h
+++ b/libretroshare/src/rsitems/rsnxsitems.h
@@ -35,11 +35,6 @@
 #include "serialiser/rstlvkeys.h"
 #include "gxs/rsgxsdata.h"
 
-enum class RsNxsSubtype : uint8_t
-{
-	PULL_REQUEST = 0x90 /// @see RsNxsPullRequestItem
-};
-
 // These items have "flag type" numbers, but this is not used.
 // TODO: refactor as C++11 enum class
 const uint8_t RS_PKT_SUBTYPE_NXS_SYNC_GRP_REQ_ITEM    = 0x01;
@@ -53,6 +48,7 @@ const uint8_t RS_PKT_SUBTYPE_NXS_SYNC_MSG_REQ_ITEM    = 0x10;
 const uint8_t RS_PKT_SUBTYPE_NXS_MSG_ITEM             = 0x20;
 const uint8_t RS_PKT_SUBTYPE_NXS_TRANSAC_ITEM         = 0x40;
 const uint8_t RS_PKT_SUBTYPE_NXS_GRP_PUBLISH_KEY_ITEM = 0x80;
+const uint8_t RS_PKT_SUBTYPE_NXS_SYNC_PULL_REQUEST_ITEM = 0x90;
 
 
 #ifdef RS_DEAD_CODE
@@ -370,13 +366,10 @@ public:
 /*!
  * Used to request to a peer pull updates from us ASAP without waiting GXS sync
  * timer */
-struct RsNxsPullRequestItem: RsItem
+class RsNxsPullRequestItem: public RsNxsItem
 {
-	explicit RsNxsPullRequestItem(RsServiceType servtype):
-	    RsItem( RS_PKT_VERSION_SERVICE,
-	            servtype,
-	            static_cast<uint8_t>(RsNxsSubtype::PULL_REQUEST),
-	            QOS_PRIORITY_RS_GXS_NET ) {}
+public:
+    explicit RsNxsPullRequestItem(uint16_t servtype): RsNxsItem(servtype, RS_PKT_SUBTYPE_NXS_SYNC_PULL_REQUEST_ITEM) {}
 
 	/// @see RsSerializable
 	void serial_process( RsGenericSerializer::SerializeJob,
@@ -388,8 +381,9 @@ struct RsNxsPullRequestItem: RsItem
  * Used to respond to a RsGrpMsgsReq
  * with message items satisfying request
  */
-struct RsNxsMsg : RsNxsItem
+class RsNxsMsg : public RsNxsItem
 {
+public:
 	explicit RsNxsMsg(uint16_t servtype)
 	  : RsNxsItem(servtype, RS_PKT_SUBTYPE_NXS_MSG_ITEM)
 	  , pos(0), count(0), meta(servtype), msg(servtype), metaData(NULL)


### PR DESCRIPTION
 The item was not deriving from RsNxsItem which caused a null pointer access when receiving a pull request through a distant sync tunnel.  Also cleaned up the code to avoid the dual representation of RsNxsItem types which made the code less readable.