### PR TITLE
Display the name of short invites properly

### DIFF
--- a/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
+++ b/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
@@ -599,7 +599,7 @@ void ConnectFriendWizard::initializePage(int id)
 			if(mIsShortInvite)
 			{
 				if(ui->nameEdit->text().isEmpty())
-					ui->nameEdit->setText(tr("[Unknown]"));
+					ui->nameEdit->setText(QString::fromUtf8(peerDetails.name.c_str()));
 				ui->addKeyToKeyring_CB->setChecked(false);
 				ui->addKeyToKeyring_CB->setEnabled(false);
 				ui->signersEdit->hide();


### PR DESCRIPTION
Instead of [Unknown], since the name is actually in the short invite.

This is what is shown on my setup now when adding a user's short invite:
![image](https://user-images.githubusercontent.com/4717816/152651906-73242f9b-35b8-44be-a038-0da659ef26ba.png)
