### PR TITLE
RetroShare-gui: Rename DATA_DIR to RS_DATA_DIR to be consistent

### DIFF
--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -146,11 +146,11 @@ unix {
 	target.path = "$${BIN_DIR}"
 	INSTALLS += target
 
-	data_files.path="$${DATA_DIR}/"
+        data_files.path="$${RS_DATA_DIR}/"
 	data_files.files=sounds qss
 	INSTALLS += data_files
 
-	style_files.path="$${DATA_DIR}/stylesheets"
+        style_files.path="$${RS_DATA_DIR}/stylesheets"
 	style_files.files=gui/qss/chat/Bubble gui/qss/chat/Bubble_Compact
 	INSTALLS += style_files
 


### PR DESCRIPTION
fixes 94bd09940722d1e4ca5dc8ab09488fd149f96aa5