### PR TITLE
[Messages] Feature to expand To field 

### DIFF
--- a/retroshare-gui/src/gui/msgs/MessageWidget.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageWidget.cpp
@@ -135,6 +135,8 @@ MessageWidget::MessageWidget(bool controlled, QWidget *parent, Qt::WindowFlags f
 	isWindow = false;
 	currMsgFlags = 0;
 	expandFiles = false;
+	ui.expandButton->hide();
+	ui.countLabel->hide();
 
 	ui.actionTextBesideIcon->setData(Qt::ToolButtonTextBesideIcon);
 	ui.actionIconOnly->setData(Qt::ToolButtonIconOnly);
@@ -144,6 +146,7 @@ MessageWidget::MessageWidget(bool controlled, QWidget *parent, Qt::WindowFlags f
 	connect(ui.downloadButton, SIGNAL(clicked()), this, SLOT(getallrecommended()));
 	connect(ui.msgText, SIGNAL(anchorClicked(QUrl)), this, SLOT(anchorClicked(QUrl)));
 	connect(ui.sendInviteButton, SIGNAL(clicked()), this, SLOT(sendInvite()));
+	connect(ui.expandButton, SIGNAL(clicked()), this, SLOT(expandTo()));
 	
 	connect(ui.replyButton, SIGNAL(clicked()), this, SLOT(reply()));
 	connect(ui.replyallButton, SIGNAL(clicked()), this, SLOT(replyAll()));
@@ -619,6 +622,18 @@ void MessageWidget::fill(const std::string &msgId)
 
 	ui.trans_ToText->setText(text);
 
+	int recipientsCount = ui.trans_ToText->toPlainText().split(QRegExp("(\\s|\\n|\\r)+"), QString::SkipEmptyParts).count();
+	ui.countLabel->setText( QString::number(recipientsCount));
+
+	if (recipientsCount >=20) {
+		ui.expandButton->show();
+		ui.countLabel->show();
+	} else {
+		ui.expandButton->hide();
+		ui.countLabel->hide();
+	}
+
+
 	if (!msgInfo.rspeerid_msgcc.empty() || !msgInfo.rsgxsid_msgcc.empty())
 	{
 		ui.ccLabel->setVisible(true);
@@ -939,4 +954,17 @@ void MessageWidget::checkLength()
 	text = tr("%1 (%2) ").arg(charlength).arg(misc::friendlyUnit(charlength));
 
 	ui.sizeLabel->setText(text);
+}
+
+void MessageWidget::expandTo()
+{
+	if (ui.expandButton->isChecked()) {
+		ui.expandButton->setIcon(FilesDefs::getIconFromQtResourcePath(QString(":/icons/png/up-arrow.png")));
+		ui.trans_ToText->setMaximumHeight(ui.trans_ToText->fontMetrics().lineSpacing()*3.5);
+		ui.expandButton->setToolTip(tr("Minimize"));
+	} else {
+		ui.expandButton->setIcon(FilesDefs::getIconFromQtResourcePath(QString(":/icons/png/down-arrow.png")));
+		ui.trans_ToText->setMaximumHeight(ui.trans_ToText->fontMetrics().lineSpacing()*1.5);
+		ui.expandButton->setToolTip(tr("Maximize"));
+	}
 }

--- a/retroshare-gui/src/gui/msgs/MessageWidget.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageWidget.cpp
@@ -631,6 +631,9 @@ void MessageWidget::fill(const std::string &msgId)
 	} else {
 		ui.expandButton->hide();
 		ui.countLabel->hide();
+		ui.expandButton->setChecked(false);
+		ui.expandButton->setIcon(FilesDefs::getIconFromQtResourcePath(QString(":/icons/png/down-arrow.png")));
+		ui.trans_ToText->setMaximumHeight(ui.trans_ToText->fontMetrics().lineSpacing()*1.5);
 	}
 
 

--- a/retroshare-gui/src/gui/msgs/MessageWidget.h
+++ b/retroshare-gui/src/gui/msgs/MessageWidget.h
@@ -72,7 +72,7 @@ private slots:
 	void saveAs();
 	void refill();
 	void sendInvite();
-
+	void expandTo();
 
 	void msgfilelistWidgetCostumPopupMenu(QPoint);
 	void messagesTagsChanged();

--- a/retroshare-gui/src/gui/msgs/MessageWidget.ui
+++ b/retroshare-gui/src/gui/msgs/MessageWidget.ui
@@ -51,8 +51,41 @@
           <property name="verticalSpacing">
            <number>3</number>
           </property>
-          <item row="4" column="0">
-           <widget class="QLabel" name="bccLabel">
+          <item row="0" column="2">
+           <widget class="QLabel" name="fromText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>2</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QLabel" name="subjectLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -65,15 +98,15 @@
              </font>
             </property>
             <property name="text">
-             <string>Bcc:</string>
+             <string>Subject:</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="toLabel">
+          <item row="5" column="0" colspan="2">
+           <widget class="QLabel" name="tagsLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -86,14 +119,33 @@
              </font>
             </property>
             <property name="text">
-             <string>To:</string>
+             <string>Tags:</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="2" colspan="4">
+           <widget class="RSTextBrowser" name="trans_BCCText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16</height>
+             </size>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
            <widget class="QLabel" name="ccLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -117,8 +169,8 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="tagsLabel">
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="fromLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -131,41 +183,14 @@
              </font>
             </property>
             <property name="text">
-             <string>Tags:</string>
+             <string>From:</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="1" column="4">
-           <widget class="QLabel" name="dateText">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="layoutDirection">
-             <enum>Qt::LeftToRight</enum>
-            </property>
-            <property name="text">
-             <string notr="true">Date</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="3">
+          <item row="0" column="3" colspan="3">
            <layout class="QHBoxLayout" name="subjectHLayout">
             <property name="spacing">
              <number>6</number>
@@ -290,7 +315,7 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="1" colspan="3">
+          <item row="1" column="2" colspan="3">
            <widget class="QLabel" name="subjectText">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -313,59 +338,10 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="fromText">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>2</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-            <property name="openExternalLinks">
-             <bool>true</bool>
-            </property>
-           </widget>
+          <item row="5" column="2" colspan="4">
+           <layout class="QHBoxLayout" name="tagLayout"/>
           </item>
-          <item row="2" column="1" colspan="4">
-           <widget class="RSTextBrowser" name="trans_ToText">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16</height>
-             </size>
-            </property>
-            <property name="openExternalLinks">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="4">
+          <item row="3" column="2" colspan="4">
            <widget class="RSTextBrowser" name="trans_CCText">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
@@ -384,30 +360,8 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1" colspan="4">
-           <widget class="RSTextBrowser" name="trans_BCCText">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16</height>
-             </size>
-            </property>
-            <property name="openExternalLinks">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1" colspan="4">
-           <layout class="QHBoxLayout" name="tagLayout"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="subjectLabel">
+          <item row="4" column="0" colspan="2">
+           <widget class="QLabel" name="bccLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -420,15 +374,89 @@
              </font>
             </property>
             <property name="text">
-             <string>Subject:</string>
+             <string>Bcc:</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="fromLabel">
+          <item row="1" column="5">
+           <widget class="QLabel" name="dateText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string notr="true">Date</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2" colspan="4">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <item>
+             <widget class="RSTextBrowser" name="trans_ToText">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16</height>
+               </size>
+              </property>
+              <property name="openExternalLinks">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="countLabel">
+              <property name="text">
+               <string>1</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="expandButton">
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../icons.qrc">
+                <normaloff>:/icons/png/down-arrow.png</normaloff>:/icons/png/down-arrow.png</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QLabel" name="toLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -441,7 +469,7 @@
              </font>
             </property>
             <property name="text">
-             <string>From:</string>
+             <string>To:</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>


### PR DESCRIPTION
i has created this changes to view the mass mail recipients to resize the To field with recipients counting.
recreated old PR #1951

![image](https://user-images.githubusercontent.com/9952056/203622072-a20d597c-40fe-4acb-9511-7cbe66fcc893.png)
![image](https://user-images.githubusercontent.com/9952056/203622536-c2ee7399-72d1-4ea6-a675-95fdce8c5bbb.png)
