### PR TITLE
Allow .jpeg files as stickers

### DIFF
--- a/retroshare-gui/src/gui/common/Emoticons.cpp
+++ b/retroshare-gui/src/gui/common/Emoticons.cpp
@@ -51,7 +51,7 @@ static QHash<QString, QPixmap> iconcache;
 void Emoticons::load()
 {
 	loadSmiley();
-	filters << "*.png" << "*.jpg" << "*.gif" << "*.webp";
+	filters << "*.png" << "*.jpg" << "*.jpeg" << "*.gif" << "*.webp";
 	stickerFolders << (QString::fromStdString(RsAccounts::AccountDirectory()) + "/stickers");		//under account, unique for user
 	stickerFolders << (QString::fromStdString(RsAccounts::ConfigDirectory()) + "/stickers");		//under .retroshare, shared between users
 	stickerFolders << (QString::fromStdString(RsAccounts::systemDataDirectory()) + "/stickers");	//exe's folder, shipped with RS


### PR DESCRIPTION
See "issue #24 RS does not recognize .jpeg files as valid stickers" in "Retroshare Bugs" forum