### PR TITLE
Allow to override openssl security level

### DIFF
--- a/retroshare-gui/src/main.cpp
+++ b/retroshare-gui/src/main.cpp
@@ -241,7 +241,8 @@ feenableexcept(FE_INVALID | FE_DIVBYZERO);
 	        >> parameter('i',"ip-address"    ,conf.forcedInetAddress,"nnn.nnn.nnn.nnn", "Force IP address to use (if cannot be detected)."    ,false)
 	        >> parameter('p',"port"          ,conf.forcedPort     ,"port"      ,"Set listenning port to use."                                 ,false)
             >> parameter('o',"opmode"        ,conf.opModeStr      ,"opmode"    ,"Set Operating mode (Full, NoTurtle, Gaming, Minimal)."       ,false)
-            >> parameter('t',"opmode"        ,conf.userSuppliedTorExecutable,"tor"    ,"supply full tor eecutable path."       ,false);
+            >> parameter('t',"tor"        ,conf.userSuppliedTorExecutable,"tor"    ,"supply full tor eecutable path."       ,false)
+            >> parameter(    "ssllevel"      ,conf.sslLevel       ,"level"     ,"Minimum SSL level allowed, set to 0 to allow login with old profiles.",false);
 #ifdef RS_JSONAPI
 	as      >> parameter('J', "jsonApiPort", conf.jsonApiPort, "jsonApiPort", "Enable JSON API on the specified port", false )
 	        >> parameter('P', "jsonApiBindAddress", conf.jsonApiBindAddress, "jsonApiBindAddress", "JSON API Bind Address.", false);

--- a/retroshare-service/src/retroshare-service.cc
+++ b/retroshare-service/src/retroshare-service.cc
@@ -180,7 +180,8 @@ int main(int argc, char* argv[])
        >> parameter( 'i', "ip-address", conf.forcedInetAddress, "IP", "Force IP address to use (if cannot be detected).", false )
        >> parameter( 'o', "opmode", conf.opModeStr, "opmode", "Set Operating mode (Full, NoTurtle, Gaming, Minimal).", false )
        >> parameter( 'p', "port", conf.forcedPort, "port", "Set listenning port to use.", false )
-       >> parameter( 't', "tor", conf.userSuppliedTorExecutable, "tor", "Set Tor executable full path.", false );
+       >> parameter( 't', "tor", conf.userSuppliedTorExecutable, "tor", "Set Tor executable full path.", false )
+       >> parameter(      "ssllevel", conf.sslLevel ,"level" ,"Minimum SSL level allowed, set to 0 to allow login with old profiles.",false);
 
 #ifdef RS_SERVICE_TERMINAL_LOGIN
 	as >> parameter( 'U', "user-id", prefUserString, "ID",


### PR DESCRIPTION
Let RS to load old profiles if started with -ssllevel 0

This PR also needed: https://github.com/RetroShare/libretroshare/pull/128