### PR TITLE
Add row count check in the RsFriendListModel::index method

### DIFF
--- a/retroshare-gui/src/gui/common/FriendListModel.cpp
+++ b/retroshare-gui/src/gui/common/FriendListModel.cpp
@@ -287,7 +287,7 @@ uint32_t   RsFriendListModel::EntryIndex::parentRow(uint32_t nb_groups) const
 
 QModelIndex RsFriendListModel::index(int row, int column, const QModelIndex& parent) const
 {
-    if(row < 0 || column < 0 || column >= COLUMN_THREAD_NB_COLUMNS)
+    if(row < 0 || column < 0 || column >= columnCount(parent) || row >= rowCount(parent))
 		return QModelIndex();
 
     if(parent.internalId() == 0)


### PR DESCRIPTION
Fix bug occurring after login where the app would crash unexpectedly. Turns out there was an index out of bounds exception occurring in the `RsFriendListModel::index` method.

Fixes #2808 