### PR TITLE
Renamed RsCollectionErrorCode::NO_ERROR to COLLECTION_NO_ERROR b…

### DIFF
--- a/retroshare-gui/src/gui/FileTransfer/SearchDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/SearchDialog.cpp
@@ -612,7 +612,7 @@ void SearchDialog::collOpen()
     RsCollection::RsCollectionErrorCode err;
     RsCollection collection(fileName, err);
 
-    if(err == RsCollection::RsCollectionErrorCode::NO_ERROR)
+    if(err == RsCollection::RsCollectionErrorCode::COLLECTION_NO_ERROR)
         RsCollectionDialog::downloadFiles(collection);
     else
         QMessageBox::information(nullptr,tr("Error open RsCollection file"),RsCollection::errorString(err));

--- a/retroshare-gui/src/gui/FileTransfer/SharedFilesDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/SharedFilesDialog.cpp
@@ -854,7 +854,7 @@ void SharedFilesDialog::collOpen()
     RsCollection::RsCollectionErrorCode err;
     RsCollection collection(fileName,err);
 
-    if(err == RsCollection::RsCollectionErrorCode::NO_ERROR)
+    if(err == RsCollection::RsCollectionErrorCode::COLLECTION_NO_ERROR)
         RsCollectionDialog::downloadFiles(collection);
 }
 

--- a/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
+++ b/retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp
@@ -2571,7 +2571,7 @@ void TransfersDialog::collOpen()
     RsCollection::RsCollectionErrorCode code;
     RsCollection collection(fileName,code);
 
-    if(code == RsCollection::RsCollectionErrorCode::NO_ERROR)
+    if(code == RsCollection::RsCollectionErrorCode::COLLECTION_NO_ERROR)
         RsCollectionDialog::downloadFiles(collection);
     else
         QMessageBox::information(nullptr,tr("Error openning collection file"),RsCollection::errorString(code));

--- a/retroshare-gui/src/gui/RetroShareLink.cpp
+++ b/retroshare-gui/src/gui/RetroShareLink.cpp
@@ -1148,7 +1148,7 @@ QString RetroShareLink::toHtmlSize() const
             RsCollection::RsCollectionErrorCode code;
             RsCollection collection(QString::fromUtf8(finfo.path.c_str()), code) ;
 
-            if(code == RsCollection::RsCollectionErrorCode::NO_ERROR)
+            if(code == RsCollection::RsCollectionErrorCode::COLLECTION_NO_ERROR)
 				size += QString(" [%1]").arg(misc::friendlyUnit(collection.size()));
 		}
 	}

--- a/retroshare-gui/src/gui/common/RsCollection.cpp
+++ b/retroshare-gui/src/gui/common/RsCollection.cpp
@@ -164,7 +164,7 @@ QString RsCollection::errorString(RsCollectionErrorCode code)
     {
     default: [[fallthrough]] ;
     case RsCollectionErrorCode::UNKNOWN_ERROR:                 return QObject::tr("Unknown error");
-    case RsCollectionErrorCode::NO_ERROR:                      return QObject::tr("No error");
+    case RsCollectionErrorCode::COLLECTION_NO_ERROR:           return QObject::tr("No error");
     case RsCollectionErrorCode::FILE_READ_ERROR:               return QObject::tr("Error while openning file");
     case RsCollectionErrorCode::FILE_CONTAINS_HARMFUL_STRINGS: return QObject::tr("Collection file contains potentially harmful code");
     case RsCollectionErrorCode::INVALID_ROOT_NODE:             return QObject::tr("Invalid root node. RsCollection node was expected.");
@@ -214,7 +214,7 @@ RsCollection::RsCollection(const QString& fileName, RsCollectionErrorCode& error
     if(!recursParseXml(xml_doc,root,0))
         error = RsCollectionErrorCode::XML_PARSING_ERROR;
     else
-        error = RsCollectionErrorCode::NO_ERROR;
+        error = RsCollectionErrorCode::COLLECTION_NO_ERROR;
 }
 
 // check that the file is a valid rscollection file, and not a lol bomb or some shit like this
@@ -222,7 +222,7 @@ RsCollection::RsCollection(const QString& fileName, RsCollectionErrorCode& error
 bool RsCollection::checkFile(const QString& fileName, RsCollectionErrorCode& error)
 {
     QFile file(fileName);
-    error = RsCollectionErrorCode::NO_ERROR;
+    error = RsCollectionErrorCode::COLLECTION_NO_ERROR;
 
     if (!file.open(QIODevice::ReadOnly))
     {

--- a/retroshare-gui/src/gui/common/RsCollection.h
+++ b/retroshare-gui/src/gui/common/RsCollection.h
@@ -56,12 +56,12 @@ class RsCollection
 {
 public:
     enum class RsCollectionErrorCode:uint8_t {
-        NO_ERROR                      = 0x00,
+        COLLECTION_NO_ERROR           = 0x00,
         UNKNOWN_ERROR                 = 0x01,
         FILE_READ_ERROR               = 0x02,
         FILE_CONTAINS_HARMFUL_STRINGS = 0x03,
         INVALID_ROOT_NODE             = 0x04,
-        XML_PARSING_ERROR             = 0x05,
+        XML_PARSING_ERROR             = 0x05
     };
 
     RsCollection();

--- a/retroshare-gui/src/gui/common/RsCollectionDialog.cpp
+++ b/retroshare-gui/src/gui/common/RsCollectionDialog.cpp
@@ -130,7 +130,7 @@ RsCollectionDialog::RsCollectionDialog(const QString& collectionFileName, RsColl
     RsCollection::RsCollectionErrorCode err_code;
     mCollection = new RsCollection(collectionFileName,err_code);
 
-    if(err_code != RsCollection::RsCollectionErrorCode::NO_ERROR)
+    if(err_code != RsCollection::RsCollectionErrorCode::COLLECTION_NO_ERROR)
     {
         QMessageBox::information(nullptr,tr("Could not load collection file"),tr("Could not load collection file"));
         close();
@@ -472,7 +472,7 @@ void RsCollectionDialog::changeFileName()
 
             RsCollection qddOldFileCollection(fileName,err);
 
-            if(err != RsCollection::RsCollectionErrorCode::NO_ERROR)
+            if(err != RsCollection::RsCollectionErrorCode::COLLECTION_NO_ERROR)
             {
                 mCollectionModel->preMods();
                 mCollection->merge_in(qddOldFileCollection.fileTree());


### PR DESCRIPTION
…ecause of double define of NO_ERROR in winerror.h

@csoler Maybe you find a better name then COLLECTION_NO_ERROR