### PR TITLE
Make RS use RNP for PGP

### DIFF
--- a/RetroShare.pro
+++ b/RetroShare.pro
@@ -25,9 +25,6 @@ CONFIG += c++14
 
 TEMPLATE = subdirs
 
-SUBDIRS += openpgpsdk
-openpgpsdk.file = openpgpsdk/src/openpgpsdk.pro
-
 rs_jsonapi:isEmpty(JSONAPI_GENERATOR_EXE) {
     SUBDIRS += jsonapi-generator
     jsonapi-generator.file = jsonapi-generator/src/jsonapi-generator.pro
@@ -36,7 +33,7 @@ rs_jsonapi:isEmpty(JSONAPI_GENERATOR_EXE) {
 
 SUBDIRS += libbitdht
 libbitdht.file = libbitdht/src/libbitdht.pro
-libretroshare.depends += openpgpsdk libbitdht
+libretroshare.depends += libbitdht
 
 SUBDIRS += libretroshare
 libretroshare.file = libretroshare/src/libretroshare.pro

--- a/retroshare-friendserver/src/friendserver.cc
+++ b/retroshare-friendserver/src/friendserver.cc
@@ -8,10 +8,10 @@
 
 #include "pgp/pgpkeyutil.h"
 #include "pgp/rscertificate.h"
-#ifdef USE_RNP_LIB
-#include "pgp/rnppgphandler.h"
-#else
+#ifdef USE_OPENPGPSDK
 #include "pgp/openpgpsdkhandler.h"
+#else
+#include "pgp/rnppgphandler.h"
 #endif
 
 #include "friendserver.h"
@@ -397,10 +397,10 @@ FriendServer::FriendServer(const std::string& base_dir,const std::string& listen
     std::string pgp_private_keyring_path = RsDirUtil::makePath(base_dir,"pgp_private_keyring") ;	// not used.
     std::string pgp_trustdb_path         = RsDirUtil::makePath(base_dir,"pgp_trustdb") ;	        // not used.
 
-#ifdef USE_RNP_LIB
-    mPgpHandler = new RNPPGPHandler(pgp_public_keyring_path,pgp_private_keyring_path,pgp_trustdb_path,pgp_lock_path);
-#else
+#ifdef USE_OPENPGPSDK
     mPgpHandler = new OpenPGPSDKHandler(pgp_public_keyring_path,pgp_private_keyring_path,pgp_trustdb_path,pgp_lock_path);
+#else
+    mPgpHandler = new RNPPGPHandler(pgp_public_keyring_path,pgp_private_keyring_path,pgp_trustdb_path,pgp_lock_path);
 #endif
 
     // Random bias. Should be cryptographically safe.

--- a/retroshare-friendserver/src/friendserver.cc
+++ b/retroshare-friendserver/src/friendserver.cc
@@ -8,7 +8,11 @@
 
 #include "pgp/pgpkeyutil.h"
 #include "pgp/rscertificate.h"
+#ifdef USE_RNP_LIB
+#include "pgp/rnppgphandler.h"
+#else
 #include "pgp/openpgpsdkhandler.h"
+#endif
 
 #include "friendserver.h"
 #include "friend_server/fsitem.h"
@@ -393,7 +397,11 @@ FriendServer::FriendServer(const std::string& base_dir,const std::string& listen
     std::string pgp_private_keyring_path = RsDirUtil::makePath(base_dir,"pgp_private_keyring") ;	// not used.
     std::string pgp_trustdb_path         = RsDirUtil::makePath(base_dir,"pgp_trustdb") ;	        // not used.
 
+#ifdef USE_RNP_LIB
+    mPgpHandler = new RNPPGPHandler(pgp_public_keyring_path,pgp_private_keyring_path,pgp_trustdb_path,pgp_lock_path);
+#else
     mPgpHandler = new OpenPGPSDKHandler(pgp_public_keyring_path,pgp_private_keyring_path,pgp_trustdb_path,pgp_lock_path);
+#endif
 
     // Random bias. Should be cryptographically safe.
 

--- a/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
+++ b/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
@@ -196,11 +196,11 @@ void PGPKeyDialog::load()
         ui.trustlevel_CB->show();
         ui.is_signing_me->show();
         ui.signersLabel->setText(tr("This key is signed by :")+" ");
-#ifdef USE_RNP_LIB
+#ifdef USE_OPENPGPSDK
+        ui.signKeyButton->setEnabled(!detail.ownsign);
+#else
         ui.signKeyButton->setEnabled(false);
         ui.signKeyButton->setToolTip("Disabled because key signing is not yet implemented in RNP lib");
-#else
-        ui.signKeyButton->setEnabled(!detail.ownsign);
 #endif
 
         if (detail.accept_connection)

--- a/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
+++ b/retroshare-gui/src/gui/connect/PGPKeyDialog.cpp
@@ -196,7 +196,12 @@ void PGPKeyDialog::load()
         ui.trustlevel_CB->show();
         ui.is_signing_me->show();
         ui.signersLabel->setText(tr("This key is signed by :")+" ");
+#ifdef USE_RNP_LIB
+        ui.signKeyButton->setEnabled(false);
+        ui.signKeyButton->setToolTip("Disabled because key signing is not yet implemented in RNP lib");
+#else
         ui.signKeyButton->setEnabled(!detail.ownsign);
+#endif
 
         if (detail.accept_connection)
         {

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -305,11 +305,17 @@ isEmpty(RS_THREAD_LIB):RS_THREAD_LIB = pthread
 #    Why:  Avoids sending probe packets
 #    BackwardCompat: old RS before Mai 2019 will not be able to distant chat.
 #
-#  V07_NON_BACKWARD_COMPATIBLE_CHANGE_005:
+###########################################################################################################################################################
+
+###########################################################################################################################################################
+#
+#  V06_EXPERIMENTAL_CHANGE_001:
 #
 #    What: removes issuer fingerprint from signature subpackets
 #    Why:  This type of subpacket is not part of RFC4880 and not recognised by OpenPGP-SDK
 #    BackwardCompat: old RS before Sept.2024 will not be able to exchange keys
+#    Note: Since signature subpacket 33 is part of the hashed section of the signature, this also invalidates the signature.
+#           Depending on the implementation, certificates with self-signature that miss this subpacket may not be accepted.
 #
 ###########################################################################################################################################################
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -305,6 +305,12 @@ isEmpty(RS_THREAD_LIB):RS_THREAD_LIB = pthread
 #    Why:  Avoids sending probe packets
 #    BackwardCompat: old RS before Mai 2019 will not be able to distant chat.
 #
+#  V07_NON_BACKWARD_COMPATIBLE_CHANGE_005:
+#
+#    What: removes issuer fingerprint from signature subpackets
+#    Why:  This type of subpacket is not part of RFC4880 and not recognised by OpenPGP-SDK
+#    BackwardCompat: old RS before Sept.2024 will not be able to exchange keys
+#
 ###########################################################################################################################################################
 
 
@@ -318,6 +324,7 @@ rs_v07_changes {
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_002
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_003
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_004
+    DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_005
     DEFINES += V07_NON_BACKWARD_COMPATIBLE_CHANGE_UNNAMED
 }
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -182,6 +182,8 @@ rs_deep_files_index_taglib:CONFIG -= no_rs_deep_files_index_taglib
 CONFIG *= no_rs_use_native_dialogs
 rs_use_native_dialogs:CONFIG -= no_rs_use_native_dialogs
 
+CONFIG *= use_rnp
+
 # To disable broadcast discovery append the following assignation to qmake
 # command line "CONFIG+=no_rs_broadcast_discovery"
 CONFIG *= rs_broadcast_discovery

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -184,8 +184,8 @@ rs_use_native_dialogs:CONFIG -= no_rs_use_native_dialogs
 
 # By default, use RNP lib for RFC4880 PGP management. If not, compilation will
 # default to openpgp-sdk, which is old and unmaintained, so probably not very secure.
-CONFIG *= rs_rnplib
-rs_no_rnplib:CONFIG -= use_rnp_lib
+CONFIG *=
+rs_no_openpgpsdk:CONFIG -= use_openpgpsdk
 
 # To disable broadcast discovery append the following assignation to qmake
 # command line "CONFIG+=no_rs_broadcast_discovery"
@@ -867,14 +867,14 @@ isEmpty(RS_UPNP_LIB) {
     }
 }
 
-rs_rnplib {
-        DEFINES += USE_RNP_LIB
-        message("Using RNP lib for PGP")
-} else {
+rs_openpgpsdk {
         SUBDIRS += openpgpsdk
         openpgpsdk.file = openpgpsdk/src/openpgpsdk.pro
         libretroshare.depends += openpgpsdk
         message("Using OpenPGP-SDK for PGP")
+} else {
+        DEFINES += USE_RNP_LIB
+        message("Using RNP lib for PGP")
 }
 
 

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -182,7 +182,10 @@ rs_deep_files_index_taglib:CONFIG -= no_rs_deep_files_index_taglib
 CONFIG *= no_rs_use_native_dialogs
 rs_use_native_dialogs:CONFIG -= no_rs_use_native_dialogs
 
-CONFIG *= use_rnp
+# By default, use RNP lib for RFC4880 PGP management. If not, compilation will
+# default to openpgp-sdk, which is old and unmaintained, so probably not very secure.
+CONFIG *= rs_rnplib
+rs_no_rnplib:CONFIG -= use_rnp_lib
 
 # To disable broadcast discovery append the following assignation to qmake
 # command line "CONFIG+=no_rs_broadcast_discovery"
@@ -850,6 +853,17 @@ isEmpty(RS_UPNP_LIB) {
         message("Autodetected RS_UPNP_LIB=$$RS_UPNP_LIB")
     }
 }
+
+rs_rnplib {
+        DEFINES += USE_RNP_LIB
+        message("Using RNP lib for PGP")
+} else {
+        SUBDIRS += openpgpsdk
+        openpgpsdk.file = openpgpsdk/src/openpgpsdk.pro
+        libretroshare.depends += openpgpsdk
+        message("Using OpenPGP-SDK for PGP")
+}
+
 
 equals(RS_UPNP_LIB, none):RS_UPNP_LIB=
 equals(RS_UPNP_LIB, miniupnpc):DEFINES*=RS_USE_LIBMINIUPNPC


### PR DESCRIPTION
Needs PR #148 (libretroshare). Compile with "qmake -r CONFIG=debug; make"

The PR makes a copy of your keyring in a new directory named rnp/ (previously pgp), so it is safe to use this PR on an existing profile. The changes however will not be visible to the openpgp-sdk version of Retroshare.