### PR TITLE
retroshare.desktop: remove deprecated category

### DIFF
--- a/data/retroshare.desktop
+++ b/data/retroshare.desktop
@@ -7,5 +7,5 @@ Exec=/usr/bin/retroshare %U
 Icon=/usr/share/pixmaps/retroshare.xpm
 Terminal=false
 Type=Application
-Categories=Application;Network;Email;InstantMessaging;Chat;Feed;FileTransfer;P2P
+Categories=Network;Email;InstantMessaging;Chat;Feed;FileTransfer;P2P
 MimeType=x-scheme-handler/retroshare;


### PR DESCRIPTION
Spotted in https://bugs.gentoo.org/947403.

```
/usr/share/applications/retroshare.desktop: warning:
value "Application;Network;P2P;Feed;Chat;InstantMessaging"
for key "Categories" in group "Desktop Entry" contains a deprecated value "Application"
```