### PR TITLE
Make forum moderator selectable by the user

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
+++ b/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
@@ -168,23 +168,23 @@ void  CreateGxsForumMsg::newMsg()
 
 	/* fill in the available OwnIds for signing */
 
-    	//std::cerr << "Initing ID chooser. Sign flags = " << std::hex << mForumMeta.mSignFlags << std::dec << std::endl;
-    uint32_t idChooserFlags = IDCHOOSER_ID_REQUIRED;
-    if(!mOrigMsgId.isNull()) {
-        // we are editing an existing message
-        std::set<RsGxsId> id_set = mModeratorSet;
-        if(!mPosterId.isNull())
-          id_set.insert(mPosterId);
+	//std::cerr << "Initing ID chooser. Sign flags = " << std::hex << mForumMeta.mSignFlags << std::dec << std::endl;
+	uint32_t idChooserFlags = IDCHOOSER_ID_REQUIRED;
+	if(!mOrigMsgId.isNull()) {
+		// we are editing an existing message
+		std::set<RsGxsId> id_set = mModeratorSet;
+		if(!mPosterId.isNull())
+			id_set.insert(mPosterId);
 
-        // TODO: Report error if idChooser has no IDs to choose from.
-        // NOTE: mPosterId may not be our own; then GxsIdChooser will not include it.
+		// TODO: Report error if idChooser has no IDs to choose from.
+		// NOTE: mPosterId may not be our own; then GxsIdChooser will not include it.
 
-        idChooserFlags |= IDCHOOSER_NO_CREATE;
-        ui->idChooser->setIdConstraintSet(id_set);
-    }
-    ui->idChooser->loadIds(idChooserFlags, mPosterId);
+		idChooserFlags |= IDCHOOSER_NO_CREATE;
+		ui->idChooser->setIdConstraintSet(id_set);
+	}
+	ui->idChooser->loadIds(idChooserFlags, mPosterId);
 
-        if (mForumId.isNull()) {
+	if (mForumId.isNull()) {
 		mStateHelper->setActive(CREATEGXSFORUMMSG_FORUMINFO, false);
 		mStateHelper->setActive(CREATEGXSFORUMMSG_PARENTMSG, false);
 		mStateHelper->setActive(CREATEGXSFORUMMSG_ORIGMSG, false);
@@ -406,7 +406,7 @@ void  CreateGxsForumMsg::createMsg()
 	msg.mMeta.mGroupId = mForumId;
 	msg.mMeta.mParentId = mParentId;
 	msg.mMeta.mOrigMsgId = mOrigMsgId;
-  msg.mMeta.mMsgFlags = 0;
+	msg.mMeta.mMsgFlags = 0;
 	msg.mMeta.mMsgId.clear() ;
 
 	if (mParentMsgLoaded) {
@@ -428,8 +428,8 @@ void  CreateGxsForumMsg::createMsg()
 		case GxsIdChooser::KnowId:
 		case GxsIdChooser::UnKnowId:
 			msg.mMeta.mAuthorId = authorId;
-      if(!mOrigMsgId.isNull() && authorId != mPosterId)
-        msg.mMeta.mMsgFlags |= RS_GXS_FORUM_MSG_FLAGS_MODERATED;
+			if(!mOrigMsgId.isNull() && authorId != mPosterId)
+				msg.mMeta.mMsgFlags |= RS_GXS_FORUM_MSG_FLAGS_MODERATED;
 			//std::cerr << "CreateGxsForumMsg::createMsg() AuthorId: " << authorId;
 			//std::cerr << std::endl;
 

--- a/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.h
+++ b/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.h
@@ -38,7 +38,7 @@ class CreateGxsForumMsg : public QDialog
 	Q_OBJECT
 
 public:
-        CreateGxsForumMsg(const RsGxsGroupId &fId, const RsGxsMessageId &pId, const RsGxsMessageId &moId, const RsGxsId &posterId = RsGxsId(),bool isModerating=false);
+				CreateGxsForumMsg(const RsGxsGroupId &fId, const RsGxsMessageId &pId, const RsGxsMessageId &moId, const RsGxsId &posterId = RsGxsId(), const std::set<RsGxsId>& moderatorSet = std::set<RsGxsId>());
 	~CreateGxsForumMsg();
 
 	void newMsg(); /* cleanup */
@@ -59,7 +59,7 @@ private slots:
 
 protected:
 	void closeEvent (QCloseEvent * event);
-    
+
     void loadCircleInfo(const RsGxsGroupId& circle_id);
 private:
     void processSettings(bool load);
@@ -75,7 +75,7 @@ private:
 	bool mOrigMsgLoaded;
 	bool mForumMetaLoaded;
 	bool mForumCircleLoaded ;
-    bool mIsModerating;			// means that the msg has a orig author Id that is not the Id of the author
+		std::set<RsGxsId> mModeratorSet; // these IDs are allowed to edit the post in addition to mPosterId
 
 	RsGxsForumMsg mParentMsg;
 	RsGxsForumMsg mOrigMsg;

--- a/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.h
+++ b/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.h
@@ -75,7 +75,7 @@ private:
 	bool mOrigMsgLoaded;
 	bool mForumMetaLoaded;
 	bool mForumCircleLoaded ;
-		std::set<RsGxsId> mModeratorSet; // these IDs are allowed to edit the post in addition to mPosterId
+	std::set<RsGxsId> mModeratorSet; // these IDs are allowed to edit the post in addition to mPosterId
 
 	RsGxsForumMsg mParentMsg;
 	RsGxsForumMsg mOrigMsg;

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1753,33 +1753,17 @@ void GxsForumThreadWidget::editForumMessageData(const RsGxsForumMsg& msg)
 
     std::list<RsGxsId> own_ids ;
     rsIdentity->getOwnIds(own_ids) ;
-
+    std::set<RsGxsId> modIds;
     for(auto it(own_ids.begin());it!=own_ids.end();++it)
         if(mForumGroup.mAdminList.ids.find(*it) != mForumGroup.mAdminList.ids.end())
-        {
-            moderator_id = *it;
-            break;
-        }
+            modIds.insert(*it);
 
-    // Check that author is in own ids, if not use the moderator id that was collected among own ids.
-    bool is_own = false ;
-    for(auto it(own_ids.begin());it!=own_ids.end() && !is_own;++it)
-        if(*it == msg.mMeta.mAuthorId)
-            is_own = true ;
+    CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mMsgId, msg.mMeta.mAuthorId, modIds);
 
-    if (!msg.mMeta.mAuthorId.isNull())
-    {
-        CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mMsgId, is_own?(msg.mMeta.mAuthorId):moderator_id,!is_own);
+    cfm->insertPastedText(QString::fromUtf8(msg.mMsg.c_str())) ;
+    cfm->show();
 
-        cfm->insertPastedText(QString::fromUtf8(msg.mMsg.c_str())) ;
-        cfm->show();
-
-        /* window will destroy itself! */
-    }
-    else
-    {
-        QMessageBox::information(this, tr("RetroShare"),tr("You cant reply to an Anonymous Author"));
-    }
+    /* cfm window will destroy itself! */
 }
 void GxsForumThreadWidget::replyForumMessageData(const RsGxsForumMsg &msg)
 {


### PR DESCRIPTION
This PR allows the user to select which moderator identity to use when editing a forum post.

Marking this as draft for now until I get a chance to test it.