### PR TITLE
Fixed set of default language in LanguageSupport::localize. Use value…

### DIFF
--- a/retroshare-gui/src/lang/languagesupport.cpp
+++ b/retroshare-gui/src/lang/languagesupport.cpp
@@ -261,6 +261,6 @@ bool LanguageSupport::localize(const QString &languageCode)
 {
   if (!isValidLanguageCode(languageCode))
     return false;
-  QLocale::setDefault(locales().key(languageCode));
+  QLocale::setDefault(locales()[languageCode]);
   return true;
 }


### PR DESCRIPTION
… of language map instead of key.