### PR TITLE
Update Linux_InstallGuide.md

### DIFF
--- a/build_scripts/Debian+Ubuntu/Linux_InstallGuide.md
+++ b/build_scripts/Debian+Ubuntu/Linux_InstallGuide.md
@@ -6,7 +6,7 @@
 #### Debian/Ubuntu
 ```bash
    sudo apt-get install g++ cmake libbz2-dev libjson-c-dev libssl-dev libsqlcipher-dev \
-   libupnp-dev libxss-dev rapidjson-dev libbotan-2-dev libasio-dev
+   libupnp-dev libxss-dev doxygen rapidjson-dev libbotan-2-dev libasio-dev
 ```
 
 To compile with Qt5:


### PR DESCRIPTION
added "doxygen" as additional dependence because of compile error (doxygen not found) with clean ubuntu 24.04/25.04 install.