### PR TITLE
revert addition of `saveAddresses()` call from #841

### DIFF
--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -1771,8 +1771,6 @@ void ServerPage::updateStatusSam()
             ui.leBobB32Addr->hide();
             ui.pbBobGenAddr->hide();
         }
-
-		saveAddresses();
     }
 
 	samStatus ss;


### PR DESCRIPTION
This fixes a bug where the i2p local port is occasionally reset to 10. Turns out `saveAddresses()` was being called during GUI initialization; thus, uninitialized values were getting saved to the configuration file. #841, which added the `saveAddresses()` call, admits there is no evidence that the call to `saveAddresses()` is necessary and assumes that calling `saveAddresses()` is benign at worst.