### PR TITLE
remove duplicate code introduced by merging

### DIFF
--- a/retroshare-gui/src/gui/FriendsDialog.cpp
+++ b/retroshare-gui/src/gui/FriendsDialog.cpp
@@ -242,29 +242,19 @@ void FriendsDialog::chatMessageReceived(const ChatMessage &msg)
     if(!msg.chat_id.isBroadcast())
         return;
 
-    QDateTime sendTime = QDateTime::fromTime_t(msg.sendTime);
-    QDateTime recvTime = QDateTime::fromTime_t(msg.recvTime);
-    QString message = QString::fromUtf8(msg.msg.c_str());
-    QString name = QString::fromUtf8(rsPeers->getPeerName(msg.broadcast_peer_id).c_str());
+	QDateTime sendTime = DateTime::DateTimeFromTime_t(msg.sendTime);
+	QDateTime recvTime = DateTime::DateTimeFromTime_t(msg.recvTime);
+	QString message = QString::fromUtf8(msg.msg.c_str());
+	QString name = QString::fromUtf8(rsPeers->getPeerName(msg.broadcast_peer_id).c_str());
 
-    ui.chatWidget->addChatMsg(msg.incoming, name, sendTime, recvTime, message, ChatWidget::MSGTYPE_NORMAL);
+	ui.chatWidget->addChatMsg(msg.incoming, name, sendTime, recvTime, message, ChatWidget::MSGTYPE_NORMAL);
 
-    if(ui.chatWidget->isActive())
-    {
-        QDateTime sendTime = DateTime::DateTimeFromTime_t(msg.sendTime);
-        QDateTime recvTime = DateTime::DateTimeFromTime_t(msg.recvTime);
-        QString message = QString::fromUtf8(msg.msg.c_str());
-        QString name = QString::fromUtf8(rsPeers->getPeerName(msg.broadcast_peer_id).c_str());
-
-        ui.chatWidget->addChatMsg(msg.incoming, name, sendTime, recvTime, message, ChatWidget::MSGTYPE_NORMAL);
-
-        if(ui.chatWidget->isActive())
-        {
+	if(ui.chatWidget->isActive())
+	{
             // clear the chat notify when control returns to the Qt event loop
             // we have to do this later, because we don't know if we or the notify receives the chat message first
             QMetaObject::invokeMethod(this, "clearChatNotify", Qt::QueuedConnection);
-        }
-    }
+	}
 }
 
 void FriendsDialog::chatStatusReceived(const ChatId &chat_id, const QString &status_string)


### PR DESCRIPTION
Original function: https://github.com/RetroShare/RetroShare/blame/9b881a62146342264d67e0cb5207305bb87fe6c2/retroshare-gui/src/gui/FriendsDialog.cpp#L203-L219C2
changed by thunders upgrade to Qt6 and Cyrils (https://github.com/RetroShare/RetroShare/commit/2506bc5672d7dabb08fa7a5de338a9498134e902) upgrade by https://github.com/RetroShare/RetroShare/pull/2951 this pull request repairs the code duplication introduced while merging #2951. This pr also replaces #3057 to keep the changes introduced by Thunder, regardingt to the DateTime:: stuff, consistent with the code.