### PR TITLE
Remove recursive singleShot calls on feed items

### DIFF
--- a/retroshare-gui/src/gui/feeds/ChatMsgItem.cpp
+++ b/retroshare-gui/src/gui/feeds/ChatMsgItem.cpp
@@ -67,6 +67,11 @@ ChatMsgItem::ChatMsgItem(FeedHolder *parent, uint32_t feedId, const RsPeerId &pe
     updateItemStatic();
     updateItem();
     insertChat(message);
+
+    m_updateTimer = new QTimer(this);
+    m_updateTimer->setSingleShot(false);
+    connect(m_updateTimer, SIGNAL(timeout()), this, SLOT(updateItem()));
+    m_updateTimer->start(1000);
 }
 
 void ChatMsgItem::updateItemStatic()
@@ -122,11 +127,6 @@ void ChatMsgItem::updateItem()
             msgButton->setEnabled(false);
         }
     }
-    
-    /* slow Tick  */
-    int msec_rate = 10129;
-
-    QTimer::singleShot( msec_rate, this, SLOT(updateItem( void ) ));
     return;
 }
 

--- a/retroshare-gui/src/gui/feeds/ChatMsgItem.cpp
+++ b/retroshare-gui/src/gui/feeds/ChatMsgItem.cpp
@@ -37,7 +37,7 @@
 #include "gui/msgs/MessageInterface.h"
 
 #include "util/qtthreadsutils.h"
-#include <retroshare/rsevents.h>
+#include "retroshare/rsevents.h"
 
 /*****
  * #define DEBUG_ITEM 1

--- a/retroshare-gui/src/gui/feeds/ChatMsgItem.h
+++ b/retroshare-gui/src/gui/feeds/ChatMsgItem.h
@@ -60,6 +60,7 @@ private:
 	void insertChat(const std::string &message);
 
 	RsPeerId mPeerId;
+	QTimer *m_updateTimer;
 };
 
 #endif

--- a/retroshare-gui/src/gui/feeds/ChatMsgItem.h
+++ b/retroshare-gui/src/gui/feeds/ChatMsgItem.h
@@ -35,6 +35,8 @@ public:
 	/** Default Constructor */
 	ChatMsgItem(FeedHolder *parent, uint32_t feedId, const RsPeerId &peerId, const std::string &message);
 
+	virtual ~ChatMsgItem();
+
 	void updateItemStatic();
 
     virtual uint64_t uniqueIdentifier() const override { return hash_64bits("ChatMsgItem " + mPeerId.toStdString()); }
@@ -60,7 +62,7 @@ private:
 	void insertChat(const std::string &message);
 
 	RsPeerId mPeerId;
-	QTimer *m_updateTimer;
+	RsEventsHandlerId_t mEventHandlerId;
 };
 
 #endif

--- a/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
@@ -92,7 +92,7 @@ void SecurityIpItem::setup()
         	{
 			// Filter events to only update relevant items.
 			auto fe = dynamic_cast<const RsFriendListEvent*>(e.get());
-			if(fe && fe->mSslId != mSslId)
+			if(!fe || fe->mSslId != mSslId)
 				return;
 			updateItem();
 		}

--- a/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
@@ -90,9 +90,13 @@ void SecurityIpItem::setup()
 	{
 	        RsQThreadUtils::postToObject([=]()
         	{
-		        updateItem();
-	        }
-	        , this );
+			// Filter events to only update relevant items.
+			auto fe = dynamic_cast<const RsFriendListEvent*>(e.get());
+			if(fe && fe->mSslId != mSslId)
+				return;
+			updateItem();
+		}
+		, this );
 	}, mEventHandlerId, RsEventType::FRIEND_LIST );	
 }
 

--- a/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
@@ -76,6 +76,11 @@ void SecurityIpItem::setup()
 
 	updateItemStatic();
 	updateItem();
+
+	m_updateTimer = new QTimer(this);
+	m_updateTimer->setSingleShot(false);
+	connect(m_updateTimer, SIGNAL(timeout()), this, SLOT(updateItem()));
+	m_updateTimer->start(1000);
 }
 
 uint64_t SecurityIpItem::uniqueIdentifier() const
@@ -178,11 +183,6 @@ void SecurityIpItem::updateItem()
 			ui->peerDetailsButton->setEnabled(true);
 		}
 	}
-
-	/* slow Tick  */
-	int msec_rate = 10129;
-
-	QTimer::singleShot( msec_rate, this, SLOT(updateItem(void)));
 }
 
 void SecurityIpItem::toggle()

--- a/retroshare-gui/src/gui/feeds/SecurityIpItem.h
+++ b/retroshare-gui/src/gui/feeds/SecurityIpItem.h
@@ -21,12 +21,11 @@
 #ifndef _SECURITYIPITEM_H
 #define _SECURITYIPITEM_H
 
-#include "retroshare/rstypes.h"
-
-#include "FeedItem.h"
 #include <stdint.h>
 
-#include <retroshare/rsevents.h>
+#include "retroshare/rstypes.h"
+#include "retroshare/rsevents.h"
+#include "FeedItem.h"
 
 namespace Ui {
 class SecurityIpItem;

--- a/retroshare-gui/src/gui/feeds/SecurityIpItem.h
+++ b/retroshare-gui/src/gui/feeds/SecurityIpItem.h
@@ -60,12 +60,13 @@ private slots:
 	void banIpListChanged(const QString &ipAddress);
 
 private:
-    RsFeedTypeFlags mType;
+	RsFeedTypeFlags mType;
 	RsPeerId mSslId;
 	std::string mIpAddr;
 	std::string mIpAddrReported;
 	uint32_t mResult;
 	bool mIsTest;
+	QTimer *m_updateTimer;
 
 	/** Qt Designer generated object */
 	Ui::SecurityIpItem *ui;

--- a/retroshare-gui/src/gui/feeds/SecurityIpItem.h
+++ b/retroshare-gui/src/gui/feeds/SecurityIpItem.h
@@ -26,6 +26,8 @@
 #include "FeedItem.h"
 #include <stdint.h>
 
+#include <retroshare/rsevents.h>
+
 namespace Ui {
 class SecurityIpItem;
 } 
@@ -44,6 +46,7 @@ public:
 	void updateItemStatic();
 
     uint64_t uniqueIdentifier() const override;
+    virtual ~SecurityIpItem();
 
 protected:
 	/* FeedItem */
@@ -66,7 +69,7 @@ private:
 	std::string mIpAddrReported;
 	uint32_t mResult;
 	bool mIsTest;
-	QTimer *m_updateTimer;
+	RsEventsHandlerId_t mEventHandlerId;
 
 	/** Qt Designer generated object */
 	Ui::SecurityIpItem *ui;

--- a/retroshare-gui/src/gui/feeds/SecurityItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.cpp
@@ -93,17 +93,13 @@ SecurityItem::SecurityItem(FeedHolder *parent, uint32_t feedId, const RsPgpId &g
 
 	updateItemStatic();
 	updateItem();
-
-	m_updateTimer = new QTimer(this);
-	m_updateTimer->setSingleShot(false); 
-	connect(m_updateTimer, &QTimer::timeout, this, &SecurityItem::updateItem);
-	m_updateTimer->start(1000);
 }
 
 SecurityItem::~SecurityItem()
 {
     rsEvents->unregisterEventsHandler(mEventHandlerId);
 }
+
 uint64_t SecurityItem::uniqueIdentifier() const
 {
     return hash_64bits("SecurityItem " + QString::number((uint)mType).toStdString() + " " + mSslId.toStdString());

--- a/retroshare-gui/src/gui/feeds/SecurityItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.cpp
@@ -93,6 +93,11 @@ SecurityItem::SecurityItem(FeedHolder *parent, uint32_t feedId, const RsPgpId &g
 
 	updateItemStatic();
 	updateItem();
+
+	m_updateTimer = new QTimer(this);
+	m_updateTimer->setSingleShot(false); 
+	connect(m_updateTimer, &QTimer::timeout, this, &SecurityItem::updateItem);
+	m_updateTimer->start(1000);
 }
 
 SecurityItem::~SecurityItem()
@@ -303,10 +308,6 @@ void SecurityItem::updateItem()
 		//quickmsgButton->show();
 	}
 
-	/* slow Tick  */
-	int msec_rate = 10129;
-
-	QTimer::singleShot( msec_rate, this, SLOT(updateItem( void ) ));
 	return;
 }
 

--- a/retroshare-gui/src/gui/feeds/SecurityItem.h
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.h
@@ -68,7 +68,6 @@ private:
 	std::string mIP;
 	RsFeedTypeFlags mType;
 	bool mIsHome;
-	QTimer *m_updateTimer;
 
     RsEventsHandlerId_t mEventHandlerId;
 };

--- a/retroshare-gui/src/gui/feeds/SecurityItem.h
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.h
@@ -66,8 +66,9 @@ private:
 	RsPeerId mSslId;
 	std::string mSslCn;
 	std::string mIP;
-    RsFeedTypeFlags mType;
+	RsFeedTypeFlags mType;
 	bool mIsHome;
+	QTimer *m_updateTimer;
 
     RsEventsHandlerId_t mEventHandlerId;
 };


### PR DESCRIPTION
Remove recursive singleShot calls on feed items, that were creating thousands of timers and causing massive cpu overhead.
The functionality is replaced by a single, controlled member QTimer started in the constructor/setup method.