### PR TITLE
Replace RTT graph with a sortable table view: Name, RTT, ID, IP

### DIFF
--- a/retroshare-gui/src/gui/statistics/RttStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.cpp
@@ -18,124 +18,195 @@
  *                                                                             *
  *******************************************************************************/
 
+#include "RttStatistics.h"
 #include <iostream>
-#include <QTimer>
-#include <QObject>
-
-#include <QPainter>
-#include <QStylePainter>
-
+#include <limits>
+#include <QHeaderView>
+#include <QHostAddress>
 #include <retroshare/rsrtt.h>
 #include <retroshare/rspeers.h>
-#include "RttStatistics.h"
-#include "time.h"
-
 #include "gui/settings/rsharesettings.h"
 
+// --- CUSTOM SORTING CLASS ---
+// Handles numeric sorting for RTT and IP addresses instead of default alphabetical sort
+class RttTreeItem : public QTreeWidgetItem {
+public:
+    using QTreeWidgetItem::QTreeWidgetItem;
 
-RttStatistics::RttStatistics(QWidget * /*parent*/)
+    bool operator<(const QTreeWidgetItem &other) const override {
+        int sortCol = treeWidget() ? treeWidget()->sortColumn() : 0;
+
+        // 1. RTT SORTING (Column 1)
+        if (sortCol == 1) {
+            QString txt1 = text(1);
+            QString txt2 = other.text(1);
+
+            // Treat "?" as infinite so it appears at the bottom when sorting ascending
+            long val1 = (txt1 == "?") ? std::numeric_limits<long>::max() : txt1.toLong();
+            long val2 = (txt2 == "?") ? std::numeric_limits<long>::max() : txt2.toLong();
+
+            return val1 < val2;
+        }
+
+        // 2. SMART IP SORTING (Column 3)
+        if (sortCol == 3) {
+            QString s1 = text(3);
+            QString s2 = other.text(3);
+
+            QHostAddress ip1(s1);
+            QHostAddress ip2(s2);
+
+            // Check if addresses are Tor/I2P (non-numeric IPs)
+            bool isTorI2p1 = s1.contains(".onion") || s1.contains(".i2p");
+            bool isTorI2p2 = s2.contains(".onion") || s2.contains(".i2p");
+
+            // If both are valid standard IPs (IPv4/IPv6) and NOT Tor/I2P
+            if (!ip1.isNull() && !ip2.isNull() && !isTorI2p1 && !isTorI2p2) {
+                // Sort by protocol first (IPv4 vs IPv6)
+                if (ip1.protocol() != ip2.protocol())
+                    return ip1.protocol() < ip2.protocol();
+
+                // Sort IPv4 numerically
+                if (ip1.protocol() == QAbstractSocket::IPv4Protocol)
+                    return ip1.toIPv4Address() < ip2.toIPv4Address();
+            }
+
+            // Fallback to standard string sort (handles Tor/I2P/Mixed)
+            return s1 < s2;
+        }
+
+        // For Name (0) and Node ID (2), standard alphabetical sort is fine
+        return QTreeWidgetItem::operator<(other);
+    }
+};
+
+// --- IMPLEMENTATION ---
+
+RttStatistics::RttStatistics(QWidget *parent)
+    : MainPage(parent)
 {
-	setupUi(this) ;
-	
-	m_bProcessSettings = false;
+    setupUi(this);
 
-    _tunnel_statistics_F->setWidget( _tst_CW = new RttStatisticsGraph(this) ) ;
-	_tunnel_statistics_F->setWidgetResizable(true);
-	_tunnel_statistics_F->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-	_tunnel_statistics_F->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-	_tunnel_statistics_F->viewport()->setBackgroundRole(QPalette::NoRole);
-	_tunnel_statistics_F->setFrameStyle(QFrame::NoFrame);
-	_tunnel_statistics_F->setFocusPolicy(Qt::NoFocus);
-	
-	// load settings
+    m_bProcessSettings = false;
+
+    // UI Configuration
+    treeWidget->setAlternatingRowColors(true);
+    treeWidget->setSortingEnabled(true);
+
+    // Default sort: RTT Ascending (Lowest ping first)
+    treeWidget->sortByColumn(1, Qt::AscendingOrder);
+
+    // Timer setup (1000ms = 1 second)
+    m_timer = new QTimer(this);
+    connect(m_timer, &QTimer::timeout, this, &RttStatistics::updateRttValues);
+    m_timer->start(1000);
+
+    // Initial immediate update
+    updateRttValues();
+
+    // Restore column layout (Must be done AFTER initial update to apply correctly)
     processSettings(true);
 }
 
 RttStatistics::~RttStatistics()
 {
+    if(m_timer) m_timer->stop();
 
-    // save settings
+    // Force save settings on destruction
     processSettings(false);
 }
 
 void RttStatistics::processSettings(bool bLoad)
 {
     m_bProcessSettings = true;
-
     Settings->beginGroup(QString("RttStatistics"));
 
     if (bLoad) {
-        // load settings
-
-        // state of splitter
-        //splitter->restoreState(Settings->value("Splitter").toByteArray());
+        // Load column configuration (widths, sort order, hidden columns)
+        QByteArray state = Settings->value("TreeState").toByteArray();
+        if (!state.isEmpty()) {
+            treeWidget->header()->restoreState(state);
+        }
     } else {
-        // save settings
-
-        // state of splitter
-        //Settings->setValue("Splitter", splitter->saveState());
-
+        // Save column configuration
+        Settings->setValue("TreeState", treeWidget->header()->saveState());
     }
 
     Settings->endGroup();
-    
     m_bProcessSettings = false;
-
 }
 
-QString RttGraphSource::unitName() const
-{
-    return QObject::tr("secs") ;
-}
-
-QString RttGraphSource::displayName(int i) const
-{
-    int n=0 ;
-    for(std::map<std::string, std::list<std::pair<qint64,float> > >::const_iterator it=_points.begin();it!=_points.end();++it,++n)
-        if(n==i)
-            return QString::fromUtf8(rsPeers->getPeerName(RsPeerId(it->first)).c_str()) ;
-
-    return QString() ;
-}
-
-void RttGraphSource::getValues(std::map<std::string,float>& vals) const
+void RttStatistics::updateRttValues()
 {
     std::list<RsPeerId> idList;
+    if (!rsPeers) return;
+
     rsPeers->getOnlineList(idList);
+    QList<QString> currentPeerIds;
 
-    vals.clear() ;
-    std::list<RsRttPongResult> results ;
-
-    for(std::list<RsPeerId>::const_iterator it(idList.begin());it!=idList.end();++it)
+    for(const RsPeerId& pid : idList)
     {
-        rsRtt->getPongResults(*it, 1, results);
+        std::string peerIdStr = pid.toStdString();
+        QString qPeerId = QString::fromStdString(peerIdStr);
+        currentPeerIds.append(qPeerId);
 
-    vals[(*it).toStdString()] = results.back().mRTT ;
+        // 1. Get RTT Data
+        std::list<RsRttPongResult> results;
+        rsRtt->getPongResults(pid, 1, results);
+        int rttInMs = -1;
+
+        if (!results.empty()) {
+            float rttSec = results.back().mRTT;
+            // Only consider RTT valid if slightly positive
+            if (rttSec > 0.000001f) rttInMs = (int)(rttSec * 1000.0f);
+        }
+
+        // 2. Get Peer Details
+        RsPeerDetails details;
+        rsPeers->getPeerDetails(pid, details);
+
+        QString peerName = QString::fromUtf8(details.name.c_str());
+        QString ipAddress = QString::fromStdString(details.extAddr);
+
+        // 3. Update Table Item
+        QTreeWidgetItem* item = nullptr;
+
+        // Find existing item via hidden ID (UserRole)
+        for(int i=0; i < treeWidget->topLevelItemCount(); ++i) {
+            QTreeWidgetItem* temp = treeWidget->topLevelItem(i);
+            if(temp->data(0, Qt::UserRole).toString() == qPeerId) {
+                item = temp;
+                break;
+            }
+        }
+
+        if (!item) {
+            // Create new item with custom sorting logic
+            item = new RttTreeItem(treeWidget);
+            // Store Peer ID in hidden data to identify the row later
+            item->setData(0, Qt::UserRole, qPeerId);
+        }
+
+        // Col 0: Peer Name
+        item->setText(0, peerName);
+
+        // Col 1: RTT (Display number or "?")
+        if (rttInMs != -1) item->setText(1, QString::number(rttInMs));
+        else item->setText(1, "?");
+
+        // Col 2: Node ID (Full Peer ID)
+        item->setText(2, qPeerId);
+
+        // Col 3: IP Address
+        item->setText(3, ipAddress);
     }
-}
 
-RttStatisticsGraph::RttStatisticsGraph(QWidget *parent)
-        : RSGraphWidget(parent)
-{
-    RttGraphSource *src = new RttGraphSource() ;
-
-    src->setCollectionTimeLimit(10*60*1000) ; // 10 mins
-    src->setCollectionTimePeriod(1000) ;     // collect every second
-    src->setDigits(3) ;
-    src->start() ;
-
-    setSource(src) ;
-
-    setTimeScale(2.0f) ; // 1 pixels per second of time.
-
-    resetFlags(RSGRAPH_FLAGS_LOG_SCALE_Y) ;
-    resetFlags(RSGRAPH_FLAGS_PAINT_STYLE_PLAIN) ;
-    setFlags(RSGRAPH_FLAGS_SHOW_LEGEND) ;
-
-	int graphColor = Settings->valueFromGroup("BandwidthStatsWidget", "cmbGraphColor", 0).toInt();
-
-	if(graphColor==0)
-		resetFlags(RSGraphWidget::RSGraphWidget::RSGRAPH_FLAGS_DARK_STYLE);
-	else
-		setFlags(RSGraphWidget::RSGraphWidget::RSGRAPH_FLAGS_DARK_STYLE);
+    // 4. Cleanup disconnected peers
+    for(int i = treeWidget->topLevelItemCount() - 1; i >= 0; --i) {
+        QTreeWidgetItem* item = treeWidget->topLevelItem(i);
+        // If the item in table is not in the current online list, delete it
+        if(!currentPeerIds.contains(item->data(0, Qt::UserRole).toString())) {
+            delete item;
+        }
+    }
 }

--- a/retroshare-gui/src/gui/statistics/RttStatistics.h
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.h
@@ -20,44 +20,26 @@
 
 #pragma once
 
-#include <QPoint>
-#include <retroshare/rsrtt.h>
+#include <QTreeWidget>
+#include <QTimer>
+#include <QHeaderView>
 #include <retroshare-gui/RsAutoUpdatePage.h>
-
 #include "ui_RttStatistics.h"
-#include <gui/common/RSGraphWidget.h>
-
-class RttStatisticsWidget ;
-
-class RttGraphSource: public RSGraphSource
-{
-public:
-    RttGraphSource() {}
-
-    virtual void getValues(std::map<std::string,float>& vals) const ;
-    virtual QString unitName() const ;
-    virtual QString displayName(int i) const ;
-};
-
-class RttStatisticsGraph: public RSGraphWidget
-{
-public:
-    RttStatisticsGraph(QWidget *parent);
-};
 
 class RttStatistics: public MainPage, public Ui::RttStatistics
 {
+    Q_OBJECT
+
 public:
-    RttStatistics(QWidget *parent = NULL) ;
+    RttStatistics(QWidget *parent = NULL);
     ~RttStatistics();
+
+private slots:
+    void updateRttValues();
 
 private:
     void processSettings(bool bLoad);
     bool m_bProcessSettings;
 
-    RttStatisticsGraph *_tst_CW ;
-} ;
-
-
-
-
+    QTimer *m_timer;
+};

--- a/retroshare-gui/src/gui/statistics/RttStatistics.ui
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.ui
@@ -6,50 +6,49 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>611</width>
-    <height>408</height>
+    <width>750</width>
+    <height>450</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>RTT Statistics</string>
   </property>
-  <property name="windowIcon">
-   <iconset resource="images.qrc">
-    <normaloff>:/images/logo/logo_16.png</normaloff>:/images/logo/logo_16.png</iconset>
-  </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeWidget" name="treeWidget">
+     <property name="rootIsDecorated">
+      <bool>false</bool>
      </property>
-     <widget class="QScrollArea" name="_tunnel_statistics_F">
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <column>
+      <property name="text">
+       <string>Peer Name</string>
       </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
+     </column>
+     <column>
+      <property name="text">
+       <string>RTT (ms)</string>
       </property>
-      <property name="widgetResizable">
-       <bool>true</bool>
+     </column>
+     <column>
+      <property name="text">
+       <string>Node ID</string>
       </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>593</width>
-         <height>390</height>
-        </rect>
-       </property>
-      </widget>
-     </widget>
+     </column>
+     <column>
+      <property name="text">
+       <string>IP Address</string>
+      </property>
+     </column>
     </widget>
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Replace RTT graph with a sortable table view: Name, RTT, ID, IP.

The current RTT statistics view is a moving graph, that can't be sorted, and that can't fit in the window when there are many friends.

It replaced it with a table that provide Peer Name, RTT (ms), Node ID, and IP Adress. The table is entirely sortable.

Note that this view also allows easy identification of a friend by their ID.