### PR TITLE
Add table view in rtt statistics

### DIFF
--- a/retroshare-gui/src/gui/statistics/RttStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.cpp
@@ -136,8 +136,8 @@ void RttStatistics::processSettings(bool bLoad)
 // --- Table Update Logic (O(N) Optimized) ---
 void RttStatistics::updateRttValues()
 {
-    // Optimize: Only update if Table tab is visible (Index 1)
-    if (tabWidget->currentIndex() != 1) return;
+    // Only update if the rtt tab is visible and the table view is selected
+    if (!isVisible() || tabWidget->currentIndex() != 1) return;
 
     std::list<RsPeerId> idList;
     if (!rsPeers) return;

--- a/retroshare-gui/src/gui/statistics/RttStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.cpp
@@ -18,123 +18,194 @@
  *                                                                             *
  *******************************************************************************/
 
+#include "RttStatistics.h"
 #include <iostream>
-#include <QTimer>
-#include <QObject>
-
-#include <QPainter>
-#include <QStylePainter>
-
+#include <limits>
+#include <QHeaderView>
+#include <QHostAddress>
 #include <retroshare/rsrtt.h>
 #include <retroshare/rspeers.h>
-#include "RttStatistics.h"
-#include "time.h"
-
 #include "gui/settings/rsharesettings.h"
 
+// --- CUSTOM SORTING CLASS ---
+// Handles numeric sorting for RTT and IP addresses instead of default alphabetical sort
+class RttTreeItem : public QTreeWidgetItem {
+public:
+    using QTreeWidgetItem::QTreeWidgetItem;
 
-RttStatistics::RttStatistics(QWidget * /*parent*/)
+    bool operator<(const QTreeWidgetItem &other) const override {
+        int sortCol = treeWidget() ? treeWidget()->sortColumn() : 0;
+
+        // 1. RTT SORTING (Column 1)
+        if (sortCol == 1) {
+            QString txt1 = text(1);
+            QString txt2 = other.text(1);
+
+            // Treat "?" as infinite so it appears at the bottom when sorting ascending
+            long val1 = (txt1 == "?") ? std::numeric_limits<long>::max() : txt1.toLong();
+            long val2 = (txt2 == "?") ? std::numeric_limits<long>::max() : txt2.toLong();
+
+            return val1 < val2;
+        }
+
+        // 2. SMART IP SORTING (Column 3)
+        if (sortCol == 3) {
+            QString s1 = text(3);
+            QString s2 = other.text(3);
+
+            QHostAddress ip1(s1);
+            QHostAddress ip2(s2);
+
+            // Check if addresses are Tor/I2P (non-numeric IPs)
+            bool isTorI2p1 = s1.contains(".onion") || s1.contains(".i2p");
+            bool isTorI2p2 = s2.contains(".onion") || s2.contains(".i2p");
+
+            // If both are valid standard IPs (IPv4/IPv6) and NOT Tor/I2P
+            if (!ip1.isNull() && !ip2.isNull() && !isTorI2p1 && !isTorI2p2) {
+                // Sort by protocol first (IPv4 vs IPv6)
+                if (ip1.protocol() != ip2.protocol())
+                    return ip1.protocol() < ip2.protocol();
+
+                // Sort IPv4 numerically
+                if (ip1.protocol() == QAbstractSocket::IPv4Protocol)
+                    return ip1.toIPv4Address() < ip2.toIPv4Address();
+            }
+
+            // Fallback to standard string sort (handles Tor/I2P/Mixed)
+            return s1 < s2;
+        }
+
+        // For Name (0) and Node ID (2), standard alphabetical sort is fine
+        return QTreeWidgetItem::operator<(other);
+    }
+};
+
+// --- IMPLEMENTATION ---
+
+RttStatistics::RttStatistics(QWidget *parent)
+    : MainPage(parent)
 {
-	setupUi(this) ;
-	
-	m_bProcessSettings = false;
+    setupUi(this);
 
-    _tunnel_statistics_F->setWidget( _tst_CW = new RttStatisticsGraph(this) ) ;
-	_tunnel_statistics_F->setWidgetResizable(true);
-	_tunnel_statistics_F->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-	_tunnel_statistics_F->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-	_tunnel_statistics_F->viewport()->setBackgroundRole(QPalette::NoRole);
-	_tunnel_statistics_F->setFrameStyle(QFrame::NoFrame);
-	_tunnel_statistics_F->setFocusPolicy(Qt::NoFocus);
-	
-	// load settings
+    m_bProcessSettings = false;
+
+    // UI Configuration
+    treeWidget->setAlternatingRowColors(true);
+    treeWidget->setSortingEnabled(true);
+
+    // Default sort: RTT Ascending (Lowest ping first)
+    treeWidget->sortByColumn(1, Qt::AscendingOrder);
+
+    // Timer setup (1000ms = 1 second)
+    m_timer = new QTimer(this);
+    connect(m_timer, &QTimer::timeout, this, &RttStatistics::updateRttValues);
+    m_timer->start(1000);
+
+    // Initial immediate update
+    updateRttValues();
+
+    // Restore column layout (Must be done AFTER initial update to apply correctly)
     processSettings(true);
 }
 
 RttStatistics::~RttStatistics()
 {
+    if(m_timer) m_timer->stop();
 
-    // save settings
+    // Force save settings on destruction
     processSettings(false);
 }
 
 void RttStatistics::processSettings(bool bLoad)
 {
     m_bProcessSettings = true;
-
     Settings->beginGroup(QString("RttStatistics"));
 
     if (bLoad) {
-        // load settings
-
-        // state of splitter
-        //splitter->restoreState(Settings->value("Splitter").toByteArray());
+        // Load column configuration (widths, sort order, hidden columns)
+        QByteArray state = Settings->value("TreeState").toByteArray();
+        if (!state.isEmpty()) {
+            treeWidget->header()->restoreState(state);
+        }
     } else {
-        // save settings
-
-        // state of splitter
-        //Settings->setValue("Splitter", splitter->saveState());
-
+        // Save column configuration
+        Settings->setValue("TreeState", treeWidget->header()->saveState());
     }
 
     Settings->endGroup();
-    
     m_bProcessSettings = false;
-
 }
 
-QString RttGraphSource::unitName() const
-{
-    return QObject::tr("secs") ;
-}
-
-QString RttGraphSource::displayName(int i) const
-{
-    int n=0 ;
-    for(std::map<std::string, std::list<std::pair<qint64,float> > >::const_iterator it=_points.begin();it!=_points.end();++it,++n)
-        if(n==i)
-            return QString::fromUtf8(rsPeers->getPeerName(RsPeerId(it->first)).c_str()) ;
-
-    return QString() ;
-}
-
-void RttGraphSource::getValues(std::map<std::string,float>& vals) const
+void RttStatistics::updateRttValues()
 {
     std::list<RsPeerId> idList;
-    rsPeers->getOnlineList(idList);
+    if (!rsPeers) return;
 
-    vals.clear() ;
-    for(std::list<RsPeerId>::const_iterator it(idList.begin());it!=idList.end();++it)
+    rsPeers->getOnlineList(idList);
+    QList<QString> currentPeerIds;
+
+    for(const RsPeerId& pid : idList)
     {
-        std::list<RsRttPongResult> results ;
-        if (rsRtt->getPongResults(*it, 1, results) > 0 && !results.empty()) {
-            vals[(*it).toStdString()] = results.back().mRTT ;
+        std::string peerIdStr = pid.toStdString();
+        QString qPeerId = QString::fromStdString(peerIdStr);
+        currentPeerIds.append(qPeerId);
+
+        // 1. Get RTT Data
+        std::list<RsRttPongResult> results;
+        int rttInMs = -1;
+
+        if (rsRtt->getPongResults(pid, 1, results) > 0 && !results.empty()) {
+            float rttSec = results.back().mRTT;
+            // Only consider RTT valid if slightly positive
+            if (rttSec > 0.000001f) rttInMs = (int)(rttSec * 1000.0f);
+        }
+
+        // 2. Get Peer Details
+        RsPeerDetails details;
+        rsPeers->getPeerDetails(pid, details);
+
+        QString peerName = QString::fromUtf8(details.name.c_str());
+        QString ipAddress = QString::fromStdString(details.extAddr);
+
+        // 3. Update Table Item
+        QTreeWidgetItem* item = nullptr;
+
+        // Find existing item via hidden ID (UserRole)
+        for(int i=0; i < treeWidget->topLevelItemCount(); ++i) {
+            QTreeWidgetItem* temp = treeWidget->topLevelItem(i);
+            if(temp->data(0, Qt::UserRole).toString() == qPeerId) {
+                item = temp;
+                break;
+            }
+        }
+
+        if (!item) {
+            // Create new item with custom sorting logic
+            item = new RttTreeItem(treeWidget);
+            // Store Peer ID in hidden data to identify the row later
+            item->setData(0, Qt::UserRole, qPeerId);
+        }
+
+        // Col 0: Peer Name
+        item->setText(0, peerName);
+
+        // Col 1: RTT (Display number or "?")
+        if (rttInMs != -1) item->setText(1, QString::number(rttInMs));
+        else item->setText(1, "?");
+
+        // Col 2: Node ID (Full Peer ID)
+        item->setText(2, qPeerId);
+
+        // Col 3: IP Address
+        item->setText(3, ipAddress);
+    }
+
+    // 4. Cleanup disconnected peers
+    for(int i = treeWidget->topLevelItemCount() - 1; i >= 0; --i) {
+        QTreeWidgetItem* item = treeWidget->topLevelItem(i);
+        // If the item in table is not in the current online list, delete it
+        if(!currentPeerIds.contains(item->data(0, Qt::UserRole).toString())) {
+            delete item;
         }
     }
-}
-
-RttStatisticsGraph::RttStatisticsGraph(QWidget *parent)
-        : RSGraphWidget(parent)
-{
-    RttGraphSource *src = new RttGraphSource() ;
-
-    src->setCollectionTimeLimit(10*60*1000) ; // 10 mins
-    src->setCollectionTimePeriod(1000) ;     // collect every second
-    src->setDigits(3) ;
-    src->start() ;
-
-    setSource(src) ;
-
-    setTimeScale(2.0f) ; // 1 pixels per second of time.
-
-    resetFlags(RSGRAPH_FLAGS_LOG_SCALE_Y) ;
-    resetFlags(RSGRAPH_FLAGS_PAINT_STYLE_PLAIN) ;
-    setFlags(RSGRAPH_FLAGS_SHOW_LEGEND) ;
-
-	int graphColor = Settings->valueFromGroup("BandwidthStatsWidget", "cmbGraphColor", 0).toInt();
-
-	if(graphColor==0)
-		resetFlags(RSGraphWidget::RSGraphWidget::RSGRAPH_FLAGS_DARK_STYLE);
-	else
-		setFlags(RSGraphWidget::RSGraphWidget::RSGRAPH_FLAGS_DARK_STYLE);
 }

--- a/retroshare-gui/src/gui/statistics/RttStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.cpp
@@ -46,19 +46,19 @@ public:
     bool operator<(const QTreeWidgetItem &other) const {
         int sortCol = treeWidget() ? treeWidget()->sortColumn() : 0;
 
-        // RTT Sort
-        if (sortCol == 1) {
-            QString txt1 = text(1);
-            QString txt2 = other.text(1);
+        if (sortCol == RttStatistics::COL_RTT) {
+            QString txt1 = text(RttStatistics::COL_RTT);
+            QString txt2 = other.text(RttStatistics::COL_RTT);
             long val1 = (txt1 == "?") ? std::numeric_limits<long>::max() : txt1.toLong();
             long val2 = (txt2 == "?") ? std::numeric_limits<long>::max() : txt2.toLong();
             return val1 < val2;
         }
-        // IP Sort
-        if (sortCol == 3) {
-            QString s1 = text(3);
-            QString s2 = other.text(3);
+
+        if (sortCol == RttStatistics::COL_IP_ADDRESS) {
+            QString s1 = text(RttStatistics::COL_IP_ADDRESS);
+            QString s2 = other.text(RttStatistics::COL_IP_ADDRESS);
             QHostAddress ip1(s1); QHostAddress ip2(s2);
+            
             bool isTorI2p1 = s1.contains(".onion") || s1.contains(".i2p");
             bool isTorI2p2 = s2.contains(".onion") || s2.contains(".i2p");
 
@@ -105,7 +105,11 @@ RttStatistics::RttStatistics(QWidget * /*parent*/)
 
 RttStatistics::~RttStatistics()
 {
-    if(m_timer) m_timer->stop();
+    if(m_timer) {
+        m_timer->stop();
+        delete m_timer; // Explicitly delete the timer as requested
+        m_timer = nullptr;
+    }
     // save settings
     processSettings(false);
 }
@@ -136,13 +140,15 @@ void RttStatistics::processSettings(bool bLoad)
 // --- Table Update Logic (O(N) Optimized) ---
 void RttStatistics::updateRttValues()
 {
-    // Only update if the rtt tab is visible and the table view is selected
+    // Only update if the RTT tab is visible and the table view is selected
     if (!isVisible() || tabWidget->currentIndex() != 1) return;
 
     std::list<RsPeerId> idList;
     if (!rsPeers) return;
     rsPeers->getOnlineList(idList);
 
+    // 1. Collect all current items into a hash map to track them.
+    // We use the Peer ID (stored in UserRole) as the key.
     QHash<QString, QTreeWidgetItem*> existingItems;
     for(int i = 0; i < treeWidget->topLevelItemCount(); ++i) {
         QTreeWidgetItem* item = treeWidget->topLevelItem(i);
@@ -154,6 +160,7 @@ void RttStatistics::updateRttValues()
         std::string peerIdStr = (*it).toStdString();
         QString qPeerId = QString::fromStdString(peerIdStr);
 
+        // Fetch RTT and peer details
         std::list<RsRttPongResult> results;
         int rttInMs = -1;
 
@@ -167,23 +174,27 @@ void RttStatistics::updateRttValues()
         QString peerName = QString::fromUtf8(details.name.c_str());
         QString ipAddress = QString::fromStdString(details.extAddr);
 
+        // 2. Take the item from the map. 
+        // This removes it from the 'existingItems' hash so it won't be deleted later.
         QTreeWidgetItem* item = existingItems.take(qPeerId);
 
         if (!item) {
+            // If the peer is new, create a new item
             item = new RttTreeItem(treeWidget);
             item->setData(0, Qt::UserRole, qPeerId);
         }
 
-        item->setText(0, peerName);
-        if (rttInMs != -1) item->setText(1, QString::number(rttInMs));
-        else item->setText(1, "?");
-        item->setText(2, qPeerId);
-        item->setText(3, ipAddress);
+        // Update the row values using the enums defined in the header
+        item->setText(COL_PEER_NAME, peerName);
+        item->setText(COL_RTT, (rttInMs != -1) ? QString::number(rttInMs) : "?");
+        item->setText(COL_NODE_ID, qPeerId);
+        item->setText(COL_IP_ADDRESS, ipAddress);
     }
 
+    // 3. Delete any items remaining in the hash map.
+    // These correspond to peers that are no longer online or have been removed.
     qDeleteAll(existingItems);
 }
-
 
 // --- Graph Source Implementation (Unchanged logic) ---
 

--- a/retroshare-gui/src/gui/statistics/RttStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.cpp
@@ -223,8 +223,7 @@ void RttGraphSource::getValues(std::map<std::string,float>& vals) const
 
     for(std::list<RsPeerId>::const_iterator it(idList.begin());it!=idList.end();++it)
     {
-        rsRtt->getPongResults(*it, 1, results);
-        if(!results.empty()) {
+        if (rsRtt->getPongResults(*it, 1, results) > 0 && !results.empty()) {
             vals[(*it).toStdString()] = results.back().mRTT ;
         }
     }

--- a/retroshare-gui/src/gui/statistics/RttStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.cpp
@@ -18,194 +18,229 @@
  *                                                                             *
  *******************************************************************************/
 
-#include "RttStatistics.h"
+/*******************************************************************************
+ * gui/statistics/RttStatistics.cpp                                            *
+ *******************************************************************************/
+
 #include <iostream>
 #include <limits>
-#include <QHeaderView>
+#include <QTimer>
+#include <QObject>
+#include <QPainter>
+#include <QStylePainter>
 #include <QHostAddress>
+#include <QHash>
+
 #include <retroshare/rsrtt.h>
 #include <retroshare/rspeers.h>
+#include "RttStatistics.h"
+#include "time.h"
+
 #include "gui/settings/rsharesettings.h"
 
-// --- CUSTOM SORTING CLASS ---
-// Handles numeric sorting for RTT and IP addresses instead of default alphabetical sort
+// --- Custom Item for Sorting (Table) ---
 class RttTreeItem : public QTreeWidgetItem {
 public:
     using QTreeWidgetItem::QTreeWidgetItem;
 
-    bool operator<(const QTreeWidgetItem &other) const override {
+    bool operator<(const QTreeWidgetItem &other) const {
         int sortCol = treeWidget() ? treeWidget()->sortColumn() : 0;
 
-        // 1. RTT SORTING (Column 1)
+        // RTT Sort
         if (sortCol == 1) {
             QString txt1 = text(1);
             QString txt2 = other.text(1);
-
-            // Treat "?" as infinite so it appears at the bottom when sorting ascending
             long val1 = (txt1 == "?") ? std::numeric_limits<long>::max() : txt1.toLong();
             long val2 = (txt2 == "?") ? std::numeric_limits<long>::max() : txt2.toLong();
-
             return val1 < val2;
         }
-
-        // 2. SMART IP SORTING (Column 3)
+        // IP Sort
         if (sortCol == 3) {
             QString s1 = text(3);
             QString s2 = other.text(3);
-
-            QHostAddress ip1(s1);
-            QHostAddress ip2(s2);
-
-            // Check if addresses are Tor/I2P (non-numeric IPs)
+            QHostAddress ip1(s1); QHostAddress ip2(s2);
             bool isTorI2p1 = s1.contains(".onion") || s1.contains(".i2p");
             bool isTorI2p2 = s2.contains(".onion") || s2.contains(".i2p");
 
-            // If both are valid standard IPs (IPv4/IPv6) and NOT Tor/I2P
             if (!ip1.isNull() && !ip2.isNull() && !isTorI2p1 && !isTorI2p2) {
-                // Sort by protocol first (IPv4 vs IPv6)
-                if (ip1.protocol() != ip2.protocol())
-                    return ip1.protocol() < ip2.protocol();
-
-                // Sort IPv4 numerically
-                if (ip1.protocol() == QAbstractSocket::IPv4Protocol)
-                    return ip1.toIPv4Address() < ip2.toIPv4Address();
+                if (ip1.protocol() != ip2.protocol()) return ip1.protocol() < ip2.protocol();
+                if (ip1.protocol() == QAbstractSocket::IPv4Protocol) return ip1.toIPv4Address() < ip2.toIPv4Address();
             }
-
-            // Fallback to standard string sort (handles Tor/I2P/Mixed)
             return s1 < s2;
         }
-
-        // For Name (0) and Node ID (2), standard alphabetical sort is fine
         return QTreeWidgetItem::operator<(other);
     }
 };
 
-// --- IMPLEMENTATION ---
+// --- Main Constructor ---
 
-RttStatistics::RttStatistics(QWidget *parent)
-    : MainPage(parent)
+RttStatistics::RttStatistics(QWidget * /*parent*/)
 {
-    setupUi(this);
+	setupUi(this) ;
 
-    m_bProcessSettings = false;
+	m_bProcessSettings = false;
 
-    // UI Configuration
+    // Setup Graph in Tab 1
+    _tunnel_statistics_F->setWidget( _tst_CW = new RttStatisticsGraph(this) ) ;
+	_tunnel_statistics_F->setWidgetResizable(true);
+	_tunnel_statistics_F->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	_tunnel_statistics_F->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+	_tunnel_statistics_F->viewport()->setBackgroundRole(QPalette::NoRole);
+	_tunnel_statistics_F->setFrameStyle(QFrame::NoFrame);
+	_tunnel_statistics_F->setFocusPolicy(Qt::NoFocus);
+
+    // Setup Table in Tab 2
     treeWidget->setAlternatingRowColors(true);
     treeWidget->setSortingEnabled(true);
-
-    // Default sort: RTT Ascending (Lowest ping first)
     treeWidget->sortByColumn(1, Qt::AscendingOrder);
 
-    // Timer setup (1000ms = 1 second)
+    // Timer for Table Update
     m_timer = new QTimer(this);
-    connect(m_timer, &QTimer::timeout, this, &RttStatistics::updateRttValues);
+    connect(m_timer, SIGNAL(timeout()), this, SLOT(updateRttValues()));
     m_timer->start(1000);
 
-    // Initial immediate update
-    updateRttValues();
-
-    // Restore column layout (Must be done AFTER initial update to apply correctly)
+	// load settings
     processSettings(true);
 }
 
 RttStatistics::~RttStatistics()
 {
     if(m_timer) m_timer->stop();
-
-    // Force save settings on destruction
+    // save settings
     processSettings(false);
 }
 
 void RttStatistics::processSettings(bool bLoad)
 {
     m_bProcessSettings = true;
+
     Settings->beginGroup(QString("RttStatistics"));
 
     if (bLoad) {
-        // Load column configuration (widths, sort order, hidden columns)
+        // load settings
         QByteArray state = Settings->value("TreeState").toByteArray();
-        if (!state.isEmpty()) {
-            treeWidget->header()->restoreState(state);
-        }
+        if (!state.isEmpty()) treeWidget->header()->restoreState(state);
+
+        tabWidget->setCurrentIndex(Settings->value("ActiveTab", 0).toInt());
     } else {
-        // Save column configuration
+        // save settings
         Settings->setValue("TreeState", treeWidget->header()->saveState());
+        Settings->setValue("ActiveTab", tabWidget->currentIndex());
     }
 
     Settings->endGroup();
+
     m_bProcessSettings = false;
 }
 
+// --- Table Update Logic (O(N) Optimized) ---
 void RttStatistics::updateRttValues()
 {
+    // Optimize: Only update if Table tab is visible (Index 1)
+    if (tabWidget->currentIndex() != 1) return;
+
     std::list<RsPeerId> idList;
     if (!rsPeers) return;
-
     rsPeers->getOnlineList(idList);
-    QList<QString> currentPeerIds;
 
-    for(const RsPeerId& pid : idList)
+    QHash<QString, QTreeWidgetItem*> existingItems;
+    for(int i = 0; i < treeWidget->topLevelItemCount(); ++i) {
+        QTreeWidgetItem* item = treeWidget->topLevelItem(i);
+        existingItems.insert(item->data(0, Qt::UserRole).toString(), item);
+    }
+
+    for(std::list<RsPeerId>::const_iterator it = idList.begin(); it != idList.end(); ++it)
     {
-        std::string peerIdStr = pid.toStdString();
+        std::string peerIdStr = (*it).toStdString();
         QString qPeerId = QString::fromStdString(peerIdStr);
-        currentPeerIds.append(qPeerId);
 
-        // 1. Get RTT Data
         std::list<RsRttPongResult> results;
         int rttInMs = -1;
 
-        if (rsRtt->getPongResults(pid, 1, results) > 0 && !results.empty()) {
+        if (rsRtt->getPongResults(*it, 1, results) > 0 && !results.empty()) {
             float rttSec = results.back().mRTT;
-            // Only consider RTT valid if slightly positive
             if (rttSec > 0.000001f) rttInMs = (int)(rttSec * 1000.0f);
         }
 
-        // 2. Get Peer Details
         RsPeerDetails details;
-        rsPeers->getPeerDetails(pid, details);
-
+        rsPeers->getPeerDetails(*it, details);
         QString peerName = QString::fromUtf8(details.name.c_str());
         QString ipAddress = QString::fromStdString(details.extAddr);
 
-        // 3. Update Table Item
-        QTreeWidgetItem* item = nullptr;
-
-        // Find existing item via hidden ID (UserRole)
-        for(int i=0; i < treeWidget->topLevelItemCount(); ++i) {
-            QTreeWidgetItem* temp = treeWidget->topLevelItem(i);
-            if(temp->data(0, Qt::UserRole).toString() == qPeerId) {
-                item = temp;
-                break;
-            }
-        }
+        QTreeWidgetItem* item = existingItems.take(qPeerId);
 
         if (!item) {
-            // Create new item with custom sorting logic
             item = new RttTreeItem(treeWidget);
-            // Store Peer ID in hidden data to identify the row later
             item->setData(0, Qt::UserRole, qPeerId);
         }
 
-        // Col 0: Peer Name
         item->setText(0, peerName);
-
-        // Col 1: RTT (Display number or "?")
         if (rttInMs != -1) item->setText(1, QString::number(rttInMs));
         else item->setText(1, "?");
-
-        // Col 2: Node ID (Full Peer ID)
         item->setText(2, qPeerId);
-
-        // Col 3: IP Address
         item->setText(3, ipAddress);
     }
 
-    // 4. Cleanup disconnected peers
-    for(int i = treeWidget->topLevelItemCount() - 1; i >= 0; --i) {
-        QTreeWidgetItem* item = treeWidget->topLevelItem(i);
-        // If the item in table is not in the current online list, delete it
-        if(!currentPeerIds.contains(item->data(0, Qt::UserRole).toString())) {
-            delete item;
+    qDeleteAll(existingItems);
+}
+
+
+// --- Graph Source Implementation (Unchanged logic) ---
+
+QString RttGraphSource::unitName() const
+{
+    return QObject::tr("secs") ;
+}
+
+QString RttGraphSource::displayName(int i) const
+{
+    int n=0 ;
+    for(std::map<std::string, std::list<std::pair<qint64,float> > >::const_iterator it=_points.begin();it!=_points.end();++it,++n)
+        if(n==i)
+            return QString::fromUtf8(rsPeers->getPeerName(RsPeerId(it->first)).c_str()) ;
+
+    return QString() ;
+}
+
+void RttGraphSource::getValues(std::map<std::string,float>& vals) const
+{
+    std::list<RsPeerId> idList;
+    rsPeers->getOnlineList(idList);
+
+    vals.clear() ;
+    std::list<RsRttPongResult> results ;
+
+    for(std::list<RsPeerId>::const_iterator it(idList.begin());it!=idList.end();++it)
+    {
+        rsRtt->getPongResults(*it, 1, results);
+        if(!results.empty()) {
+            vals[(*it).toStdString()] = results.back().mRTT ;
         }
     }
+}
+
+RttStatisticsGraph::RttStatisticsGraph(QWidget *parent)
+        : RSGraphWidget(parent)
+{
+    RttGraphSource *src = new RttGraphSource() ;
+
+    src->setCollectionTimeLimit(10*60*1000) ; // 10 mins
+    src->setCollectionTimePeriod(1000) ;     // collect every second
+    src->setDigits(3) ;
+    src->start() ;
+
+    setSource(src) ;
+
+    setTimeScale(2.0f) ; // 1 pixels per second of time.
+
+    resetFlags(RSGRAPH_FLAGS_LOG_SCALE_Y) ;
+    resetFlags(RSGRAPH_FLAGS_PAINT_STYLE_PLAIN) ;
+    setFlags(RSGRAPH_FLAGS_SHOW_LEGEND) ;
+
+	int graphColor = Settings->valueFromGroup("BandwidthStatsWidget", "cmbGraphColor", 0).toInt();
+
+	if(graphColor==0)
+		resetFlags(RSGraphWidget::RSGraphWidget::RSGRAPH_FLAGS_DARK_STYLE);
+	else
+		setFlags(RSGraphWidget::RSGraphWidget::RSGRAPH_FLAGS_DARK_STYLE);
 }

--- a/retroshare-gui/src/gui/statistics/RttStatistics.h
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.h
@@ -20,44 +20,26 @@
 
 #pragma once
 
-#include <QPoint>
-#include <retroshare/rsrtt.h>
+#include <QTreeWidget>
+#include <QTimer>
+#include <QHeaderView>
 #include <retroshare-gui/RsAutoUpdatePage.h>
-
 #include "ui_RttStatistics.h"
-#include <gui/common/RSGraphWidget.h>
-
-class RttStatisticsWidget ;
-
-class RttGraphSource: public RSGraphSource
-{
-public:
-    RttGraphSource() {}
-
-    virtual void getValues(std::map<std::string,float>& vals) const ;
-    virtual QString unitName() const ;
-    virtual QString displayName(int i) const ;
-};
-
-class RttStatisticsGraph: public RSGraphWidget
-{
-public:
-    RttStatisticsGraph(QWidget *parent);
-};
 
 class RttStatistics: public MainPage, public Ui::RttStatistics
 {
+    Q_OBJECT
+
 public:
-    RttStatistics(QWidget *parent = NULL) ;
+    RttStatistics(QWidget *parent = NULL);
     ~RttStatistics();
+
+private slots:
+    void updateRttValues();
 
 private:
     void processSettings(bool bLoad);
     bool m_bProcessSettings;
 
-    RttStatisticsGraph *_tst_CW ;
-} ;
-
-
-
-
+    QTimer *m_timer;
+};

--- a/retroshare-gui/src/gui/statistics/RttStatistics.h
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.h
@@ -18,28 +18,55 @@
  *                                                                             *
  *******************************************************************************/
 
+/*******************************************************************************
+ * gui/statistics/RttStatistics.h                                              *
+ *******************************************************************************/
+
 #pragma once
 
-#include <QTreeWidget>
+#include <QPoint>
 #include <QTimer>
+#include <QTreeWidget>
 #include <QHeaderView>
+#include <retroshare/rsrtt.h>
 #include <retroshare-gui/RsAutoUpdatePage.h>
+
 #include "ui_RttStatistics.h"
+#include <gui/common/RSGraphWidget.h>
+
+class RttStatisticsWidget ;
+
+class RttGraphSource: public RSGraphSource
+{
+public:
+    RttGraphSource() {}
+
+    virtual void getValues(std::map<std::string,float>& vals) const ;
+    virtual QString unitName() const ;
+    virtual QString displayName(int i) const ;
+};
+
+class RttStatisticsGraph: public RSGraphWidget
+{
+public:
+    RttStatisticsGraph(QWidget *parent);
+};
 
 class RttStatistics: public MainPage, public Ui::RttStatistics
 {
     Q_OBJECT
 
 public:
-    RttStatistics(QWidget *parent = NULL);
+    RttStatistics(QWidget *parent = NULL) ;
     ~RttStatistics();
 
 private slots:
-    void updateRttValues();
+    void updateRttValues(); // Slot for table update
 
 private:
     void processSettings(bool bLoad);
     bool m_bProcessSettings;
 
-    QTimer *m_timer;
-};
+    RttStatisticsGraph *_tst_CW ;
+    QTimer *m_timer; // Timer for the table
+} ;

--- a/retroshare-gui/src/gui/statistics/RttStatistics.h
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.h
@@ -57,6 +57,15 @@ class RttStatistics: public MainPage, public Ui::RttStatistics
     Q_OBJECT
 
 public:
+
+    // Define column indices to avoid magic numbers
+    enum TableColumns {
+        COL_PEER_NAME = 0,
+        COL_RTT       = 1,
+        COL_NODE_ID   = 2,
+        COL_IP_ADDRESS = 3
+    };
+
     RttStatistics(QWidget *parent = NULL) ;
     ~RttStatistics();
 

--- a/retroshare-gui/src/gui/statistics/RttStatistics.ui
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.ui
@@ -6,49 +6,103 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>750</width>
-    <height>450</height>
+    <width>700</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>RTT Statistics</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_Main">
    <item>
-    <widget class="QTreeWidget" name="treeWidget">
-     <property name="rootIsDecorated">
-      <bool>false</bool>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string>Peer Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>RTT (ms)</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Node ID</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>IP Address</string>
-      </property>
-     </column>
+     
+     <widget class="QWidget" name="tab_graph">
+      <attribute name="title">
+       <string>Graph View</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_Graph">
+       <item row="0" column="0">
+        <widget class="QSplitter" name="splitter">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <widget class="QScrollArea" name="_tunnel_statistics_F">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>100</width>
+             <height>100</height>
+            </rect>
+           </property>
+          </widget>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+
+     <widget class="QWidget" name="tab_table">
+      <attribute name="title">
+       <string>Table View</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_Table">
+       <item>
+        <widget class="QTreeWidget" name="treeWidget">
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>Peer Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>RTT (ms)</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Node ID</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>IP Address</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/retroshare-gui/src/gui/statistics/RttStatistics.ui
+++ b/retroshare-gui/src/gui/statistics/RttStatistics.ui
@@ -6,50 +6,49 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>611</width>
-    <height>408</height>
+    <width>750</width>
+    <height>450</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>RTT Statistics</string>
   </property>
-  <property name="windowIcon">
-   <iconset resource="images.qrc">
-    <normaloff>:/images/logo/logo_16.png</normaloff>:/images/logo/logo_16.png</iconset>
-  </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeWidget" name="treeWidget">
+     <property name="rootIsDecorated">
+      <bool>false</bool>
      </property>
-     <widget class="QScrollArea" name="_tunnel_statistics_F">
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <column>
+      <property name="text">
+       <string>Peer Name</string>
       </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
+     </column>
+     <column>
+      <property name="text">
+       <string>RTT (ms)</string>
       </property>
-      <property name="widgetResizable">
-       <bool>true</bool>
+     </column>
+     <column>
+      <property name="text">
+       <string>Node ID</string>
       </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>593</width>
-         <height>390</height>
-        </rect>
-       </property>
-      </widget>
-     </widget>
+     </column>
+     <column>
+      <property name="text">
+       <string>IP Address</string>
+      </property>
+     </column>
     </widget>
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Add a sortable table view: Name, RTT, ID, and IP

The current RTT statistics view is a moving graph, that can't be sorted, and that can't fit in the window when there are many friends

This PR add a sortable table that provide Peer Name, RTT (ms), Node ID, and IP Address

Note that this view also allows easy identification of a friend by their ID.