### PR TITLE
feat: add bandwidth statistics for total data per peer (Issue #3088)

### DIFF
--- a/retroshare-gui/src/gui/statistics/BwCtrlWindow.cpp
+++ b/retroshare-gui/src/gui/statistics/BwCtrlWindow.cpp
@@ -22,244 +22,263 @@
 #include "gui/common/RSGraphWidget.h"
 #include "ui_BwCtrlWindow.h"
 #include "util/RsQtVersion.h"
-#include <QTimer>
 #include <QDateTime>
+#include <QTimer>
 
 #include <algorithm>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <time.h>
 
 #include "retroshare-gui/RsAutoUpdatePage.h"
 #include "retroshare/rsconfig.h"
 #include "retroshare/rspeers.h"
 
-#include <QModelIndex>
 #include <QHeaderView>
+#include <QModelIndex>
 #include <QPainter>
 #include <limits>
 
-class BWListDelegate: public QAbstractItemDelegate
-{
+static QString formatBytes(uint64_t bytes) {
+  if (bytes < 1024)
+    return QString::number(bytes) + " B";
+  float f = bytes / 1024.0f;
+  if (f < 1024.0f)
+    return QString::asprintf("%.2f KB", f);
+  f /= 1024.0f;
+  if (f < 1024.0f)
+    return QString::asprintf("%.2f MB", f);
+  f /= 1024.0f;
+  return QString::asprintf("%.2f GB", f);
+}
+
+class BWListDelegate : public QAbstractItemDelegate {
 public:
-    BWListDelegate(QObject *parent=0);
-    virtual ~BWListDelegate();
-    void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const;
-    QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const;
+  BWListDelegate(QObject *parent = 0);
+  virtual ~BWListDelegate();
+  void paint(QPainter *painter, const QStyleOptionViewItem &option,
+             const QModelIndex &index) const;
+  QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const;
 };
 
-BWListDelegate::BWListDelegate(QObject *parent) : QAbstractItemDelegate(parent)
-{
+BWListDelegate::BWListDelegate(QObject *parent)
+    : QAbstractItemDelegate(parent) {}
+
+BWListDelegate::~BWListDelegate(void) {}
+
+void BWListDelegate::paint(QPainter *painter,
+                           const QStyleOptionViewItem &option,
+                           const QModelIndex &index) const {
+  QString strNA = tr("N/A");
+  QStyleOptionViewItem opt = option;
+
+  QString temp;
+  float flValue;
+  qint64 qi64Value;
+
+  // prepare
+  painter->save();
+  painter->setClipRect(opt.rect);
+
+  // set text color
+  QVariant value = index.data(Qt::ForegroundRole);
+  if (value.isValid() && qvariant_cast<QColor>(value).isValid()) {
+    opt.palette.setColor(QPalette::Text, qvariant_cast<QColor>(value));
+  }
+  QPalette::ColorGroup cg = option.state & QStyle::State_Enabled
+                                ? QPalette::Normal
+                                : QPalette::Disabled;
+  if (option.state & QStyle::State_Selected) {
+    painter->setPen(opt.palette.color(cg, QPalette::HighlightedText));
+  } else {
+    painter->setPen(opt.palette.color(cg, QPalette::Text));
+  }
+
+  // draw the background color
+  if (option.showDecorationSelected &&
+      (option.state & QStyle::State_Selected)) {
+    if (cg == QPalette::Normal && !(option.state & QStyle::State_Active)) {
+      cg = QPalette::Inactive;
+    }
+    painter->fillRect(option.rect,
+                      option.palette.brush(cg, QPalette::Highlight));
+  } else {
+    value = index.data(Qt::BackgroundRole);
+    if (value.isValid() && qvariant_cast<QColor>(value).isValid()) {
+      painter->fillRect(option.rect, qvariant_cast<QColor>(value));
+    }
+  }
+
+  switch (index.column()) {
+  case COLUMN_IN_RATE:
+    temp = QString::asprintf("%.3f ", index.data().toFloat());
+    // temp=QString::number(index.data().toFloat());
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_IN_MAX:
+    temp = QString::asprintf("%.3f ", index.data().toFloat());
+    // temp=QString::number(index.data().toFloat());
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_IN_QUEUE:
+    temp = QString::number(index.data().toInt());
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_IN_ALLOC:
+    flValue = index.data().toFloat();
+    if (flValue < std::numeric_limits<float>::max()) {
+      temp = QString::asprintf("%.3f ", flValue);
+    } else {
+      temp = strNA;
+    }
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_IN_ALLOC_SENT:
+    qi64Value = index.data().value<qint64>();
+    if (qi64Value < std::numeric_limits<qint64>::max()) {
+      temp = QString::number(qi64Value);
+    } else {
+      temp = strNA;
+    }
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_OUT_RATE:
+    temp = QString::asprintf("%.3f ", index.data().toFloat());
+    // temp=QString::number(index.data().toFloat());
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_OUT_MAX:
+    temp = QString::asprintf("%.3f ", index.data().toFloat());
+    // temp=QString::number(index.data().toFloat());
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_OUT_QUEUE:
+    temp = QString::number(index.data().toInt());
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_OUT_ALLOC:
+    flValue = index.data().toFloat();
+    if (flValue < std::numeric_limits<float>::max()) {
+      temp = QString::number(flValue);
+    } else {
+      temp = strNA;
+    }
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_OUT_ALLOC_SENT:
+    qi64Value = index.data().value<qint64>();
+    if (qi64Value < std::numeric_limits<qint64>::max()) {
+      temp = QString::number(qi64Value);
+    } else {
+      temp = strNA;
+    }
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  case COLUMN_IN_TOTAL:
+  case COLUMN_OUT_TOTAL:
+    qi64Value = index.data().value<qint64>();
+    temp = formatBytes(qi64Value);
+    painter->drawText(option.rect, Qt::AlignRight, temp);
+    break;
+  default:
+    painter->drawText(option.rect, Qt::AlignLeft, index.data().toString());
+  }
+
+  // done
+  painter->restore();
 }
 
-BWListDelegate::~BWListDelegate(void)
-{
+QSize BWListDelegate::sizeHint(const QStyleOptionViewItem &option /*option*/,
+                               const QModelIndex &index) const {
+  float FS = QFontMetricsF(option.font).height();
+  // float fact = FS/14.0 ;
+
+  float w = QFontMetrics_horizontalAdvance(
+      QFontMetricsF(option.font), index.data(Qt::DisplayRole).toString());
+
+  return QSize(w, FS * 1.2);
+  // return QSize(50*fact,17*fact);
 }
 
-void BWListDelegate::paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
-{
-	QString strNA = tr("N/A");
-	QStyleOptionViewItem opt = option;
+BwCtrlWindow::BwCtrlWindow(QWidget *parent) : RsAutoUpdatePage(1000, parent) {
+  setupUi(this);
 
-	QString temp ;
-	float flValue;
-	qint64 qi64Value;
+  BWDelegate = new BWListDelegate();
+  bwTreeWidget->setItemDelegate(BWDelegate);
 
-	// prepare
-	painter->save();
-	painter->setClipRect(opt.rect);
+  // float FS = QFontMetricsF(font()).height();
+  // float fact = FS/14.0 ;
 
-	//set text color
-	QVariant value = index.data(Qt::ForegroundRole);
-	if(value.isValid() && qvariant_cast<QColor>(value).isValid()) {
-		opt.palette.setColor(QPalette::Text, qvariant_cast<QColor>(value));
-	}
-	QPalette::ColorGroup cg = option.state & QStyle::State_Enabled ? QPalette::Normal : QPalette::Disabled;
-	if(option.state & QStyle::State_Selected){
-		painter->setPen(opt.palette.color(cg, QPalette::HighlightedText));
-	} else {
-		painter->setPen(opt.palette.color(cg, QPalette::Text));
-	}
-
-	// draw the background color
-	if(option.showDecorationSelected && (option.state & QStyle::State_Selected)) {
-		if(cg == QPalette::Normal && !(option.state & QStyle::State_Active)) {
-			cg = QPalette::Inactive;
-		}
-		painter->fillRect(option.rect, option.palette.brush(cg, QPalette::Highlight));
-	} else {
-		value = index.data(Qt::BackgroundRole);
-		if(value.isValid() && qvariant_cast<QColor>(value).isValid()) {
-			painter->fillRect(option.rect, qvariant_cast<QColor>(value));
-		}
-	}
-
-	switch(index.column()) {
-	case COLUMN_IN_RATE:
-		temp = QString::asprintf("%.3f ", index.data().toFloat());
-		//temp=QString::number(index.data().toFloat());
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_IN_MAX:
-		temp = QString::asprintf("%.3f ", index.data().toFloat());
-		//temp=QString::number(index.data().toFloat());
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_IN_QUEUE:
-		temp=QString::number(index.data().toInt());
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_IN_ALLOC:
-		flValue = index.data().toFloat();
-		if (flValue < std::numeric_limits<float>::max()){
-			temp = QString::asprintf("%.3f ", flValue);
-		} else {
-			temp=strNA;
-		}
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_IN_ALLOC_SENT:
-		qi64Value = index.data().value<qint64>();
-		if (qi64Value < std::numeric_limits<qint64>::max()){
-			temp= QString::number(qi64Value);
-		} else {
-			temp = strNA;
-		}
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_OUT_RATE:
-		temp = QString::asprintf("%.3f ", index.data().toFloat());
-		//temp=QString::number(index.data().toFloat());
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_OUT_MAX:
-		temp = QString::asprintf("%.3f ", index.data().toFloat());
-		//temp=QString::number(index.data().toFloat());
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_OUT_QUEUE:
-		temp=QString::number(index.data().toInt());
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_OUT_ALLOC:
-		flValue = index.data().toFloat();
-		if (flValue < std::numeric_limits<float>::max()){
-			temp=QString::number(flValue);
-		} else {
-			temp = strNA;
-		}
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	case COLUMN_OUT_ALLOC_SENT:
-		qi64Value = index.data().value<qint64>();
-		if (qi64Value < std::numeric_limits<qint64>::max()){
-			temp= QString::number(qi64Value);
-		} else {
-			temp = strNA;
-		}
-		painter->drawText(option.rect, Qt::AlignRight, temp);
-		break;
-	default:
-		painter->drawText(option.rect, Qt::AlignLeft, index.data().toString());
-	}
-
-	// done
-	painter->restore();
+  /* Set header resize modes and initial section sizes Peer TreeView*/
+  QHeaderView *_header = bwTreeWidget->header();
+  //    _header->resizeSection ( COLUMN_RSNAME, 170*fact );
+  QHeaderView_setSectionResizeMode(_header, QHeaderView::Interactive);
 }
 
-QSize BWListDelegate::sizeHint(const QStyleOptionViewItem & option/*option*/, const QModelIndex & index) const
-{
-    float FS = QFontMetricsF(option.font).height();
-    //float fact = FS/14.0 ;
+BwCtrlWindow::~BwCtrlWindow() {}
 
-    float w = QFontMetrics_horizontalAdvance(QFontMetricsF(option.font), index.data(Qt::DisplayRole).toString());
-
-    return QSize(w,FS*1.2);
-    //return QSize(50*fact,17*fact);
-}
-
-BwCtrlWindow::BwCtrlWindow(QWidget *parent) 
-: RsAutoUpdatePage(1000,parent)
-{
-    setupUi(this);
-
-    BWDelegate = new BWListDelegate();
-    bwTreeWidget->setItemDelegate(BWDelegate);
-    
-    //float FS = QFontMetricsF(font()).height();
-    //float fact = FS/14.0 ;
-
-    /* Set header resize modes and initial section sizes Peer TreeView*/
-    QHeaderView * _header = bwTreeWidget->header () ;
-//    _header->resizeSection ( COLUMN_RSNAME, 170*fact );
-    QHeaderView_setSectionResizeMode(_header, QHeaderView::Interactive);
-}
-
-BwCtrlWindow::~BwCtrlWindow()
-{
-}
-
-void BwCtrlWindow::updateDisplay()
-{
-	/* do nothing if locked, or not visible */
-	if (RsAutoUpdatePage::eventsLocked() == true) 
-	{
+void BwCtrlWindow::updateDisplay() {
+  /* do nothing if locked, or not visible */
+  if (RsAutoUpdatePage::eventsLocked() == true) {
 #ifdef DEBUG_BWCTRLWINDOW
-		std::cerr << "BwCtrlWindow::update() events Are Locked" << std::endl;
+    std::cerr << "BwCtrlWindow::update() events Are Locked" << std::endl;
 #endif
-		return;
-    	}
+    return;
+  }
 
-	if (!rsConfig)
-	{
+  if (!rsConfig) {
 #ifdef DEBUG_BWCTRLWINDOW
-		std::cerr << "BwCtrlWindow::update rsConfig NOT Set" << std::endl;
+    std::cerr << "BwCtrlWindow::update rsConfig NOT Set" << std::endl;
 #endif
-		return;
-	}
+    return;
+  }
 
-    updateBandwidth();
+  updateBandwidth();
 }
 
-void BwCtrlWindow::updateBandwidth()
-{
-	QTreeWidget *peerTreeWidget = bwTreeWidget;
+void BwCtrlWindow::updateBandwidth() {
+  QTreeWidget *peerTreeWidget = bwTreeWidget;
 
-	peerTreeWidget->clear();
+  peerTreeWidget->clear();
 
-	RsConfigDataRates totalRates;
-	std::map<RsPeerId, RsConfigDataRates> rateMap;
-	std::map<RsPeerId, RsConfigDataRates>::iterator it;
+  RsConfigDataRates totalRates;
+  std::map<RsPeerId, RsConfigDataRates> rateMap;
+  std::map<RsPeerId, RsConfigDataRates>::iterator it;
 
-    rsConfig->getTotalBandwidthRates(totalRates);
-	rsConfig->getAllBandwidthRates(rateMap);
+  rsConfig->getTotalBandwidthRates(totalRates);
+  rsConfig->getAllBandwidthRates(rateMap);
 
-			/* insert */
-	QTreeWidgetItem *item = new QTreeWidgetItem();
-	peerTreeWidget->addTopLevelItem(item);
-	peerTreeWidget->setSelectionMode(QAbstractItemView::SingleSelection);
-	
-	/* do Totals */
-	item -> setData(COLUMN_PEERID, Qt::DisplayRole, tr("TOTALS"));
-	item -> setData(COLUMN_RSNAME, Qt::DisplayRole, tr("Totals"));
+  /* insert */
+  QTreeWidgetItem *item = new QTreeWidgetItem();
+  peerTreeWidget->addTopLevelItem(item);
+  peerTreeWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 
-	item -> setData(COLUMN_IN_RATE, Qt::DisplayRole, totalRates.mRateIn);
-	item -> setData(COLUMN_IN_MAX, Qt::DisplayRole,totalRates.mRateMaxIn);
-	item -> setData(COLUMN_IN_QUEUE, Qt::DisplayRole, totalRates.mQueueIn);
-	item -> setData(COLUMN_IN_ALLOC, Qt::DisplayRole, std::numeric_limits<float>::max());
-	item -> setData(COLUMN_IN_ALLOC_SENT, Qt::DisplayRole, std::numeric_limits<qint64>::max());
+  /* do Totals */
+  item->setData(COLUMN_PEERID, Qt::DisplayRole, tr("TOTALS"));
+  item->setData(COLUMN_RSNAME, Qt::DisplayRole, tr("Totals"));
 
-	item -> setData(COLUMN_OUT_RATE, Qt::DisplayRole, totalRates.mRateOut);
-	item -> setData(COLUMN_OUT_MAX, Qt::DisplayRole, totalRates.mRateMaxOut);
-	item -> setData(COLUMN_OUT_QUEUE, Qt::DisplayRole, totalRates.mQueueOut);
-	item -> setData(COLUMN_OUT_ALLOC, Qt::DisplayRole, std::numeric_limits<float>::max());
-	item -> setData(COLUMN_OUT_ALLOC_SENT, Qt::DisplayRole, std::numeric_limits<qint64>::max());
+  item->setData(COLUMN_IN_RATE, Qt::DisplayRole, totalRates.mRateIn);
+  item->setData(COLUMN_IN_MAX, Qt::DisplayRole, totalRates.mRateMaxIn);
+  item->setData(COLUMN_IN_QUEUE, Qt::DisplayRole, totalRates.mQueueIn);
+  item->setData(COLUMN_IN_ALLOC, Qt::DisplayRole,
+                std::numeric_limits<float>::max());
+  item->setData(COLUMN_IN_ALLOC_SENT, Qt::DisplayRole,
+                std::numeric_limits<qint64>::max());
+  item->setData(COLUMN_IN_TOTAL, Qt::DisplayRole, totalRates.mTotalIn);
 
-	time_t now = time(NULL);
-	for(it = rateMap.begin(); it != rateMap.end(); ++it)
-	{
-		/* find the entry */
-		QTreeWidgetItem *peer_item = NULL;
+  item->setData(COLUMN_OUT_RATE, Qt::DisplayRole, totalRates.mRateOut);
+  item->setData(COLUMN_OUT_MAX, Qt::DisplayRole, totalRates.mRateMaxOut);
+  item->setData(COLUMN_OUT_QUEUE, Qt::DisplayRole, totalRates.mQueueOut);
+  item->setData(COLUMN_OUT_ALLOC, Qt::DisplayRole,
+                std::numeric_limits<float>::max());
+  item->setData(COLUMN_OUT_ALLOC_SENT, Qt::DisplayRole,
+                std::numeric_limits<qint64>::max());
+  item->setData(COLUMN_OUT_TOTAL, Qt::DisplayRole, totalRates.mTotalOut);
+
+  time_t now = time(NULL);
+  for (it = rateMap.begin(); it != rateMap.end(); ++it) {
+    /* find the entry */
+    QTreeWidgetItem *peer_item = NULL;
 #if 0
 		QString qpeerid = QString::fromStdString(*it);
 		int itemCount = peerTreeWidget->topLevelItemCount();
@@ -274,105 +293,91 @@ void BwCtrlWindow::updateBandwidth()
 		}
 #endif
 
-		if (!peer_item)
-		{
-			/* insert */
-			peer_item = new QTreeWidgetItem();
-			peerTreeWidget->addTopLevelItem(peer_item);
-		}
+    if (!peer_item) {
+      /* insert */
+      peer_item = new QTreeWidgetItem();
+      peerTreeWidget->addTopLevelItem(peer_item);
+    }
 
-		std::string name = rsPeers->getPeerName(it->first);
+    std::string name = rsPeers->getPeerName(it->first);
 
-		peer_item -> setData(COLUMN_PEERID, Qt::DisplayRole, QString::fromStdString(it->first.toStdString()));
-		peer_item -> setData(COLUMN_RSNAME, Qt::DisplayRole, QString::fromUtf8(name.c_str()));
+    peer_item->setData(COLUMN_PEERID, Qt::DisplayRole,
+                       QString::fromStdString(it->first.toStdString()));
+    peer_item->setData(COLUMN_RSNAME, Qt::DisplayRole,
+                       QString::fromUtf8(name.c_str()));
 
-		peer_item -> setData(COLUMN_IN_RATE, Qt::DisplayRole, it->second.mRateIn);
-		peer_item -> setData(COLUMN_IN_MAX, Qt::DisplayRole, it->second.mRateMaxIn);
-		peer_item -> setData(COLUMN_IN_QUEUE, Qt::DisplayRole, it->second.mQueueIn);
-		peer_item -> setData(COLUMN_IN_ALLOC, Qt::DisplayRole, it->second.mAllocIn);
-		peer_item -> setData(COLUMN_IN_ALLOC_SENT, Qt::DisplayRole, qint64(now - it->second.mAllocTs));
+    peer_item->setData(COLUMN_IN_RATE, Qt::DisplayRole, it->second.mRateIn);
+    peer_item->setData(COLUMN_IN_MAX, Qt::DisplayRole, it->second.mRateMaxIn);
+    peer_item->setData(COLUMN_IN_QUEUE, Qt::DisplayRole, it->second.mQueueIn);
+    peer_item->setData(COLUMN_IN_ALLOC, Qt::DisplayRole, it->second.mAllocIn);
+    peer_item->setData(COLUMN_IN_ALLOC_SENT, Qt::DisplayRole,
+                       qint64(now - it->second.mAllocTs));
+    peer_item->setData(COLUMN_IN_TOTAL, Qt::DisplayRole, it->second.mTotalIn);
 
-		peer_item -> setData(COLUMN_OUT_RATE, Qt::DisplayRole, it->second.mRateOut);
-		peer_item -> setData(COLUMN_OUT_MAX, Qt::DisplayRole, it->second.mRateMaxOut);
-		peer_item -> setData(COLUMN_OUT_QUEUE, Qt::DisplayRole, it->second.mQueueOut);
-		if (it->second.mAllowedTs != 0)
-		{
-			peer_item -> setData(COLUMN_OUT_ALLOC, Qt::DisplayRole, it->second.mAllowedOut);
-			peer_item -> setData(COLUMN_OUT_ALLOC_SENT, Qt::DisplayRole,qint64(now - it->second.mAllowedTs));
-		}
-		else
-		{
-			peer_item -> setData(COLUMN_OUT_ALLOC, Qt::DisplayRole, std::numeric_limits<float>::max());
-			peer_item -> setData(COLUMN_OUT_ALLOC_SENT, Qt::DisplayRole, std::numeric_limits<qint64>::max());
-		}
+    peer_item->setData(COLUMN_OUT_RATE, Qt::DisplayRole, it->second.mRateOut);
+    peer_item->setData(COLUMN_OUT_MAX, Qt::DisplayRole, it->second.mRateMaxOut);
+    peer_item->setData(COLUMN_OUT_QUEUE, Qt::DisplayRole, it->second.mQueueOut);
+    if (it->second.mAllowedTs != 0) {
+      peer_item->setData(COLUMN_OUT_ALLOC, Qt::DisplayRole,
+                         it->second.mAllowedOut);
+      peer_item->setData(COLUMN_OUT_ALLOC_SENT, Qt::DisplayRole,
+                         qint64(now - it->second.mAllowedTs));
+    } else {
+      peer_item->setData(COLUMN_OUT_ALLOC, Qt::DisplayRole,
+                         std::numeric_limits<float>::max());
+      peer_item->setData(COLUMN_OUT_ALLOC_SENT, Qt::DisplayRole,
+                         std::numeric_limits<qint64>::max());
+    }
+    peer_item->setData(COLUMN_OUT_TOTAL, Qt::DisplayRole, it->second.mTotalOut);
 
+    /* colour the columns */
+    if (it->second.mAllowedTs != 0) {
+      if (it->second.mAllowedOut < it->second.mRateOut) {
+        /* RED */
+        QColor bc("#ff4444"); // red
+        peer_item->setBackground(COLUMN_OUT_RATE, QBrush(bc));
 
-		/* colour the columns */
-		if (it->second.mAllowedTs != 0)
-		{
-			if (it->second.mAllowedOut < it->second.mRateOut)
-			{	
-				/* RED */
-				QColor bc("#ff4444"); // red
-				peer_item -> setBackground(COLUMN_OUT_RATE,QBrush(bc));
-	
-			}
-			else if (it->second.mAllowedOut < it->second.mRateMaxOut)
-			{
-				/* YELLOW */
-				QColor bc("#ffff66"); // yellow
-				peer_item -> setBackground(COLUMN_OUT_MAX,QBrush(bc));
-	
-			}
-			else
-			{
-				/* GREEN */
-				QColor bc("#44ff44");//bright green
-				peer_item -> setBackground(COLUMN_OUT_ALLOC,QBrush(bc));
-			}
-		}
-		else
-		{
-			/* GRAY */
-			QColor bc("#444444");// gray
-			peer_item -> setBackground(COLUMN_OUT_ALLOC,QBrush(bc));
-			peer_item -> setBackground(COLUMN_OUT_ALLOC_SENT,QBrush(bc));
+      } else if (it->second.mAllowedOut < it->second.mRateMaxOut) {
+        /* YELLOW */
+        QColor bc("#ffff66"); // yellow
+        peer_item->setBackground(COLUMN_OUT_MAX, QBrush(bc));
 
-		}
+      } else {
+        /* GREEN */
+        QColor bc("#44ff44"); // bright green
+        peer_item->setBackground(COLUMN_OUT_ALLOC, QBrush(bc));
+      }
+    } else {
+      /* GRAY */
+      QColor bc("#444444"); // gray
+      peer_item->setBackground(COLUMN_OUT_ALLOC, QBrush(bc));
+      peer_item->setBackground(COLUMN_OUT_ALLOC_SENT, QBrush(bc));
+    }
 
-		/* queueOut */
-#define QUEUE_RED	10000
-#define QUEUE_ORANGE	2000
-#define QUEUE_YELLOW	500
+    /* queueOut */
+#define QUEUE_RED 10000
+#define QUEUE_ORANGE 2000
+#define QUEUE_YELLOW 500
 
-		if (it->second.mQueueOut > QUEUE_RED)
-		{	
-			/* RED */
-			QColor bc("#ff4444"); // red
-			peer_item -> setBackground(COLUMN_OUT_QUEUE,QBrush(bc));
-	
-		}
-		else if (it->second.mQueueOut > QUEUE_ORANGE)
-		{
-			/* ORANGE */
-			QColor bc("#ff9900"); //orange
-			peer_item -> setBackground(COLUMN_OUT_QUEUE,QBrush(bc));
+    if (it->second.mQueueOut > QUEUE_RED) {
+      /* RED */
+      QColor bc("#ff4444"); // red
+      peer_item->setBackground(COLUMN_OUT_QUEUE, QBrush(bc));
 
-		}
-		else if (it->second.mQueueOut > QUEUE_YELLOW)
-		{
-			/* YELLOW */
-			QColor bc("#ffff66"); // yellow
-			peer_item -> setBackground(COLUMN_OUT_QUEUE,QBrush(bc));
+    } else if (it->second.mQueueOut > QUEUE_ORANGE) {
+      /* ORANGE */
+      QColor bc("#ff9900"); // orange
+      peer_item->setBackground(COLUMN_OUT_QUEUE, QBrush(bc));
 
-		}
-		else
-		{
-			/* GREEN */
-			QColor bc("#44ff44");//bright green
-			peer_item -> setBackground(COLUMN_OUT_QUEUE,QBrush(bc));
-		}
-	}
+    } else if (it->second.mQueueOut > QUEUE_YELLOW) {
+      /* YELLOW */
+      QColor bc("#ffff66"); // yellow
+      peer_item->setBackground(COLUMN_OUT_QUEUE, QBrush(bc));
+
+    } else {
+      /* GREEN */
+      QColor bc("#44ff44"); // bright green
+      peer_item->setBackground(COLUMN_OUT_QUEUE, QBrush(bc));
+    }
+  }
 }
-
-

--- a/retroshare-gui/src/gui/statistics/BwCtrlWindow.h
+++ b/retroshare-gui/src/gui/statistics/BwCtrlWindow.h
@@ -20,13 +20,15 @@
 
 #pragma once
 
-#include <QMainWindow>
+class QAbstractItemDelegate;
+class QModelIndex;
+class QPainter;
+class QString;
+class QSize;
 
-#include <QAbstractItemDelegate>
-
-#include "gui/common/RSGraphWidget.h"
+#include "../../retroshare-gui/RsAutoUpdatePage.h"
+#include "../common/RSGraphWidget.h"
 #include "ui_BwCtrlWindow.h"
-#include <retroshare-gui/RsAutoUpdatePage.h>
 
 
 // Defines for download list list columns

--- a/retroshare-gui/src/gui/statistics/BwCtrlWindow.h
+++ b/retroshare-gui/src/gui/statistics/BwCtrlWindow.h
@@ -24,9 +24,10 @@
 
 #include <QAbstractItemDelegate>
 
-#include <retroshare-gui/RsAutoUpdatePage.h>
 #include "gui/common/RSGraphWidget.h"
 #include "ui_BwCtrlWindow.h"
+#include <retroshare-gui/RsAutoUpdatePage.h>
+
 
 // Defines for download list list columns
 #define COLUMN_RSNAME 0
@@ -41,28 +42,26 @@
 #define COLUMN_OUT_QUEUE 9
 #define COLUMN_OUT_ALLOC 10
 #define COLUMN_OUT_ALLOC_SENT 11
-#define COLUMN_ALLOWED RECVD 12
-#define COLUMN_COUNT 13
-
+#define COLUMN_ALLOWED_RECVD 12
+#define COLUMN_IN_TOTAL 13
+#define COLUMN_OUT_TOTAL 14
+#define COLUMN_COUNT 15
 
 class QModelIndex;
 class QPainter;
-class BWListDelegate ;
+class BWListDelegate;
 
-class BwCtrlWindow : public RsAutoUpdatePage,  public Ui::BwCtrlWindow
-{
-    Q_OBJECT
+class BwCtrlWindow : public RsAutoUpdatePage, public Ui::BwCtrlWindow {
+  Q_OBJECT
 public:
+  BwCtrlWindow(QWidget *parent = 0);
+  ~BwCtrlWindow();
 
-    BwCtrlWindow(QWidget *parent = 0);
-    ~BwCtrlWindow();
-
-    void updateBandwidth();
+  void updateBandwidth();
 
 public slots:
-    virtual void updateDisplay() ;
+  virtual void updateDisplay();
 
 protected:
-    BWListDelegate *BWDelegate;
-
+  BWListDelegate *BWDelegate;
 };

--- a/retroshare-gui/src/gui/statistics/BwCtrlWindow.ui
+++ b/retroshare-gui/src/gui/statistics/BwCtrlWindow.ui
@@ -79,8 +79,24 @@
        </property>
       </column>
       <column>
+      <column>
        <property name="text">
         <string>Allowed Recvd</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Reserved</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Traffic In</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Traffic Out</string>
        </property>
       </column>
      </widget>


### PR DESCRIPTION
### Summary
This PR implements the feature requested in Issue #3088: displaying total received and sent data per friend/peer in the Bandwidth Statistics window.

### Changes
- **libretroshare**:
  - [rsconfig.h](cci:7://file:///C:/Users/muham/.gemini/antigravity/scratch/RetroShare_Fix/libretroshare/src/retroshare/rsconfig.h:0:0-0:0): Added `mTotalIn` and `mTotalOut` to [RsConfigDataRates](cci:1://file:///C:/Users/muham/.gemini/antigravity/scratch/RetroShare_Fix/libretroshare/src/retroshare/rsconfig.h:146:1-153:3).
  - [pqipersongrp](cci:1://file:///C:/Users/muham/.gemini/antigravity/scratch/RetroShare_Fix/libretroshare/src/pqi/pqipersongrp.h:47:4-47:62): Implemented traffic retrieval logic via [getPeerTotalTraffic](cci:1://file:///C:/Users/muham/.gemini/antigravity/scratch/RetroShare_Fix/libretroshare/src/pqi/pqipersongrp.cc:397:0-733:86).
  - `p3bwctrl`: Updated [getAllBandwidthRates](cci:1://file:///C:/Users/muham/.gemini/antigravity/scratch/RetroShare_Fix/libretroshare/src/services/p3bwctrl.cc:248:0-278:1) to populate total traffic stats.
- **retroshare-gui**:
  - [BwCtrlWindow](cci:2://file:///C:/Users/muham/.gemini/antigravity/scratch/RetroShare_Fix/retroshare-gui/src/gui/statistics/BwCtrlWindow.h:53:0-66:1): Added "Total In" and "Total Out" columns to the peer tree widget.
  - Implemented [formatBytes](cci:1://file:///C:/Users/muham/.gemini/antigravity/scratch/RetroShare_Fix/retroshare-gui/src/gui/statistics/BwCtrlWindow.cpp:41:0-52:1) helper to display values in B/KB/MB/GB.

### Related Issues
Closes #3088