### PR TITLE
Close statistics window with Escape key

### DIFF
--- a/retroshare-gui/src/gui/statistics/GxsTransportStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/GxsTransportStatistics.cpp
@@ -457,8 +457,8 @@ void GxsTransportStatistics::loadGroups()
 {
 	mStateHelper->setLoading(GXSTRANS_GROUP_META, true);
 
-	// FIX: Use a QPointer to track 'this'. Since the window can now be closed via 
-	// the Escape key, we must ensure the object still exists before updating it.
+	// Use a QPointer to safely track 'this'. Even if the window is static,
+	// this prevents crashes if the instance is ever released during async execution.
 	QPointer<GxsTransportStatistics> self(this);
 
 	RsThread::async([self]()
@@ -478,7 +478,6 @@ void GxsTransportStatistics::loadGroups()
 			return;
 		}
 
-		// Only proceed if the widget hasn't been destroyed by the user
 		if (self) 
 		{
 			RsQThreadUtils::postToObject( [stats, self]()
@@ -487,8 +486,6 @@ void GxsTransportStatistics::loadGroups()
 				 * thread, for example to update the data model with new information
 				 * after a blocking call to RetroShare API complete */
 
-				// Final safety check: ensure the object wasn't deleted while 
-				// waiting for the GUI thread event loop.
 				if (self) 
 				{
 					// TODO: consider making mGroupStats an unique_ptr to avoid copying
@@ -502,7 +499,7 @@ void GxsTransportStatistics::loadGroups()
 		}
 		else 
 		{
-			// Clean up memory if the window was closed during background processing
+			// Clean up memory if the object was somehow released
 			delete stats;
 		}
 	});

--- a/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
+++ b/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
@@ -23,6 +23,7 @@
 #include <QTimer>
 #include <QDateTime>
 #include <QActionGroup>
+#include <QKeyEvent>
 
 #include <algorithm>
 #include <iostream>
@@ -227,4 +228,13 @@ void StatisticsWindow::setNewPage(int page)
 	{
 		ui->stackPages->setCurrentIndex(page);
 	}
+}
+
+void StatisticsWindow::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Escape) {
+        close(); // Close window is escape is pressed
+    } else {
+        QMainWindow::keyPressEvent(event);
+    }
 }

--- a/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
+++ b/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
@@ -74,8 +74,14 @@ void StatisticsWindow::showYourself()
         mInstance = new StatisticsWindow();
     }
 
+    /* Ensure the window is visible and restored if minimized */
+    if (mInstance->isMinimized()) {
+        mInstance->showNormal();
+    }
+
     mInstance->show();
-    mInstance->activateWindow();
+    mInstance->raise();          /* Bring to front */
+    mInstance->activateWindow(); /* Give focus */
 }
 
 StatisticsWindow* StatisticsWindow::getInstance()
@@ -93,22 +99,26 @@ void StatisticsWindow::releaseInstance()
 /********************************************** STATIC WINDOW *************************************/
 
 
-
 StatisticsWindow::StatisticsWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::StatisticsWindow)
 {
     ui->setupUi(this);
    
-	Settings->loadWidgetInformation(this);
-	
+    /* Automatically destroy the object when the window is closed */
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    Settings->loadWidgetInformation(this);
+    
     initStackedPage();
     connect(ui->stackPages, SIGNAL(currentChanged(int)), this, SLOT(setNewPage(int)));
     ui->stackPages->setCurrentIndex(0);
-	int toolSize = Settings->getToolButtonSize();
-	ui->toolBar->setToolButtonStyle(Settings->getToolButtonStyle());
-	ui->toolBar->setIconSize(QSize(toolSize,toolSize));
-	setWindowTitle("RetroShare Statistics - " + MainWindow::getInstance()->get_nameAndLocation());
+    
+    int toolSize = Settings->getToolButtonSize();
+    ui->toolBar->setToolButtonStyle(Settings->getToolButtonStyle());
+    ui->toolBar->setIconSize(QSize(toolSize,toolSize));
+    
+    setWindowTitle("RetroShare Statistics - " + MainWindow::getInstance()->get_nameAndLocation());
 }
 
 StatisticsWindow::~StatisticsWindow()
@@ -233,8 +243,11 @@ void StatisticsWindow::setNewPage(int page)
 void StatisticsWindow::keyPressEvent(QKeyEvent *event)
 {
     if (event->key() == Qt::Key_Escape) {
-        close(); // Close window is escape is pressed
+        /* This will trigger the closeEvent and, thanks to WA_DeleteOnClose, the destructor */
+        close();
     } else {
+        /* Pass the event to the base class for default handling */
         QMainWindow::keyPressEvent(event);
     }
 }
+

--- a/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
+++ b/retroshare-gui/src/gui/statistics/StatisticsWindow.cpp
@@ -98,26 +98,24 @@ void StatisticsWindow::releaseInstance()
 
 /********************************************** STATIC WINDOW *************************************/
 
-
 StatisticsWindow::StatisticsWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::StatisticsWindow)
 {
     ui->setupUi(this);
    
-    /* Automatically destroy the object when the window is closed */
-    setAttribute(Qt::WA_DeleteOnClose);
-
     Settings->loadWidgetInformation(this);
+    
+    // Ensure the window is NOT destroyed on close to preserve temporal curves
+    // and avoid async race conditions.
+    this->setAttribute(Qt::WA_DeleteOnClose, false);
     
     initStackedPage();
     connect(ui->stackPages, SIGNAL(currentChanged(int)), this, SLOT(setNewPage(int)));
     ui->stackPages->setCurrentIndex(0);
-    
     int toolSize = Settings->getToolButtonSize();
     ui->toolBar->setToolButtonStyle(Settings->getToolButtonStyle());
     ui->toolBar->setIconSize(QSize(toolSize,toolSize));
-    
     setWindowTitle("RetroShare Statistics - " + MainWindow::getInstance()->get_nameAndLocation());
 }
 
@@ -243,10 +241,10 @@ void StatisticsWindow::setNewPage(int page)
 void StatisticsWindow::keyPressEvent(QKeyEvent *event)
 {
     if (event->key() == Qt::Key_Escape) {
-        /* This will trigger the closeEvent and, thanks to WA_DeleteOnClose, the destructor */
-        close();
+        // Just call close(), which will hide the window without destroying 
+        // the static instance or resetting statistics data.
+        this->close();
     } else {
-        /* Pass the event to the base class for default handling */
         QMainWindow::keyPressEvent(event);
     }
 }

--- a/retroshare-gui/src/gui/statistics/StatisticsWindow.h
+++ b/retroshare-gui/src/gui/statistics/StatisticsWindow.h
@@ -66,7 +66,8 @@ public slots:
 	
 protected:
     void changeEvent(QEvent *e);
-	void closeEvent (QCloseEvent * event);
+    void closeEvent (QCloseEvent * event);
+    void keyPressEvent(QKeyEvent *event) override;
 	
 private:
     void initStackedPage();


### PR DESCRIPTION
StatisticsWindow: override the keyPressEvent function, enabling the statistics window to close when the Escape key is pressed

Code and comment by Gemini