### PR TITLE
remove downcast error

### DIFF
--- a/retroshare-gui/src/gui/AboutWidget.cpp
+++ b/retroshare-gui/src/gui/AboutWidget.cpp
@@ -71,7 +71,7 @@ AboutWidget::AboutWidget(QWidget* parent)
 void AboutWidget::installAWidget() {
     assert(tWidget == NULL);
     aWidget = new AWidget();
-    QVBoxLayout* l = (QVBoxLayout*)specialFrame->layout();
+	QHBoxLayout* l = (QHBoxLayout*)specialFrame->layout();
     l->insertWidget(0, aWidget);
     l->setStretchFactor(aWidget, 100);
     aWidget->setFocus();
@@ -87,7 +87,7 @@ void AboutWidget::installTWidget() {
     tWidget->setNextPieceLabel(npLabel);
 
     QWidget* pan = new QWidget();
-    QVBoxLayout* vl = new QVBoxLayout(pan);
+	QHBoxLayout* vl = new QHBoxLayout(pan);
     QLabel* topRecLabel = new QLabel(tr("Max score: %1").arg(tWidget->getMaxScore()));
     QLabel* scoreLabel = new QLabel(pan);
     QLabel* levelLabel = new QLabel(pan);


### PR DESCRIPTION
../../../retroshare-gui/src/gui/AboutWidget.cpp:74:22: runtime error: downcast of address 0x503001940ad0 which does not point to an object of type 'QVBoxLayout' 0x503001940ad0: note: object is of type 'QHBoxLayout'
 00 00 00 00 38 52 09 41 94 7f 00 00 00 59 40 01 10 51 00 00 38 53 09 41 94 7f 00 00 00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'QHBoxLayout'