### PR TITLE
add date format selection (System, ISO 8601, Text) in user settings, and standardize date and time formatting across the UI

### DIFF
--- a/retroshare-gui/src/gui/Identity/IdDetailsDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDetailsDialog.cpp
@@ -149,7 +149,7 @@ void IdDetailsDialog::loadIdentity(RsGxsIdGroup data)
     ui->autoBanIdentities_CB->setVisible(!data.mPgpId.isNull()) ;
     ui->banoption_label->setVisible(!data.mPgpId.isNull()) ;
 	
-	ui->lineEdit_Created->setText(QLocale::system().toString(DateTime::DateTimeFromTime_t(data.mMeta.mPublishTs), QLocale::ShortFormat));
+	ui->lineEdit_Created->setText(DateTime::formatDateTime(data.mMeta.mPublishTs));
 	
 	time_t now = time(NULL) ;
 	ui->lineEdit_LastUsed->setText(getHumanReadableDuration(now - data.mLastUsageTS)) ;

--- a/retroshare-gui/src/gui/Identity/IdDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDialog.cpp
@@ -1654,10 +1654,12 @@ void IdDialog::loadIdentity(RsGxsIdGroup data)
 	/* get GPG Details from rsPeers */
 	RsPgpId ownPgpId  = rsPeers->getGPGOwnId();
 
-    ui->lineEdit_PublishTS->setText(QLocale::system().toString(DateTime::DateTimeFromTime_t(data.mMeta.mPublishTs), QLocale::ShortFormat));
+    ui->lineEdit_PublishTS->setText(DateTime::formatDateTime(data.mMeta.mPublishTs));
+
     //ui->lineEdit_Nickname->setText(QString::fromUtf8(data.mMeta.mGroupName.c_str()).left(RSID_MAXIMUM_NICKNAME_SIZE));
-	ui->lineEdit_KeyId->setText(QString::fromStdString(data.mMeta.mGroupId.toStdString()));
-	//ui->lineEdit_GpgHash->setText(QString::fromStdString(data.mPgpIdHash.toStdString()));
+    ui->lineEdit_KeyId->setText(QString::fromStdString(data.mMeta.mGroupId.toStdString()));
+
+    //ui->lineEdit_GpgHash->setText(QString::fromStdString(data.mPgpIdHash.toStdString()));
     if(data.mPgpKnown)
 	    ui->lineEdit_GpgId->setText(QString::fromStdString(data.mPgpId.toStdString()));
     else

--- a/retroshare-gui/src/gui/Posted/BoardPostDisplayWidget.cpp
+++ b/retroshare-gui/src/gui/Posted/BoardPostDisplayWidget.cpp
@@ -196,15 +196,15 @@ void BoardPostDisplayWidgetBase::baseSetup()
         fromLabel()->setId(mPost.mMeta.mAuthorId);
         titleLabel()->setText(tr( "<p><font color=\"#ff0000\"><b>The author of this message (with ID %1) is banned.</b>").arg(QString::fromStdString(mPost.mMeta.mAuthorId.toStdString()))) ;
         QDateTime qtime = DateTime::DateTimeFromTime_t(mPost.mMeta.mPublishTs);
-        QString timestamp = qtime.toString("hh:mm dd-MMM-yyyy");
+	QString timestamp = DateTime::formatDateTime(qtime);
         dateLabel()->setText(timestamp);
         pictureLabel()->setDisabled(true);
     }
     else
     {
         QDateTime qtime = DateTime::DateTimeFromTime_t(mPost.mMeta.mPublishTs);
-        QString timestamp = qtime.toString("hh:mm dd-MMM-yyyy");
-        QString timestamp2 = misc::timeRelativeToNow(mPost.mMeta.mPublishTs) + " " + tr("ago");
+	QString timestamp = DateTime::formatDateTime(qtime);
+	QString timestamp2 = misc::timeRelativeToNow(mPost.mMeta.mPublishTs) + " " + tr("ago");
         dateLabel()->setText(timestamp);
         dateLabel()->setToolTip(timestamp2);
 

--- a/retroshare-gui/src/gui/Posted/PostedCardView.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedCardView.cpp
@@ -188,7 +188,7 @@ void PostedCardView::fill()
 		ui->fromLabel->setId(mPost.mMeta.mAuthorId);
 		ui->titleLabel->setText(tr( "<p><font color=\"#ff0000\"><b>The author of this message (with ID %1) is banned.</b>").arg(QString::fromStdString(mPost.mMeta.mAuthorId.toStdString()))) ;
 		QDateTime qtime = DateTime::DateTimeFromTime_t(mPost.mMeta.mPublishTs);
-		QString timestamp = qtime.toString("hh:mm dd-MMM-yyyy");
+		QString timestamp = DateTime::formatDateTime(qtime);
 		ui->dateLabel->setText(timestamp);
 	} else {
 
@@ -199,7 +199,7 @@ void PostedCardView::fill()
 		//int desired_width =  sqpixmap2.width()*desired_height/(float)sqpixmap2.height();
 
 		QDateTime qtime = DateTime::DateTimeFromTime_t(mPost.mMeta.mPublishTs);
-		QString timestamp = qtime.toString("hh:mm dd-MMM-yyyy");
+		QString timestamp = DateTime::formatDateTime(qtime);
 		QString timestamp2 = misc::timeRelativeToNow(mPost.mMeta.mPublishTs);
 		ui->dateLabel->setText(timestamp2);
 		ui->dateLabel->setToolTip(timestamp);

--- a/retroshare-gui/src/gui/Posted/PostedItem.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedItem.cpp
@@ -500,7 +500,7 @@ void PostedItem::fill()
 		ui->fromLabel->setId(mPost.mMeta.mAuthorId);
 		ui->titleLabel->setText(tr( "<p><font color=\"#ff0000\"><b>The author of this message (with ID %1) is banned.</b>").arg(QString::fromStdString(mPost.mMeta.mAuthorId.toStdString()))) ;
 		QDateTime qtime = DateTime::DateTimeFromTime_t(mPost.mMeta.mPublishTs);
-		QString timestamp = qtime.toString("hh:mm dd-MMM-yyyy");
+		QString timestamp = DateTime::formatDateTime(qtime);
 		ui->dateLabel->setText(timestamp);
 	} else {
 		RetroShareLink link = RetroShareLink::createGxsGroupLink(RetroShareLink::TYPE_POSTED, mGroupMeta.mGroupId, groupName());
@@ -515,7 +515,7 @@ void PostedItem::fill()
         ui->thumbnailLabel->setFixedSize(desired_width,desired_height);
 
 		QDateTime qtime = DateTime::DateTimeFromTime_t(mPost.mMeta.mPublishTs);
-		QString timestamp = qtime.toString("hh:mm dd-MMM-yyyy");
+		QString timestamp = DateTime::formatDateTime(qtime);
 		QString timestamp2 = misc::timeRelativeToNow(mPost.mMeta.mPublishTs);
 		ui->dateLabel->setText(timestamp2);
 		ui->dateLabel->setToolTip(timestamp);

--- a/retroshare-gui/src/gui/Posted/PostedListWidget.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedListWidget.cpp
@@ -427,7 +427,7 @@ void PostedListWidget::insertPostedDetails(const RsPostedGroup &group)
             ui->infoLastPost->setText(tr("Never"));
         else
 		
-			ui->infoLastPost->setText(DateTime::formatLongDateTime(group.mMeta.mLastPost));
+			ui->infoLastPost->setText(DateTime::formatDateTime(group.mMeta.mLastPost));
 		
 			QString formatDescription = QString::fromUtf8(group.mDescription.c_str());
 
@@ -442,7 +442,7 @@ void PostedListWidget::insertPostedDetails(const RsPostedGroup &group)
 			link = RetroShareLink::createMessage(group.mMeta.mAuthorId, "");
 			ui->infoAdministrator->setText(link.toHtml());
 		
-		    ui->createdinfolabel->setText(DateTime::formatLongDateTime(group.mMeta.mPublishTs));
+		    ui->createdinfolabel->setText(DateTime::formatDateTime(group.mMeta.mPublishTs));
 
 			QString distrib_string ( "[unknown]" );
             

--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
@@ -870,7 +870,7 @@ void PostedListWidgetWithModel::insertBoardDetails(const RsPostedGroup& group)
     if(group.mMeta.mLastPost==0)
         ui->infoLastPost->setText(tr("Never"));
     else
-        ui->infoLastPost->setText(DateTime::formatLongDateTime(group.mMeta.mLastPost));
+        ui->infoLastPost->setText(DateTime::formatDateTime(group.mMeta.mLastPost));
 
     uint32_t current_sync_time  = GxsGroupFrameDialog::checkDelay(rsPosted->getSyncPeriod(group.mMeta.mGroupId))/86400 ;
 
@@ -913,7 +913,7 @@ void PostedListWidgetWithModel::insertBoardDetails(const RsPostedGroup& group)
 	link = RetroShareLink::createMessage(group.mMeta.mAuthorId, "");
 	ui->infoAdministrator->setText(link.toHtml());
 
-	ui->createdinfolabel->setText(DateTime::formatLongDateTime(group.mMeta.mPublishTs));
+	ui->createdinfolabel->setText(DateTime::formatDateTime(group.mMeta.mPublishTs));
 
 	QString distrib_string ( "[unknown]" );
 

--- a/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
@@ -303,7 +303,7 @@ void ChatLobbyUserNotify::chatLobbyNewMessage(ChatLobbyId lobby_id, QDateTime ti
 		}
 
 	if ((bGetNickName || bFoundTextToNotify || _bCountUnRead)){
-		QString strAnchor = time.toString(Qt::ISODate);
+		QString strAnchor = DateTime::formatDateTime(time);
 		MsgData msgData;
 		msgData.text=RsHtml::plainText(senderName) + ": " + msg;
 		msgData.unread=!(bGetNickName || bFoundTextToNotify);

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -1102,7 +1102,7 @@ void ChatWidget::addChatMsg(bool incoming, const QString &name, const RsGxsId gx
 	QString formattedMessage = RsHtml().formatText(ui->textBrowser->document(), message, formatTextFlag, backgroundColor, desiredContrast, desiredMinimumFontSize);
 	QDateTime dtTimestamp=incoming ? sendTime : recvTime;
 	QString formatMsg = chatStyle.formatMessage(type, name, dtTimestamp, formattedMessage, formatFlag, backgroundColor);
-	QString timeStamp = dtTimestamp.toString(Qt::ISODate);
+	QString timeStamp = DateTime::formatDateTime(dtTimestamp);
 
 	//replace Date and Time anchors
 	formatMsg.replace(QString("<a name=\"date\">"),QString("<a name=\"%1\">").arg(timeStamp));

--- a/retroshare-gui/src/gui/common/FriendList.cpp
+++ b/retroshare-gui/src/gui/common/FriendList.cpp
@@ -937,7 +937,7 @@ void FriendList::insertPeers()
 
                 /* last contact */
                 QDateTime sslLastContact = DateTime::DateTimeFromTime_t(sslDetail.lastConnect);
-                sslItem->setData(COLUMN_LAST_CONTACT, Qt::DisplayRole, QVariant(sslLastContact));
+		sslItem->setData(COLUMN_LAST_CONTACT, Qt::DisplayRole, DateTime::formatDateTime(sslDetail.lastConnect));
                 sslItem->setData(COLUMN_LAST_CONTACT, ROLE_SORT_NAME, QVariant(sslLastContact));
                 if (sslLastContact > bestLastContact) {
                     bestLastContact = sslLastContact;
@@ -1215,7 +1215,7 @@ void FriendList::insertPeers()
             // Filter
             gpgItem->setData(COLUMN_NAME, ROLE_FILTER, gpgName);
 
-            gpgItem->setData(COLUMN_LAST_CONTACT, Qt::DisplayRole, showInfoAtGpgItem ? QVariant(bestLastContact) : "");
+	    gpgItem->setData(COLUMN_LAST_CONTACT, Qt::DisplayRole, showInfoAtGpgItem ? DateTime::formatDateTime(bestLastContact) : "");
             gpgItem->setData(COLUMN_LAST_CONTACT, ROLE_SORT_NAME, QVariant(bestLastContact));
             gpgItem->setText(COLUMN_IP, showInfoAtGpgItem ? bestIP : "");
             gpgItem->setData(COLUMN_IP, ROLE_SORT_NAME, bestIP);

--- a/retroshare-gui/src/gui/common/FriendListModel.cpp
+++ b/retroshare-gui/src/gui/common/FriendListModel.cpp
@@ -748,8 +748,9 @@ QVariant RsFriendListModel::displayRole(const EntryIndex& e, int col) const
                                 }
                         }
 
-                        if(col == COLUMN_THREAD_LAST_CONTACT) return QVariant(most_recent_time);
-                        if(col == COLUMN_THREAD_IP)           return QVariant(most_recent_ip);
+			// Use the standardized date format from user preferences
+			if(col == COLUMN_THREAD_LAST_CONTACT) return DateTime::formatDateTime(most_recent_time);
+			if(col == COLUMN_THREAD_IP)           return QVariant(most_recent_ip);
 
                         return QVariant();
                 }
@@ -790,7 +791,8 @@ QVariant RsFriendListModel::displayRole(const EntryIndex& e, int col) const
 						return QVariant(QString::fromUtf8(node->node_info.location.c_str()));
 				}
 
-				case COLUMN_THREAD_LAST_CONTACT:   return QVariant(DateTime::DateTimeFromTime_t(node->node_info.lastConnect).toString());
+				// Force usage of the global DateTime formatting utility
+				case COLUMN_THREAD_LAST_CONTACT:   return DateTime::formatDateTime(node->node_info.lastConnect);
 				case COLUMN_THREAD_IP:             return QVariant(  (node->node_info.state & RS_PEER_STATE_CONNECTED) ? StatusDefs::connectStateIpString(node->node_info) : QString("---"));
 				case COLUMN_THREAD_ID:             return QVariant(  QString::fromStdString(node->node_info.id.toStdString()) );
 

--- a/retroshare-gui/src/gui/common/FriendListModel.cpp
+++ b/retroshare-gui/src/gui/common/FriendListModel.cpp
@@ -748,7 +748,7 @@ QVariant RsFriendListModel::displayRole(const EntryIndex& e, int col) const
                                 }
                         }
 
-			if(col == COLUMN_THREAD_LAST_CONTACT) return QVariant((qulonglong)DateTime::DateTimeToTime_t(most_recent_time));
+			if(col == COLUMN_THREAD_LAST_CONTACT) return QVariant((qulonglong)most_recent_time.toTime_t());
 			if(col == COLUMN_THREAD_IP)           return QVariant(most_recent_ip);
 
                         return QVariant();

--- a/retroshare-gui/src/gui/common/FriendListModel.cpp
+++ b/retroshare-gui/src/gui/common/FriendListModel.cpp
@@ -748,8 +748,7 @@ QVariant RsFriendListModel::displayRole(const EntryIndex& e, int col) const
                                 }
                         }
 
-			// Use the standardized date format from user preferences
-			if(col == COLUMN_THREAD_LAST_CONTACT) return DateTime::formatDateTime(most_recent_time);
+			if(col == COLUMN_THREAD_LAST_CONTACT) return QVariant((qulonglong)DateTime::DateTimeToTime_t(most_recent_time));
 			if(col == COLUMN_THREAD_IP)           return QVariant(most_recent_ip);
 
                         return QVariant();
@@ -791,8 +790,7 @@ QVariant RsFriendListModel::displayRole(const EntryIndex& e, int col) const
 						return QVariant(QString::fromUtf8(node->node_info.location.c_str()));
 				}
 
-				// Force usage of the global DateTime formatting utility
-				case COLUMN_THREAD_LAST_CONTACT:   return DateTime::formatDateTime(node->node_info.lastConnect);
+				case COLUMN_THREAD_LAST_CONTACT:   return QVariant((qulonglong)node->node_info.lastConnect);
 				case COLUMN_THREAD_IP:             return QVariant(  (node->node_info.state & RS_PEER_STATE_CONNECTED) ? StatusDefs::connectStateIpString(node->node_info) : QString("---"));
 				case COLUMN_THREAD_ID:             return QVariant(  QString::fromStdString(node->node_info.id.toStdString()) );
 

--- a/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
@@ -434,7 +434,7 @@ void GroupTreeWidget::fillGroupItems(QTreeWidgetItem *categoryItem, const QList<
 		}
 		else
 		{
-			item->setText(GTW_COLUMN_LAST_POST, itemInfo.lastpost.toString(Qt::ISODate).replace("T"," "));
+			item->setText(GTW_COLUMN_LAST_POST, DateTime::formatDateTime(itemInfo.lastpost));
 			item->setData(GTW_COLUMN_LAST_POST, ROLE_SORT, (qint64) DateTime::DateTimeToTime_t(itemInfo.lastpost));
 		}
 
@@ -464,7 +464,7 @@ void GroupTreeWidget::fillGroupItems(QTreeWidgetItem *categoryItem, const QList<
 		if(itemInfo.lastpost == DateTime::DateTimeFromTime_t(0))
 			tooltip += "\n" + tr("Last Post") + ": "  + tr("Never") ;
 		else
-			tooltip += "\n" + tr("Last Post") + ": "  + DateTime::formatLongDateTime(itemInfo.lastpost) ;
+			tooltip += "\n" + tr("Last Post") + ": "  + DateTime::formatDateTime(itemInfo.lastpost) ;
 		if(!IS_GROUP_SUBSCRIBED(itemInfo.subscribeFlags))
 			tooltip += "\n" + tr("Subscribe to download and read messages") ;
 

--- a/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
+++ b/retroshare-gui/src/gui/connect/ConfCertDialog.cpp
@@ -155,7 +155,7 @@ void ConfCertDialog::load()
 
 	ui.loc->setText(QString::fromUtf8(detail.location.c_str()));
 	// Dont Show a timestamp in RS calculate the day
-	ui.lastcontact->setText(DateTime::formatLongDateTime(detail.lastConnect));
+	ui.lastcontact->setText(DateTime::formatDateTime(detail.lastConnect));
 
 	/* set retroshare version */
 	std::string version;

--- a/retroshare-gui/src/gui/feeds/BoardsCommentsItem.cpp
+++ b/retroshare-gui/src/gui/feeds/BoardsCommentsItem.cpp
@@ -436,7 +436,7 @@ void BoardsCommentsItem::setComment(const RsGxsComment& cmt)
 	ui->commLabel->setText(RsHtml().formatText(NULL, RsStringUtil::CopyLines(QString::fromUtf8(cmt.mComment.c_str()), autorized_lines), RSHTML_FORMATTEXT_EMBED_LINKS));;
 
 	ui->nameLabel->setId(cmt.mMeta.mAuthorId);
-	ui->datetimeLabel->setText(DateTime::formatLongDateTime(cmt.mMeta.mPublishTs));
+	ui->datetimeLabel->setText(DateTime::formatDateTime(cmt.mMeta.mPublishTs));
 
 	RsIdentityDetails idDetails ;
 	rsIdentity->getIdDetails(cmt.mMeta.mAuthorId,idDetails);

--- a/retroshare-gui/src/gui/feeds/BoardsPostItem.cpp
+++ b/retroshare-gui/src/gui/feeds/BoardsPostItem.cpp
@@ -404,7 +404,7 @@ void BoardsPostItem::fill()
 		ui->msgFrame->setVisible(doc.toPlainText().length() > 0);
 	}
 
-	ui->datetimelabel->setText(DateTime::formatLongDateTime(mPost.mMeta.mPublishTs));
+	ui->datetimelabel->setText(DateTime::formatDateTime(mPost.mMeta.mPublishTs));
 }
 
 QString BoardsPostItem::messageName()

--- a/retroshare-gui/src/gui/feeds/ChannelsCommentsItem.cpp
+++ b/retroshare-gui/src/gui/feeds/ChannelsCommentsItem.cpp
@@ -366,7 +366,7 @@ void ChannelsCommentsItem::fill(bool missing_post)
 
     ui->commLabel->setText(RsHtml().formatText(NULL, RsStringUtil::CopyLines(QString::fromUtf8(mComment.mComment.c_str()), autorized_lines), RSHTML_FORMATTEXT_EMBED_LINKS));
     ui->nameLabel->setId(mComment.mMeta.mAuthorId);
-    ui->datetimeLabel->setText(DateTime::formatLongDateTime(mComment.mMeta.mPublishTs));
+    ui->datetimeLabel->setText(DateTime::formatDateTime(mComment.mMeta.mPublishTs));
 
     RsIdentityDetails idDetails ;
     rsIdentity->getIdDetails(mComment.mMeta.mAuthorId,idDetails);

--- a/retroshare-gui/src/gui/feeds/ChatMsgItem.cpp
+++ b/retroshare-gui/src/gui/feeds/ChatMsgItem.cpp
@@ -157,7 +157,7 @@ void ChatMsgItem::insertChat(const std::string &message)
     std::cerr << "ChatMsgItem::insertChat(): " << msg << std::endl;
 #endif
 
-    timestampLabel->setText(DateTime::formatLongDateTime(QDateTime::currentDateTime()));
+    timestampLabel->setText(DateTime::formatDateTime(QDateTime::currentDateTime()));
 
     QString formatMsg = QString::fromUtf8(message.c_str());
 

--- a/retroshare-gui/src/gui/feeds/GxsChannelGroupItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsChannelGroupItem.cpp
@@ -227,7 +227,7 @@ void GxsChannelGroupItem::fill()
 	if(mGroup.mMeta.mLastPost==0)
 		ui->infoLastPost->setText(tr("Never"));
 	else
-		ui->infoLastPost->setText(DateTime::formatLongDateTime(mGroup.mMeta.mLastPost));
+		ui->infoLastPost->setText(DateTime::formatDateTime(mGroup.mMeta.mLastPost));
 
 	if (mIsHome)
 	{

--- a/retroshare-gui/src/gui/feeds/GxsChannelPostItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsChannelPostItem.cpp
@@ -436,7 +436,7 @@ void GxsChannelPostItem::fill()
 		fillExpandFrame();
 	}
 
-	ui->datetimelabel->setText(DateTime::formatLongDateTime(mPost.mMeta.mPublishTs));
+	ui->datetimelabel->setText(DateTime::formatDateTime(mPost.mMeta.mPublishTs));
 
 	if ( (mPost.mAttachmentCount != 0) || (mPost.mSize != 0) ) {
 		ui->filelabel->setVisible(true);

--- a/retroshare-gui/src/gui/feeds/GxsForumMsgItem.cpp
+++ b/retroshare-gui/src/gui/feeds/GxsForumMsgItem.cpp
@@ -309,7 +309,7 @@ void GxsForumMsgItem::fillMessage()
     if (wasExpanded() || ui->expandFrame->isVisible())
         fillExpandFrame();
 
-    ui->timestamplabel->setText(DateTime::formatLongDateTime(mMessage.mMeta.mPublishTs));
+    ui->timestamplabel->setText(DateTime::formatDateTime(mMessage.mMeta.mPublishTs));
 
     /* header stuff */
     ui->subjectLabel->setText(msgLink.toHtml());

--- a/retroshare-gui/src/gui/feeds/MsgItem.cpp
+++ b/retroshare-gui/src/gui/feeds/MsgItem.cpp
@@ -226,7 +226,7 @@ void MsgItem::updateItemStatic()
 	titleLabel->setText(title);
 	subjectLabel->setText(QString::fromUtf8(mi.title.c_str()));
 	mMsg = QString::fromUtf8(mi.msg.c_str());
-	timestampLabel->setText(DateTime::formatLongDateTime(mi.ts));
+	timestampLabel->setText(DateTime::formatDateTime(mi.ts));
 
 	if (wasExpanded() || expandFrame->isVisible()) {
 		fillExpandFrame();

--- a/retroshare-gui/src/gui/feeds/PeerItem.cpp
+++ b/retroshare-gui/src/gui/feeds/PeerItem.cpp
@@ -132,7 +132,7 @@ void PeerItem::updateItemStatic()
 	{
 		/* set peer name */
 		peerNameLabel->setText(QString::fromUtf8(details.name.c_str()));
-		lastLabel-> setText(DateTime::formatLongDateTime(details.lastConnect));
+		lastLabel-> setText(DateTime::formatDateTime(details.lastConnect));
 
 		/* expanded Info */
 		nameLabel->setText(QString::fromUtf8(details.name.c_str()));

--- a/retroshare-gui/src/gui/feeds/PostedGroupItem.cpp
+++ b/retroshare-gui/src/gui/feeds/PostedGroupItem.cpp
@@ -190,7 +190,7 @@ void PostedGroupItem::fill()
     if(mGroup.mMeta.mLastPost==0)
         ui->infoLastPost->setText(tr("Never"));
     else
-        ui->infoLastPost->setText(DateTime::formatLongDateTime(mGroup.mMeta.mLastPost));
+        ui->infoLastPost->setText(DateTime::formatDateTime(mGroup.mMeta.mLastPost));
 
 	//TODO - nice icon for subscribed group
 //	if (IS_GROUP_PUBLISHER(mGroup.mMeta.mSubscribeFlags)) {

--- a/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityIpItem.cpp
@@ -131,7 +131,7 @@ void SecurityIpItem::updateItemStatic()
 	}
 
 	QDateTime currentTime = QDateTime::currentDateTime();
-	ui->timeLabel->setText(DateTime::formatLongDateTime(currentTime));
+	ui->timeLabel->setText(DateTime::formatDateTime(currentTime));
 }
 
 void SecurityIpItem::updateItem()

--- a/retroshare-gui/src/gui/feeds/SecurityItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.cpp
@@ -171,7 +171,7 @@ void SecurityItem::updateItemStatic()
 	titleLabel->setText(title);
 
 	QDateTime currentTime = QDateTime::currentDateTime();
-	timeLabel->setText(DateTime::formatLongDateTime(currentTime));
+	timeLabel->setText(DateTime::formatDateTime(currentTime));
 
 	if (mIsHome)
 	{

--- a/retroshare-gui/src/gui/gxs/GxsCommentDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsCommentDialog.cpp
@@ -180,7 +180,7 @@ void GxsCommentDialog::setCommentHeader(QWidget *header)
 
 	QDateTime qtime;
 	qtime.setTime_t(mCurrentPost.mMeta.mPublishTs);
-	QString timestamp = qtime.toString("dd.MMMM yyyy hh:mm");
+	QString timestamp = DateTime::formatDateTime(qtime);
 	ui->dateLabel->setText(timestamp);
 	ui->fromLabel->setText(QString::fromUtf8(mCurrentPost.mMeta.mAuthorId.c_str()));
 	ui->titleLabel->setText("<a href=" + QString::fromStdString(mCurrentPost.mLink) +

--- a/retroshare-gui/src/gui/gxs/GxsCommentTreeWidget.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsCommentTreeWidget.cpp
@@ -801,7 +801,7 @@ void GxsCommentTreeWidget::insertComments(const std::vector<RsGxsComment>& comme
 		{
 			QDateTime qtime = DateTime::DateTimeFromTime_t(comment.mMeta.mPublishTs) ;
 
-			text = qtime.toString("yyyy-MM-dd hh:mm:ss") ;
+			text = DateTime::formatDateTime(qtime);
 			item->setText(PCITEM_COLUMN_DATE, text) ;
 			item->setToolTip(PCITEM_COLUMN_DATE, text) ;
 			item->setData(PCITEM_COLUMN_DATE, ROLE_SORT, QVariant(qlonglong(comment.mMeta.mPublishTs)));

--- a/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
@@ -461,10 +461,10 @@ void GxsGroupDialog::updateFromExistingMeta(const QString &description)
     if(mGrpMeta.mLastPost==0)
         ui.lastpostline->setText(tr("Never"));
     else
-        ui.lastpostline->setText(DateTime::formatLongDateTime(mGrpMeta.mLastPost));
+        ui.lastpostline->setText(DateTime::formatDateTime(mGrpMeta.mLastPost));
     ui.authorValueLabel->setId(mGrpMeta.mAuthorId);
 	
-    ui.createdline->setText(DateTime::formatLongDateTime(mGrpMeta.mPublishTs));
+    ui.createdline->setText(DateTime::formatDateTime(mGrpMeta.mPublishTs));
 
 	link = RetroShareLink::createMessage(mGrpMeta.mAuthorId, "");
 

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostFilesModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostFilesModel.cpp
@@ -386,7 +386,7 @@ QVariant RsGxsChannelPostFilesModel::sortRole(const ChannelPostFileInfo& fmpe,in
     {
 	case COLUMN_FILES_NAME: return QVariant(QString::fromUtf8(fmpe.mName.c_str()));
 	case COLUMN_FILES_SIZE: return QVariant(qulonglong(fmpe.mSize));
-	case COLUMN_FILES_DATE: return QVariant(qulonglong(fmpe.mPublishTime));
+	case COLUMN_FILES_DATE: return DateTime::formatDateTime(fmpe.mPublishTime);
 	case COLUMN_FILES_FILE:
     {
         FileInfo finfo;

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostFilesModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostFilesModel.cpp
@@ -386,7 +386,7 @@ QVariant RsGxsChannelPostFilesModel::sortRole(const ChannelPostFileInfo& fmpe,in
     {
 	case COLUMN_FILES_NAME: return QVariant(QString::fromUtf8(fmpe.mName.c_str()));
 	case COLUMN_FILES_SIZE: return QVariant(qulonglong(fmpe.mSize));
-	case COLUMN_FILES_DATE: return DateTime::formatDateTime(fmpe.mPublishTime);
+	case COLUMN_FILES_DATE: return QVariant(qulonglong(fmpe.mPublishTime));
 	case COLUMN_FILES_FILE:
     {
         FileInfo finfo;
@@ -408,7 +408,7 @@ QVariant RsGxsChannelPostFilesModel::displayRole(const ChannelPostFileInfo& fmpe
 	{
 	case COLUMN_FILES_NAME: return QString::fromUtf8(fmpe.mName.c_str());
 	case COLUMN_FILES_SIZE: return QString::number(fmpe.mSize);
-	case COLUMN_FILES_DATE: return QString::number(fmpe.mPublishTime);
+	case COLUMN_FILES_DATE: return QVariant(qulonglong(fmpe.mPublishTime));
 	case COLUMN_FILES_FILE: {
 		FileInfo finfo;
 		if(rsFiles->FileDetails(fmpe.mHash,RS_FILE_HINTS_DOWNLOAD,finfo))

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
@@ -227,7 +227,7 @@ void ChannelPostDelegate::paint(QPainter * painter, const QStyleOptionViewItem &
         y += font_height;
         y += font_height/2.0;
 
-        QString info_text = QLocale::system().toString(DateTime::DateTimeFromTime_t(post.mMeta.mPublishTs), QLocale::ShortFormat);
+	QString info_text = DateTime::formatDateTime(post.mMeta.mPublishTs);
 
         if(post.mAttachmentCount > 0)
             info_text += ", " + QString::number(post.mAttachmentCount)+ " " +((post.mAttachmentCount>1)?tr("files"):tr("file")) + " (" + misc::friendlyUnit(qulonglong(post.mSize)) + ")" ;
@@ -955,7 +955,7 @@ void GxsChannelPostsWidgetWithModel::showPostDetails()
 
     ui->postName_LB->setText(QString::fromUtf8(post.mMeta.mMsgName.c_str()));
 
-    ui->postTime_LB->setText(QDateTime::fromMSecsSinceEpoch(post.mMeta.mPublishTs*1000).toString("MM/dd/yyyy, hh:mm"));
+    ui->postTime_LB->setText(DateTime::formatDateTime(post.mMeta.mPublishTs));
     ui->postTime_LB->setFixedWidth(W);
 
     //ui->channelPostFiles_TV->resizeColumnToContents(RsGxsChannelPostFilesModel::COLUMN_FILES_FILE);
@@ -1284,7 +1284,7 @@ void GxsChannelPostsWidgetWithModel::insertChannelDetails(const RsGxsChannelGrou
     if(group.mMeta.mLastPost==0)
         ui->infoLastPost->setText(tr("Never"));
     else
-        ui->infoLastPost->setText(DateTime::formatLongDateTime(group.mMeta.mLastPost));
+        ui->infoLastPost->setText(DateTime::formatDateTime(group.mMeta.mLastPost));
 
     uint32_t current_sync_time  = GxsGroupFrameDialog::checkDelay(rsGxsChannels->getSyncPeriod(group.mMeta.mGroupId))/86400 ;
 
@@ -1335,7 +1335,7 @@ void GxsChannelPostsWidgetWithModel::insertChannelDetails(const RsGxsChannelGrou
     else
         ui->infoAdministrator->setText("[No contact author]");
 
-    ui->infoCreated->setText(DateTime::formatLongDateTime(group.mMeta.mPublishTs));
+    ui->infoCreated->setText(DateTime::formatDateTime(group.mMeta.mPublishTs));
 
     QString distrib_string ( "[unknown]" );
 

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
@@ -318,8 +318,9 @@ void ChannelPostFilesDelegate::paint(QPainter * painter, const QStyleOptionViewI
             break;
     case RsGxsChannelPostFilesModel::COLUMN_FILES_SIZE: painter->drawText(option.rect,Qt::AlignRight | Qt::AlignVCenter,misc::friendlyUnit(qulonglong(file.mSize)));
             break;
-    case RsGxsChannelPostFilesModel::COLUMN_FILES_DATE: painter->drawText(option.rect,Qt::AlignLeft | Qt::AlignVCenter,QDateTime::fromMSecsSinceEpoch(file.mPublishTime*1000).toString("MM/dd/yyyy, hh:mm"));
-            break;
+    case RsGxsChannelPostFilesModel::COLUMN_FILES_DATE: 
+	    painter->drawText(option.rect, Qt::AlignLeft | Qt::AlignVCenter, " " + DateTime::formatDateTime(file.mPublishTime));
+	    break;
     case RsGxsChannelPostFilesModel::COLUMN_FILES_FILE: {
 
         GxsChannelFilesStatusWidget w(file);
@@ -357,7 +358,7 @@ QSize ChannelPostFilesDelegate::sizeHint(const QStyleOptionViewItem& option, con
     {
     case RsGxsChannelPostFilesModel::COLUMN_FILES_NAME: return QSize(1.1*QFontMetrics_horizontalAdvance(fm, QString::fromUtf8(file.mName.c_str())),fm.height());
     case RsGxsChannelPostFilesModel::COLUMN_FILES_SIZE: return QSize(1.1*QFontMetrics_horizontalAdvance(fm, misc::friendlyUnit(qulonglong(file.mSize))),fm.height());
-    case RsGxsChannelPostFilesModel::COLUMN_FILES_DATE: return QSize(1.1*QFontMetrics_horizontalAdvance(fm, QDateTime::fromMSecsSinceEpoch(file.mPublishTime*1000).toString("MM/dd/yyyy, hh:mm")),fm.height());
+    case RsGxsChannelPostFilesModel::COLUMN_FILES_DATE: return QSize(1.1 * QFontMetrics_horizontalAdvance(fm, DateTime::formatDateTime(file.mPublishTime)), fm.height());
     default:
     case RsGxsChannelPostFilesModel::COLUMN_FILES_FILE: return QSize(option.rect.width(),GxsChannelFilesStatusWidget(file).height());
     }

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1062,7 +1062,7 @@ void GxsForumThreadWidget::updateForumDescription(bool success)
     if(group.mMeta.mLastPost==0)
         forum_description += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post"),tr("Never"));
     else
-        forum_description += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post"),DateTime::formatLongDateTime(group.mMeta.mLastPost));
+        forum_description += QString("<b>%1: \t</b>%2<br/>").arg(tr("Last post"),DateTime::formatDateTime(group.mMeta.mLastPost));
 
     if(IS_GROUP_SUBSCRIBED(group.mMeta.mSubscribeFlags))
     {
@@ -1222,7 +1222,7 @@ void GxsForumThreadWidget::insertMessage()
 
         for(int i=0;i<static_cast<int>(post_versions.size());++i)
         {
-            ui->versions_CB->insertItem(i, ((i==0)?tr("(Latest) "):tr("(Old) "))+" "+DateTime::formatLongDateTime( post_versions[i].first));
+            ui->versions_CB->insertItem(i, ((i==0)?tr("(Latest) "):tr("(Old) "))+" "+DateTime::formatDateTime( post_versions[i].first));
             ui->versions_CB->setItemData(i,QString::fromStdString(post_versions[i].second.toStdString()));
 
 #ifdef DEBUG_FORUMS
@@ -1298,7 +1298,7 @@ void GxsForumThreadWidget::insertMessageData(const RsGxsForumMsg &msg)
     // TODO enabled even when there are no new message
     ui->nextUnreadButton->setEnabled(true);
     ui->lineLeft->show();
-    ui->time_label->setText(DateTime::formatLongDateTime(msg.mMeta.mPublishTs));
+    ui->time_label->setText(DateTime::formatDateTime(msg.mMeta.mPublishTs));
     ui->lineRight->show();
     ui->by_text_label->show();
     ui->by_label->setId(msg.mMeta.mAuthorId);
@@ -1627,7 +1627,7 @@ static QString buildReplyHeader(const RsMsgMetaData &meta)
     QString header = QString("<span>-----%1-----").arg(QApplication::translate("GxsForumThreadWidget", "Original Message"));
     header += QString("<br><font size='3'><strong>%1: </strong>%2</font><br>").arg(QApplication::translate("GxsForumThreadWidget", "From"), from);
 
-    header += QString("<br><font size='3'><strong>%1: </strong>%2</font><br>").arg(QApplication::translate("GxsForumThreadWidget", "Sent"), DateTime::formatLongDateTime(meta.mPublishTs));
+    header += QString("<br><font size='3'><strong>%1: </strong>%2</font><br>").arg(QApplication::translate("GxsForumThreadWidget", "Sent"), DateTime::formatDateTime(meta.mPublishTs));
     header += QString("<font size='3'><strong>%1: </strong>%2</font></span><br>").arg(QApplication::translate("GxsForumThreadWidget", "Subject"), QString::fromUtf8(meta.mMsgName.c_str()));
     header += "<br>";
 

--- a/retroshare-gui/src/gui/msgs/MessageComposer.cpp
+++ b/retroshare-gui/src/gui/msgs/MessageComposer.cpp
@@ -1169,7 +1169,7 @@ QString MessageComposer::buildReplyHeader(const MessageInfo &msgInfo)
         header += QString("<font size='3'><strong>%1: </strong>%2</font><br>").arg(tr("Cc"), cc);
     }
 
-    header += QString("<br><font size='3'><strong>%1: </strong>%2</font><br>").arg(tr("Sent"), DateTime::formatLongDateTime(msgInfo.ts));
+    header += QString("<br><font size='3'><strong>%1: </strong>%2</font><br>").arg(tr("Sent"), DateTime::formatDateTime(msgInfo.ts));
     header += QString("<font size='3'><strong>%1: </strong>%2</font></span><br>").arg(tr("Subject"), QString::fromUtf8(msgInfo.title.c_str()));
     header += "<br>";
 

--- a/retroshare-gui/src/gui/profile/ProfileWidget.cpp
+++ b/retroshare-gui/src/gui/profile/ProfileWidget.cpp
@@ -45,7 +45,7 @@ ProfileWidget::ProfileWidget(QWidget *parent, Qt::WindowFlags flags)
     connect(ui.CopyCertButton,SIGNAL(clicked()), this, SLOT(copyCert()));
     connect(ui.profile_Button,SIGNAL(clicked()), this, SLOT(profilemanager()));
 
-    ui.onLineSince->setText(DateTime::formatLongDateTime(RsApplication::startupTime()));
+    ui.onLineSince->setText(DateTime::formatDateTime(RsApplication::startupTime()));
 }
 
 void ProfileWidget::showEvent ( QShowEvent * /*event*/ )

--- a/retroshare-gui/src/gui/settings/AppearancePage.cpp
+++ b/retroshare-gui/src/gui/settings/AppearancePage.cpp
@@ -47,6 +47,8 @@
 #include <QStatusBar>
 #include <QStyledItemDelegate>
 #include <QStyleFactory>
+#include <QDateTime>
+#include <QLocale>
 
 /** Constructor */
 AppearancePage::AppearancePage(QWidget * parent, Qt::WindowFlags flags)
@@ -89,6 +91,16 @@ AppearancePage::AppearancePage(QWidget * parent, Qt::WindowFlags flags)
 	foreach (QString name, styleSheets.keys()) {
 		ui.cmboStyleSheet->addItem(name, styleSheets[name]);
 	}
+
+	/* Populate Date Format combo box */
+	QDateTime now = QDateTime::currentDateTime();
+
+	ui.cmboDateFormat->addItem(tr("System Default") + " (" + QLocale::system().toString(now, QLocale::ShortFormat) + ")", RshareSettings::DateFormat_System);
+	// Remove 'T' from ISO date for nicer display
+	ui.cmboDateFormat->addItem(tr("ISO 8601") + " (" + now.toString(Qt::ISODate).replace('T', ' ') + ")", RshareSettings::DateFormat_ISO);
+	ui.cmboDateFormat->addItem(tr("Text") + " (" + now.toString("dd MMM yyyy HH:mm") + ")", RshareSettings::DateFormat_Text);
+
+	connect(ui.cmboDateFormat, SIGNAL(currentIndexChanged(int)), this, SLOT(updateDateFormat()));
 
 	connect(ui.cmboTollButtonsSize,           SIGNAL(currentIndexChanged(int)), this, SLOT(updateCmboToolButtonSize() ));
 //	connect(ui.cmboListItemSize,              SIGNAL(currentIndexChanged(int)), this, SLOT(updateCmboListItemSize()   ));
@@ -262,6 +274,15 @@ void AppearancePage::load()
 	int index = ui.cmboLanguage->findData(Settings->getLanguageCode());
 	whileBlocking(ui.cmboLanguage)->setCurrentIndex(index);
 
+	// Load Date Format
+	int dateFormat = Settings->getDateFormat();
+	int comboIndex = ui.cmboDateFormat->findData(dateFormat);
+	if (comboIndex != -1) {
+		whileBlocking(ui.cmboDateFormat)->setCurrentIndex(comboIndex);
+	} else {
+		whileBlocking(ui.cmboDateFormat)->setCurrentIndex(0);
+	}
+
 	index = ui.cmboStyle->findData(RsApplication::style().toLower());
 	whileBlocking(ui.cmboStyle)->setCurrentIndex(index);
 
@@ -371,3 +392,12 @@ void AppearancePage::updateFontSize()
 
 	RsGUIEventManager::getInstance()->notifySettingsChanged();
 }
+
+void AppearancePage::updateDateFormat()
+{
+    int format = ui.cmboDateFormat->currentData().toInt();
+    Settings->setDateFormat(format);
+
+    RsGUIEventManager::getInstance()->notifySettingsChanged();
+}
+

--- a/retroshare-gui/src/gui/settings/AppearancePage.cpp
+++ b/retroshare-gui/src/gui/settings/AppearancePage.cpp
@@ -37,6 +37,7 @@
 #include "gui/statusbar/SysTrayStatus.h"
 #include "lang/languagesupport.h"
 #include "util/misc.h"
+#include "util/DateTime.h"
 
 #include <QAbstractItemView>
 #include <QComboBox>
@@ -95,10 +96,23 @@ AppearancePage::AppearancePage(QWidget * parent, Qt::WindowFlags flags)
 	/* Populate Date Format combo box */
 	QDateTime now = QDateTime::currentDateTime();
 
-	ui.cmboDateFormat->addItem(tr("System Default") + " (" + QLocale::system().toString(now, QLocale::ShortFormat) + ")", RshareSettings::DateFormat_System);
-	// Remove 'T' from ISO date for nicer display
-	ui.cmboDateFormat->addItem(tr("ISO 8601") + " (" + now.toString(Qt::ISODate).replace('T', ' ') + ")", RshareSettings::DateFormat_ISO);
-	ui.cmboDateFormat->addItem(tr("Text") + " (" + now.toString("dd MMM yyyy HH:mm") + ")", RshareSettings::DateFormat_Text);
+	// 1. Format Système (ShortFormat)
+	ui.cmboDateFormat->addItem(tr("System Default") + " (" + 
+	QLocale::system().toString(now.date(), QLocale::ShortFormat) + " " + 
+	QLocale::system().toString(now.time(), QLocale::ShortFormat) + ")", 
+	RshareSettings::DateFormat_System);
+
+	// 2. Format ISO (YYYY-MM-DD + HH:mm)
+	ui.cmboDateFormat->addItem(tr("ISO 8601") + " (" + 
+	now.date().toString(Qt::ISODate) + " " + 
+	now.time().toString("HH:mm") + ")", 
+	RshareSettings::DateFormat_ISO);
+
+	// 3. Format Texte (LongFormat de Qt + Heure)
+	ui.cmboDateFormat->addItem(tr("Text") + " (" + 
+	QLocale::system().toString(now.date(), QLocale::LongFormat) + " " + 
+	QLocale::system().toString(now.time(), QLocale::ShortFormat) + ")", 
+	RshareSettings::DateFormat_Text);
 
 	connect(ui.cmboDateFormat, SIGNAL(currentIndexChanged(int)), this, SLOT(updateDateFormat()));
 
@@ -397,7 +411,7 @@ void AppearancePage::updateDateFormat()
 {
     int format = ui.cmboDateFormat->currentData().toInt();
     Settings->setDateFormat(format);
-
+    DateTime::updateDateFormatCache();
     RsGUIEventManager::getInstance()->notifySettingsChanged();
 }
 

--- a/retroshare-gui/src/gui/settings/AppearancePage.h
+++ b/retroshare-gui/src/gui/settings/AppearancePage.h
@@ -60,6 +60,7 @@ private slots:
     void switch_status_ShowSystray(bool) ;
 
     void updateLanguageCode()    ;
+    void updateDateFormat();
     void updateInterfaceStyle()  ;
     void updateSheetName()       ;
     void updateRbtPageOnToolBar();

--- a/retroshare-gui/src/gui/settings/AppearancePage.ui
+++ b/retroshare-gui/src/gui/settings/AppearancePage.ui
@@ -14,7 +14,8 @@
    <enum>Qt::NoContextMenu</enum>
   </property>
   <layout class="QGridLayout" name="AppearancePageGLayout">
-   <item row="0" column="0" colspan="2">
+
+   <item row="0" column="0">
     <widget class="QGroupBox" name="grpLanguage">
      <property name="minimumSize">
       <size>
@@ -48,19 +49,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <spacer name="grpLanguageHSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>300</width>
-          <height>16</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="labelLanguage">
         <property name="text">
@@ -68,9 +56,59 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="2">
+       <spacer name="grpLanguageHSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
+
+   <item row="0" column="1">
+    <widget class="QGroupBox" name="grpDateFormat">
+     <property name="title">
+      <string>Date Format</string>
+     </property>
+     <layout class="QGridLayout" name="grpDateGLayout">
+      <item row="0" column="0">
+       <widget class="RSComboBox" name="cmboDateFormat">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Choose the date display format</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <spacer name="grpDateHSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+
    <item row="3" column="0">
     <widget class="QGroupBox" name="grpToolBar">
      <property name="minimumSize">

--- a/retroshare-gui/src/gui/settings/CryptoPage.cpp
+++ b/retroshare-gui/src/gui/settings/CryptoPage.cpp
@@ -68,7 +68,7 @@ CryptoPage::CryptoPage(QWidget * parent, Qt::WindowFlags flags)
     ui.retroshareId_content_LB->hide();
     ui.stackPageCertificate->hide();
 
-	ui.onlinesince->setText(DateTime::formatLongDateTime(RsApplication::startupTime()));
+	ui.onlinesince->setText(DateTime::formatDateTime(RsApplication::startupTime()));
 }
 
 #ifdef UNUSED_CODE

--- a/retroshare-gui/src/gui/settings/rsharesettings.cpp
+++ b/retroshare-gui/src/gui/settings/rsharesettings.cpp
@@ -45,6 +45,7 @@
 
 /* Retroshare's Settings */
 #define SETTING_LANGUAGE            "LanguageCode"
+#define SETTING_DATEFORMAT          "DateFormat"
 #define SETTING_STYLE               "InterfaceStyle"
 #define SETTING_SHEETNAME           "SheetName"
 #define SETTING_PAGEBUTTONLOC       "PageButtonLocation"
@@ -131,6 +132,7 @@ void RshareSettings::initSettings()
 #endif
 
 	setDefault(SETTING_LANGUAGE, LanguageSupport::defaultLanguageCode());
+	setDefault(SETTING_DATEFORMAT, (int)DateFormat_System);
 	setDefault(SETTING_SHEETNAME, ":Standard_Light");
 
 	/* defaults here are not ideal.... but dusent matter */
@@ -1268,3 +1270,14 @@ void RshareSettings::setJsonApiAuthTokens(const QStringList& authTokens)
 	setValueToGroup("JsonApi", "authTokens", authTokens);
 }
 #endif // RS_JSONAPI
+       
+int RshareSettings::getDateFormat()
+{
+    return value(SETTING_DATEFORMAT, (int)DateFormat_System).toInt();
+}
+
+void RshareSettings::setDateFormat(int format)
+{
+    setValue(SETTING_DATEFORMAT, format);
+}
+

--- a/retroshare-gui/src/gui/settings/rsharesettings.h
+++ b/retroshare-gui/src/gui/settings/rsharesettings.h
@@ -109,7 +109,18 @@ public:
 		LASTDIR_BLOGS,
         LASTDIR_SOUNDS,
         LASTDIR_PLUGIN
-    };
+	};
+
+	enum DateFormat {
+        	DateFormat_System = 0,
+	        DateFormat_ISO    = 1,
+	        DateFormat_Text   = 2
+	};
+
+	/** Get the date format (0=System, 1=ISO, 2=Text) */
+	int getDateFormat();
+	/** Set the date format */
+	void setDateFormat(int format);
 
 	enum enumToasterPosition
 	{

--- a/retroshare-gui/src/util/DateTime.cpp
+++ b/retroshare-gui/src/util/DateTime.cpp
@@ -23,6 +23,45 @@
 
 #include "DateTime.h"
 #include "rshare.h"
+#include "gui/settings/rsharesettings.h"
+
+/**
+ * This utility class provides standardized date and time formatting across the application.
+ * * - formatDate() and formatTime(): These methods dynamically adjust the output 
+ * based on the user's selected preference in the application settings 
+ * (ISO 8601, System Short Format, or Text).
+ * * - formatLongDate() and formatLongDateTime(): These methods use the standard 
+ * Qt System Long Format to provide a detailed, locale-aware representation 
+ * of the date, bypassing the application's specific short-date preferences.
+ */
+
+// --- Date Functions ---
+
+QString DateTime::formatDate(time_t dateValue)
+{
+	return formatDate(DateTimeFromTime_t(dateValue).date());
+}
+
+QString DateTime::formatDate(const QDate &dateValue)
+{
+	/* Retrieve the date format index from global settings */
+	int dateFormat = Settings->getDateFormat(); 
+
+	if (dateFormat == RshareSettings::DateFormat_ISO) {
+		/* Option "ISO 8601": Returns YYYY-MM-DD */
+		return dateValue.toString(Qt::ISODate);
+	} 
+	
+	if (dateFormat == RshareSettings::DateFormat_Text) {
+		/* Option "Text": Returns the system's Long Format */
+		return QLocale::system().toString(dateValue, QLocale::LongFormat);
+	}
+
+	/* Default or "System" option: Returns the system's Short Format */
+	return QLocale::system().toString(dateValue, QLocale::ShortFormat);
+}
+
+// --- Long Date Functions ---
 
 QString DateTime::formatLongDate(time_t dateValue)
 {
@@ -31,13 +70,8 @@ QString DateTime::formatLongDate(time_t dateValue)
 
 QString DateTime::formatLongDate(const QDate &dateValue)
 {
-	QString customDateFormat = RsApplication::customDateFormat();
-
-	if (customDateFormat.isEmpty()) {
-		return dateValue.toString(Qt::ISODate);
-	} else {
-		return QLocale().toString(dateValue, customDateFormat);
-	}
+	// Strictly use the system's long format (descriptive)
+	return QLocale::system().toString(dateValue, QLocale::LongFormat);
 }
 
 QString DateTime::formatLongDateTime(time_t datetimeValue)
@@ -50,25 +84,7 @@ QString DateTime::formatLongDateTime(const QDateTime &datetimeValue)
 	return formatLongDate(datetimeValue.date()) + " " + formatTime(datetimeValue.time());
 }
 
-QString DateTime::formatDateTime(time_t datetimeValue)
-{
-	return formatDateTime(DateTimeFromTime_t(datetimeValue));
-}
-
-QString DateTime::formatDateTime(const QDateTime &datetimeValue)
-{
-	return formatDate(datetimeValue.date()) + " " + formatTime(datetimeValue.time());
-}
-
-QString DateTime::formatDate(time_t dateValue)
-{
-	return formatDate(DateTimeFromTime_t(dateValue).date());
-}
-
-QString DateTime::formatDate(const QDate &dateValue)
-{
-	return QLocale::system().toString(dateValue, QLocale::ShortFormat);
-}
+// --- Time Functions ---
 
 QString DateTime::formatTime(time_t timeValue)
 {
@@ -77,8 +93,31 @@ QString DateTime::formatTime(time_t timeValue)
 
 QString DateTime::formatTime(const QTime &timeValue)
 {
+	int dateFormat = Settings->getDateFormat();
+
+	if (dateFormat == RshareSettings::DateFormat_ISO) {
+		/* ISO standard implies 24h format (HH:mm) */
+		return timeValue.toString("HH:mm");
+	}
+
+	/* Default or "System" option: Returns the system's Short Format (respects 12h/24h locale) */
 	return QLocale::system().toString(timeValue, QLocale::ShortFormat);
 }
+
+// --- Combined Functions ---
+
+QString DateTime::formatDateTime(time_t datetimeValue)
+{
+	return formatDateTime(DateTimeFromTime_t(datetimeValue));
+}
+
+QString DateTime::formatDateTime(const QDateTime &datetimeValue)
+{
+	/* Combines the date (respecting user preference) with the system time */
+	return formatDate(datetimeValue.date()) + " " + formatTime(datetimeValue.time());
+}
+
+// --- Conversions Functions ---
 
 QDateTime DateTime::DateTimeFromTime_t(time_t timeValue)
 {

--- a/retroshare-gui/src/util/DateTime.cpp
+++ b/retroshare-gui/src/util/DateTime.cpp
@@ -25,15 +25,31 @@
 #include "rshare.h"
 #include "gui/settings/rsharesettings.h"
 
-/**
+/*
  * This utility class provides standardized date and time formatting across the application.
- * * - formatDate() and formatTime(): These methods dynamically adjust the output 
+ * - formatDate() and formatTime(): These methods dynamically adjust the output 
  * based on the user's selected preference in the application settings 
- * (ISO 8601, System Short Format, or Text).
- * * - formatLongDate() and formatLongDateTime(): These methods use the standard 
- * Qt System Long Format to provide a detailed, locale-aware representation 
- * of the date, bypassing the application's specific short-date preferences.
+ * (System = Qt Short Format, ISO 8601, Text = Qt Long Format)
+ * - formatLongDate() and formatLongDateTime(): use standard Qt Long Format
  */
+
+// Initialiaze cache
+int DateTime::mDateFormatCache = -1;
+
+
+// Cache management
+void DateTime::updateDateFormatCache()
+{
+    mDateFormatCache = Settings->getDateFormat();
+}
+
+int DateTime::getDateFormat()
+{
+    if (mDateFormatCache == -1) {
+        updateDateFormatCache();
+    }
+    return mDateFormatCache;
+}
 
 // --- Date Functions ---
 
@@ -45,7 +61,7 @@ QString DateTime::formatDate(time_t dateValue)
 QString DateTime::formatDate(const QDate &dateValue)
 {
 	/* Retrieve the date format index from global settings */
-	int dateFormat = Settings->getDateFormat(); 
+	int dateFormat = getDateFormat(); 
 
 	if (dateFormat == RshareSettings::DateFormat_ISO) {
 		/* Option "ISO 8601": Returns YYYY-MM-DD */
@@ -93,7 +109,7 @@ QString DateTime::formatTime(time_t timeValue)
 
 QString DateTime::formatTime(const QTime &timeValue)
 {
-	int dateFormat = Settings->getDateFormat();
+	int dateFormat = getDateFormat();
 
 	if (dateFormat == RshareSettings::DateFormat_ISO) {
 		/* ISO standard implies 24h format (HH:mm) */

--- a/retroshare-gui/src/util/DateTime.h
+++ b/retroshare-gui/src/util/DateTime.h
@@ -18,6 +18,8 @@
  *                                                                             *
  *******************************************************************************/
 
+/* ... (header copyright) ... */
+
 #ifndef _DATETIME_H
 #define _DATETIME_H
 
@@ -30,23 +32,23 @@ class QTime;
 class DateTime
 {
 public:
-	/* format long date and time e.g. "September 30, 2012" */
+	/* Always uses the standard Qt Long Format (e.g. "Tuesday, January 13, 2026") */
 	static QString formatLongDate(time_t dateValue);
 	static QString formatLongDate(const QDate &dateValue);
 
-	/* format long date and time e.g. "September 30, 2012 01:05 PM" */
+	/* Combined format: formatLongDate + formatTime */
 	static QString formatLongDateTime(time_t datetimeValue);
 	static QString formatLongDateTime(const QDateTime &datetimeValue);
 
-	/* format date e.g. "9/30/12", "30.09.12" */
+	/* Uses Application Preferences if defined, otherwise falls back to System Short Format */
 	static QString formatDate(time_t dateValue);
 	static QString formatDate(const QDate &dateValue);
 
-	/* format time e.g. "13:05:12" */
+	/* Standard System Short Format for time */
 	static QString formatTime(time_t timeValue);
 	static QString formatTime(const QTime &timeValue);
 
-	/* format date and time (see formatDate & formatTime) */
+	/* Combined format: formatDate + formatTime */
 	static QString formatDateTime(time_t datetimeValue);
 	static QString formatDateTime(const QDateTime &datetimeValue);
 

--- a/retroshare-gui/src/util/DateTime.h
+++ b/retroshare-gui/src/util/DateTime.h
@@ -57,6 +57,17 @@ public:
 
 	/* Convert QDateTime to time_t */
 	static time_t DateTimeToTime_t(const QDateTime& dateTime);
+
+	/*
+	* Updates the internal cache for the date format.
+	* Should be called at startup and whenever settings are changed.
+	*/
+	static void updateDateFormatCache();
+
+private:
+	static int mDateFormatCache;
+	static int getDateFormat(); // Internal helper to get cached value
+
 };
 
 #endif


### PR DESCRIPTION
gui: add option to customize date format in Appearance settings

This commit introduces the UI selection and backend storage for the Date Format preference (System, ISO 8601, Text).

Note: This change only handles the configuration part. The actual date display throughout the application (Chat, Forums, etc.) does not yet use this setting and will be updated in separate PRs

code by Gemini