### PR TITLE
Circle forum id select

### DIFF
--- a/retroshare-gui/src/gui/gxs/GxsIdChooser.h
+++ b/retroshare-gui/src/gui/gxs/GxsIdChooser.h
@@ -36,6 +36,7 @@ class RsGxsUpdateBroadcastBase;
 #define IDCHOOSER_ANON_DEFAULT  0x0002
 #define IDCHOOSER_NO_CREATE     0x0004
 #define IDCHOOSER_NON_ANONYMOUS 0x0008
+#define IDCHOOSER_NO_CONSTRAINT 0x0010
 
 class GxsIdChooser : public RSComboBox
 {
@@ -58,10 +59,12 @@ public:
 	ChosenId_Ret getChosenId(RsGxsId &gxsId);
 
 	void setEntryEnabled(int index, bool enabled);
-    
-	void setIdConstraintSet(const std::set<RsGxsId>& s) ;
+
+	void setIdConstraintSet(const std::set<RsGxsId>& s); // empty = all allowed
+	void intersectIdConstraintSet(const std::set<RsGxsId>& s);
+	void unionIdConstraintSet(const std::set<RsGxsId>& s);
 	bool isInConstraintSet(const RsGxsId& id) const ;
-        
+
 	uint32_t countEnabledEntries() const ;
 signals:
     // emitted after first load of own ids
@@ -86,7 +89,7 @@ private:
 	bool mFirstLoad;
     uint32_t mAllowedCount ;
 
-    std::set<RsGxsId> mConstraintIdsSet ; // leave empty if all allowed
+    std::set<RsGxsId> mConstraintIdsSet ;
 //    RsGxsUpdateBroadcastBase *mBase;
 
     RsEventsHandlerId_t mEventHandlerId;

--- a/retroshare-gui/src/gui/gxs/GxsIdChooser.h
+++ b/retroshare-gui/src/gui/gxs/GxsIdChooser.h
@@ -36,7 +36,6 @@ class RsGxsUpdateBroadcastBase;
 #define IDCHOOSER_ANON_DEFAULT  0x0002
 #define IDCHOOSER_NO_CREATE     0x0004
 #define IDCHOOSER_NON_ANONYMOUS 0x0008
-#define IDCHOOSER_NO_CONSTRAINT 0x0010
 
 class GxsIdChooser : public RSComboBox
 {
@@ -87,9 +86,10 @@ private:
 	uint32_t mFlags;
 	RsGxsId mDefaultId;
 	bool mFirstLoad;
-    uint32_t mAllowedCount ;
+	uint32_t mAllowedCount ;
 
-    std::set<RsGxsId> mConstraintIdsSet ;
+	std::set<RsGxsId> mConstraintIdsSet ;
+	bool noIdConstraint;
 //    RsGxsUpdateBroadcastBase *mBase;
 
     RsEventsHandlerId_t mEventHandlerId;

--- a/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
+++ b/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
@@ -607,12 +607,23 @@ void CreateGxsForumMsg::loadCircleInfo(const RsGxsGroupId& circle_id)
             mForumCircleData = cg;
             mForumCircleLoaded = true;
 
-            //std::cerr << "Loaded content of circle " << cg.mMeta.mGroupId << std::endl;
+            // get set of eligible ids
+            RsGxsCircleDetails circleDetails;
+            rsGxsCircles->getCircleDetails(
+              RsGxsCircleId(cg.mMeta.mGroupId), circleDetails);
+            std::set<RsGxsId> ids;
+            uint32_t mask =
+                GXS_EXTERNAL_CIRCLE_FLAGS_IN_ADMIN_LIST |
+                GXS_EXTERNAL_CIRCLE_FLAGS_SUBSCRIBED;
+            for(auto it = circleDetails.mSubscriptionFlags.begin();
+                it != circleDetails.mSubscriptionFlags.end(); it++
+            ) {
+              if((it->second & mask) == mask) {
+                ids.insert(it->first);
+              }
+            }
 
-            //for(std::set<RsGxsId>::const_iterator it(cg.mInvitedMembers.begin());it!=cg.mInvitedMembers.end();++it)
-            //    std::cerr << "  added constraint to circle element " << *it << std::endl;
-
-            ui->idChooser->intersectIdConstraintSet(cg.mInvitedMembers) ;
+            ui->idChooser->intersectIdConstraintSet(ids);
             ui->idChooser->setFlags(IDCHOOSER_NO_CREATE | ui->idChooser->flags()) ;	// since there's a circle involved, no ID creation can be needed
 
             RsGxsId tmpid ;

--- a/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
+++ b/retroshare-gui/src/gui/gxsforums/CreateGxsForumMsg.cpp
@@ -180,7 +180,7 @@ void  CreateGxsForumMsg::newMsg()
 		// NOTE: mPosterId may not be our own; then GxsIdChooser will not include it.
 
 		idChooserFlags |= IDCHOOSER_NO_CREATE;
-		ui->idChooser->setIdConstraintSet(id_set);
+    ui->idChooser->intersectIdConstraintSet(id_set);
 	}
 	ui->idChooser->loadIds(idChooserFlags, mPosterId);
 
@@ -612,7 +612,7 @@ void CreateGxsForumMsg::loadCircleInfo(const RsGxsGroupId& circle_id)
             //for(std::set<RsGxsId>::const_iterator it(cg.mInvitedMembers.begin());it!=cg.mInvitedMembers.end();++it)
             //    std::cerr << "  added constraint to circle element " << *it << std::endl;
 
-            ui->idChooser->setIdConstraintSet(cg.mInvitedMembers) ;
+            ui->idChooser->intersectIdConstraintSet(cg.mInvitedMembers) ;
             ui->idChooser->setFlags(IDCHOOSER_NO_CREATE | ui->idChooser->flags()) ;	// since there's a circle involved, no ID creation can be needed
 
             RsGxsId tmpid ;

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1746,19 +1746,7 @@ void GxsForumThreadWidget::editForumMessageData(const RsGxsForumMsg& msg)
         return;
     }
 
-    // Go through the list of own ids and see if one of them is a moderator
-    // TODO: offer to select which moderator ID to use if multiple IDs fit the conditions of the forum
-
-    RsGxsId moderator_id ;
-
-    std::list<RsGxsId> own_ids ;
-    rsIdentity->getOwnIds(own_ids) ;
-    std::set<RsGxsId> modIds;
-    for(auto it(own_ids.begin());it!=own_ids.end();++it)
-        if(mForumGroup.mAdminList.ids.find(*it) != mForumGroup.mAdminList.ids.end())
-            modIds.insert(*it);
-
-    CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mMsgId, msg.mMeta.mAuthorId, modIds);
+    CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mMsgId, msg.mMeta.mAuthorId, mForumGroup.mAdminList.ids);
 
     cfm->insertPastedText(QString::fromUtf8(msg.mMsg.c_str())) ;
     cfm->show();

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -730,12 +730,12 @@ void GxsForumThreadWidget::threadListCustomPopupMenu(QPoint /*point*/)
             else
             {
                 // Go through the list of own ids and see if one of them is a moderator
-                // TODO: offer to select which moderator ID to use if multiple IDs fit the conditions of the forum
 
                 std::list<RsGxsId> own_ids ;
                 rsIdentity->getOwnIds(own_ids) ;
 
                 for(auto it(own_ids.begin());it!=own_ids.end();++it)
+                    // TODO: also make sure the ID is in the circle
                     if(mForumGroup.canEditPosts(*it))
                     {
                         contextMnu.addAction(editAct);


### PR DESCRIPTION
Fixes an issue in circle-restricted forums where invited non-member identities are still listed in the dropdown for creating/editing a post. This PR removes those non-member identities from the dropdown list.

depends on #3117 