### PR TITLE
Fix and Correct compliation error introduced in pr #3122

### DIFF
--- a/retroshare-gui/src/gui/common/FriendListModel.cpp
+++ b/retroshare-gui/src/gui/common/FriendListModel.cpp
@@ -748,7 +748,7 @@ QVariant RsFriendListModel::displayRole(const EntryIndex& e, int col) const
                                 }
                         }
 
-			if(col == COLUMN_THREAD_LAST_CONTACT) return QVariant((qulonglong)most_recent_time.toTime_t());
+			if(col == COLUMN_THREAD_LAST_CONTACT) return QVariant((qulonglong)DateTime::DateTimeToTime_t(most_recent_time));
 			if(col == COLUMN_THREAD_IP)           return QVariant(most_recent_ip);
 
                         return QVariant();

--- a/retroshare-gui/src/gui/gxs/GxsIdDetails.h
+++ b/retroshare-gui/src/gui/gxs/GxsIdDetails.h
@@ -136,6 +136,7 @@ public:
      *  - makeDefaultGroupIcon(const RsGxsGroupId&, const QString&, AvatarSize)
      *  - makeDefaultGroupIcon(const QString&, const QString&, AvatarSize)
      */
+    static const QPixmap makeDefaultGroupIconFromString(const QString& idStr, const QString& iconPath, AvatarSize size = MEDIUM);
 	static bool loadPixmapFromData(const unsigned char *data, size_t data_len, QPixmap& pix, AvatarSize size = MEDIUM);
     static void checkCleanImagesCache();
     static void debug_dumpImagesCache();
@@ -164,6 +165,7 @@ private:
 	                         quint16 size, QColor fillColor);
 	static QPixmap drawIdentIcon(QString hash, quint16 width, bool rotate);
 	static QPixmap generateColoredIcon(const QString& idStr, const QString& iconPath, int size);
+    static const QPixmap makeDefaultGroupIconWithCacheKey(const QString& idStr, const QString& iconPath, AvatarSize size, const std::string& cacheKey);
 
 private slots:
 	void objectDestroyed(QObject *object);


### PR DESCRIPTION
Compilation was failing because `makeDefaultGroupIconFromString` was implemented in `GxsIdDetails.cpp` and used from `AvatarDefs.cpp`, but never declared in `GxsIdDetails.h`. This change adds the missing header declaration, aligning it with the existing implementation and resolving the build error.

Beyond the missing declaration, the function’s behavior was also incorrect for non-GXS identifiers. The previous implementation delegated to the `QString` overload of `makeDefaultGroupIcon`, which attempts to convert the input string into an `RsGxsGroupId`. This conversion fails for identifiers such as `RsPeerId` and `RsPgpId`, resulting in a type mismatch during compilation.

The function has been reimplemented to handle string-based identifiers correctly. It now generates cache keys directly from the input string using `groupIconCacheKeyFromString()`, passes the string straight into `generateColoredIcon()`, and avoids any conversion to `RsGxsGroupId`. A separate cache key strategy is preserved to prevent collisions between GXS and non-GXS avatars.

As a result, default avatar generation now works consistently for `RsPeerId`, `RsPgpId`, and other non-GXS IDs, while mirroring the structure and behavior of the GXS overload without relying on invalid ID conversions.