### PR TITLE
fix rapidjson include directory for plugins

### DIFF
--- a/plugins/Common/retroshare_plugin.pri
+++ b/plugins/Common/retroshare_plugin.pri
@@ -21,8 +21,16 @@
 TEMPLATE = lib
 CONFIG *= plugin
 
-DEPENDPATH += $$PWD/../../libretroshare/src/ $$PWD/../../retroshare-gui/src/
-INCLUDEPATH += $$PWD/../../libretroshare/src/ $$PWD/../../retroshare-gui/src/
+# TODO: Why are these not added by retroshare.pri?
+DEPENDPATH += $$PWD/../../retroshare-gui/src/
+INCLUDEPATH += $$PWD/../../retroshare-gui/src/
+
+# TODO: Why can we not include use_libretroshare.pri
+DEPENDPATH += $$PWD/../../libretroshare/src/
+INCLUDEPATH += $$PWD/../../libretroshare/src/
+# rapidjson headers are required for libretroshare
+INCLUDEPATH += ../../supportlibs/rapidjson/include
+
 
 linux-* {
 	target.path = "$${RS_PLUGIN_DIR}"

--- a/plugins/FeedReader/FeedReader.pro
+++ b/plugins/FeedReader/FeedReader.pro
@@ -110,12 +110,6 @@ TRANSLATIONS +=  \
 			lang/FeedReader_tr.ts \
 			lang/FeedReader_zh_CN.ts
 
-# when rapidjson is mainstream on all distribs, we will not need the sources anymore
-# in the meantime, they are part of the RS directory so that it is always possible to find them
-
-INCLUDEPATH += ../../rapidjson-1.1.0
-
-
 linux-* {
 	CONFIG += link_pkgconfig
 

--- a/plugins/VOIP/VOIP.pro
+++ b/plugins/VOIP/VOIP.pro
@@ -40,11 +40,6 @@ target.files = lib/libVOIP.so
 DEPENDPATH += $$PWD/../../retroshare-gui/src/temp/ui
 INCLUDEPATH += $$PWD/../../retroshare-gui/src/temp/ui
 
-# when rapidjson is mainstream on all distribs, we will not need the sources anymore
-# in the meantime, they are part of the RS directory so that it is always possible to find them
-
-INCLUDEPATH += ../../supportlibs/rapidjson/include
-
 
 #################################### Linux #####################################
 


### PR DESCRIPTION
This fixes an issue where plugins fail to find the rapidjson headers that are necessary for using libretroshare.