### PR TITLE
Fix Identity/Chat refresh logic to handle instant avatar updates

### DIFF
--- a/retroshare-gui/src/gui/Identity/IdDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDialog.cpp
@@ -451,6 +451,9 @@ IdDialog::IdDialog(QWidget *parent)
     updateIdTimer.setSingleShot(true);
 	connect(&updateIdTimer, SIGNAL(timeout()), this, SLOT(updateIdList()));
 
+    updateCirclesTimer.setSingleShot(true);
+	connect(&updateCirclesTimer, SIGNAL(timeout()), this, SLOT(updateCircles()));
+
     mFontSizeHandler.registerFontSize(ui->idTreeWidget, 0, [this] (QAbstractItemView*, int fontSize) {
         // Set new font size on all items
         mIdListModel->setFontSize(fontSize);
@@ -540,7 +543,10 @@ void IdDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
 		case RsGxsCircleEventCode::CACHE_DATA_UPDATED:
 
 			if (isVisible())
-                updateCircles();
+            {
+                if(!updateCirclesTimer.isActive())
+                    updateCirclesTimer.start(200);
+            }
 			else
 				needUpdateCirclesOnNextShow = true;
 		default:
@@ -1426,13 +1432,11 @@ void IdDialog::updateIdListRequest()
 {
     if(updateIdTimer.isActive())
     {
-        std::cerr << "updateIdListRequest(): restarting timer"<< std::endl;
         updateIdTimer.stop();
         updateIdTimer.start(1000);
     }
     else
     {
-        std::cerr << "updateIdListRequest(): starting timer"<< std::endl;
         updateIdTimer.start(1000);
     }
 }

--- a/retroshare-gui/src/gui/Identity/IdDialog.cpp
+++ b/retroshare-gui/src/gui/Identity/IdDialog.cpp
@@ -545,7 +545,7 @@ void IdDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
 			if (isVisible())
             {
                 if(!updateCirclesTimer.isActive())
-                    updateCirclesTimer.start(200);
+                    updateCirclesTimer.start(1000);
             }
 			else
 				needUpdateCirclesOnNextShow = true;
@@ -1430,15 +1430,7 @@ void IdDialog::updateSelection(const QItemSelection& /* new_sel */,const QItemSe
 
 void IdDialog::updateIdListRequest()
 {
-    if(updateIdTimer.isActive())
-    {
-        updateIdTimer.stop();
-        updateIdTimer.start(1000);
-    }
-    else
-    {
-        updateIdTimer.start(1000);
-    }
+    updateIdTimer.start(1000);
 }
 
 void IdDialog::updateIdList()

--- a/retroshare-gui/src/gui/Identity/IdDialog.h
+++ b/retroshare-gui/src/gui/Identity/IdDialog.h
@@ -181,6 +181,7 @@ private:
 	RsEventsHandlerId_t mEventHandlerId_circles;
 
 	QTimer updateIdTimer;
+	QTimer updateCirclesTimer;
 	bool needUpdateIdsOnNextShow;
 	bool needUpdateCirclesOnNextShow;
 

--- a/retroshare-gui/src/gui/Identity/IdentityListModel.cpp
+++ b/retroshare-gui/src/gui/Identity/IdentityListModel.cpp
@@ -928,15 +928,9 @@ int RsIdentityListModel::getCategory(const QModelIndex& i) const
 }
 void RsIdentityListModel::setIdentities(const std::list<RsGroupMetaData>& identities_meta)
 {
+    preMods();
     beginResetModel();
-    
-    // Clear data manually to avoid double-signaling from clear()
-    mIdentities.clear();
-    mCategories.clear();
-    mCategories.resize(3);
-    mCategories[0].category_name = tr("My own identities");
-    mCategories[1].category_name = tr("My contacts");
-    mCategories[2].category_name = tr("All");
+    clear();
 
     for(auto id:identities_meta)
     {
@@ -954,7 +948,14 @@ void RsIdentityListModel::setIdentities(const std::list<RsGroupMetaData>& identi
         mIdentities.push_back(idinfo);
     }
 
+    if (mCategories.size()>0)
+    {
+        beginInsertRows(QModelIndex(),0,mCategories.size()-1);
+        endInsertRows();
+    }
+
     endResetModel();
+    postMods();
 
     mLastInternalDataUpdate = time(NULL);
 

--- a/retroshare-gui/src/gui/Identity/IdentityListModel.h
+++ b/retroshare-gui/src/gui/Identity/IdentityListModel.h
@@ -248,6 +248,7 @@ private:
 
     // List of identities for which getIdDetails() failed, to be requested again.
     mutable QTimer *mIdentityUpdateTimer;
+    mutable QTimer *mThrottlingTimer;
 
 public:
     void handleIdentityEvent(std::shared_ptr<const RsEvent> event);

--- a/retroshare-gui/src/gui/Identity/IdentityListModel.h
+++ b/retroshare-gui/src/gui/Identity/IdentityListModel.h
@@ -41,7 +41,7 @@ class RsIdentityListModel : public QAbstractItemModel
 
 public:
     explicit RsIdentityListModel(QObject *parent = NULL);
-    ~RsIdentityListModel(){}
+    ~RsIdentityListModel();
 
     enum Columns {
 		COLUMN_THREAD_NAME         = 0x00,
@@ -248,6 +248,12 @@ private:
 
     // List of identities for which getIdDetails() failed, to be requested again.
     mutable QTimer *mIdentityUpdateTimer;
+
+public:
+    void handleIdentityEvent(std::shared_ptr<const RsEvent> event);
+
+private:
+   RsEventsHandlerId_t mEventHandlerId = 0;
 };
 
 

--- a/retroshare-gui/src/gui/Identity/IdentityListModel.h
+++ b/retroshare-gui/src/gui/Identity/IdentityListModel.h
@@ -134,6 +134,7 @@ public:
     QModelIndex getIndexOfCategory(Category id) const;
 
     void updateIdentityList();
+    void refreshIdentityDetails(const RsGxsId& id);
 
     int count() const { return mIdentities.size() ; }	// total number of identities
 

--- a/retroshare-gui/src/gui/Posted/PostedDialog.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedDialog.cpp
@@ -51,6 +51,9 @@ PostedDialog::PostedDialog(QWidget *parent):
 	            [this](std::shared_ptr<const RsEvent> event)
 	{ RsQThreadUtils::postToObject( [=]() { handleEvent_main_thread(event); }, this ); },
 	            mEventHandlerId, RsEventType::GXS_POSTED );
+    mUpdateTimer = new QTimer(this);
+    mUpdateTimer->setSingleShot(true);
+    connect(mUpdateTimer, SIGNAL(timeout()), this, SLOT(timerUpdate()));
 }
 
 void PostedDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
@@ -72,10 +75,11 @@ void PostedDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
 		case RsPostedEventCode::NEW_POSTED_GROUP:       // [[fallthrough]];
         case RsPostedEventCode::BOARD_DELETED:       // [[fallthrough]];
         case RsPostedEventCode::SUBSCRIBE_STATUS_CHANGED:   // [[fallthrough]];
-            updateDisplay(true);
+            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
             break;
 
         case RsPostedEventCode::STATISTICS_CHANGED:
+            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
             updateGroupStatistics(e->mPostedGroupId);
             break;
 

--- a/retroshare-gui/src/gui/Posted/PostedDialog.h
+++ b/retroshare-gui/src/gui/Posted/PostedDialog.h
@@ -65,6 +65,11 @@ private:
 
 	void handleEvent_main_thread(std::shared_ptr<const RsEvent> event);
     RsEventsHandlerId_t mEventHandlerId;
+
+    QTimer *mUpdateTimer;
+
+private slots:
+    void timerUpdate() { updateDisplay(true); }
 };
 
 #endif

--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.h
@@ -138,6 +138,9 @@ private:
     GxsIdChooser *ownIdChooser ;
     //icons cache
     QIcon bullet_red_128, bullet_grey_128, bullet_green_128, bullet_yellow_128, bullet_blue_128;
+
+    RsEventsHandlerId_t mEventHandlerId_identity;
+    void handleIdentityEvent(std::shared_ptr<const RsEvent> event);
 };
 
 #endif

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelDialog.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelDialog.cpp
@@ -70,7 +70,6 @@ void GxsChannelDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> ev
         switch(e->mChannelEventCode)
         {
         case RsChannelEventCode::STATISTICS_CHANGED:      // [[fallthrough]];
-            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
             Q_FALLTHROUGH();
 
         case RsChannelEventCode::NEW_MESSAGE:             // [[fallthrough]];
@@ -85,7 +84,7 @@ void GxsChannelDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> ev
         case RsChannelEventCode::NEW_CHANNEL:             // [[fallthrough]];
         case RsChannelEventCode::DELETED_CHANNEL:             // [[fallthrough]];
         case RsChannelEventCode::SUBSCRIBE_STATUS_CHANGED:// reloads group summary (calling GxsGroupFrameDialog parent method)
-            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
+            if(!mUpdateTimer->isActive()) mUpdateTimer->start(1000);
             break;
 
         default:

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelDialog.h
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelDialog.h
@@ -86,6 +86,11 @@ private:
     std::set<TurtleRequestId> mSearchResults;
 
     RsEventsHandlerId_t mEventHandlerId;
+
+    QTimer *mUpdateTimer;
+
+private slots:
+    void timerUpdate() { updateDisplay(true); }
 };
 
 #endif

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
@@ -47,6 +47,9 @@ GxsForumsDialog::GxsForumsDialog(QWidget *parent) :
 	            [this](std::shared_ptr<const RsEvent> event)
 	{ RsQThreadUtils::postToObject( [=]() { handleEvent_main_thread(event); }, this ); },
 	            mEventHandlerId, RsEventType::GXS_FORUMS );
+    mUpdateTimer = new QTimer(this);
+    mUpdateTimer->setSingleShot(true);
+    connect(mUpdateTimer, SIGNAL(timeout()), this, SLOT(timerUpdate()));
 }
 
 void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
@@ -70,11 +73,11 @@ void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> eve
         case RsForumEventCode::UPDATED_FORUM:       // [[fallthrough]];
         case RsForumEventCode::DELETED_FORUM:       // [[fallthrough]];
         case RsForumEventCode::SUBSCRIBE_STATUS_CHANGED:
-            updateDisplay(true);
+            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
             break;
 
         case RsForumEventCode::STATISTICS_CHANGED:
-	    updateDisplay(true);
+            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
             updateGroupStatisticsReal(e->mForumGroupId);
             break;
 

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
@@ -73,11 +73,11 @@ void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> eve
         case RsForumEventCode::UPDATED_FORUM:       // [[fallthrough]];
         case RsForumEventCode::DELETED_FORUM:       // [[fallthrough]];
         case RsForumEventCode::SUBSCRIBE_STATUS_CHANGED:
-            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
+            if(!mUpdateTimer->isActive()) mUpdateTimer->start(1000);
             break;
 
         case RsForumEventCode::STATISTICS_CHANGED:
-            if(!mUpdateTimer->isActive()) mUpdateTimer->start(200);
+            if(!mUpdateTimer->isActive()) mUpdateTimer->start(1000);
             updateGroupStatisticsReal(e->mForumGroupId);
             break;
 

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.h
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.h
@@ -65,6 +65,11 @@ private:
 	void handleEvent_main_thread(std::shared_ptr<const RsEvent> event);
 
     RsEventsHandlerId_t mEventHandlerId;
+
+    QTimer *mUpdateTimer;
+
+private slots:
+    void timerUpdate() { updateDisplay(true); }
 };
 
 #endif


### PR DESCRIPTION
Need libretroshare pr/253

Code and comment by Antigravity

Fix Identity/Chat refresh logic to handle instant avatar updates
This PR updates the GUI to listen for GXS Identity events, fixing a regression where avatars would disappear or fail to update due to cache invalidation in the core.
1. Fix People Tab (IdentityListModel)
- **Issue:** The existing [timerUpdate] logic only refreshed category headers, failing to repaint child Identity items when their data changed (e.g., after a cache miss/reload).
- **Fix:** Added [handleIdentityEvent] to listen for `RsEventType::GXS_IDENTITY`. It triggers a precise `dataChanged` signal for the specific identity row, forcing an immediate repaint.
2. Fix Chat Lobby (ChatLobbyDialog)
- **Issue:** Participant icons in the Chat Lobby were cached and never updated unless the lobby was reloaded.
- **Fix:** Added `handleIdentityEvent` to force an update of the participant's `QTreeWidgetItem` icon when their identity changes.