### PR TITLE
fix zero post counts in Channels/Forums/Boards on Startup

### DIFF
--- a/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.cpp
@@ -541,6 +541,18 @@ void GroupTreeWidget::setUnreadCount(QTreeWidgetItem *item, int unreadCount)
 	item->setFont(GTW_COLUMN_NAME, itFont);
 }
 
+void GroupTreeWidget::setCounts(QTreeWidgetItem *item, int unreadCount, int totalCount)
+{
+	if (item == NULL) {
+		return;
+	}
+
+	setUnreadCount(item, unreadCount);
+
+	item->setText(GTW_COLUMN_POSTS, QString::number(totalCount));
+	item->setData(GTW_COLUMN_POSTS, ROLE_SORT, totalCount);
+}
+
 QTreeWidgetItem *GroupTreeWidget::getItemFromId(const QString &id)
 {
 	if (id.isEmpty()) {

--- a/retroshare-gui/src/gui/common/GroupTreeWidget.h
+++ b/retroshare-gui/src/gui/common/GroupTreeWidget.h
@@ -113,6 +113,7 @@ public:
 	void fillGroupItems(QTreeWidgetItem *categoryItem, const QList<GroupItemInfo> &itemList);
 	// Set the unread count of an item
 	void setUnreadCount(QTreeWidgetItem *item, int unreadCount);
+	void setCounts(QTreeWidgetItem *item, int unreadCount, int totalCount);
 
 	bool isSearchRequestItem(QPoint &point,uint32_t& search_req_id);
 	bool isSearchRequestResult(QPoint &point, QString &group_id, uint32_t& search_req_id);

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
@@ -1159,44 +1159,7 @@ void GxsGroupFrameDialog::updateGroupSummary()
 /*********************** **** **** **** ***********************/
 /*********************** **** **** **** ***********************/
 
-void GxsGroupFrameDialog::updateGroupStatistics(const RsGxsGroupId &groupId)
-{
-    mGroupStatisticsToUpdate.insert(groupId);
-    mShouldUpdateGroupStatistics = true;
-}
 
-void GxsGroupFrameDialog::updateGroupStatisticsReal(const RsGxsGroupId &groupId)
-{
-    RsThread::async([this,groupId]()
-	{
-		GxsGroupStatistic stats;
-
-        if(! getGroupStatistics(groupId, stats))
-		{
-			std::cerr << __PRETTY_FUNCTION__ << " failed to collect group statistics for group " << groupId << std::endl;
-			return;
-		}
-
-		RsQThreadUtils::postToObject( [this,stats, groupId]()
-		{
-			/* Here it goes any code you want to be executed on the Qt Gui
-			 * thread, for example to update the data model with new information
-			 * after a blocking call to RetroShare API complete, note that
-			 * Qt::QueuedConnection is important!
-			 */
-
-            QTreeWidgetItem *item = ui->groupTreeWidget->getItemFromId(QString::fromStdString(stats.mGrpId.toStdString()));
-
-            if (item)
-                ui->groupTreeWidget->setUnreadCount(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread);
-
-            mCachedGroupStats[groupId] = stats;
-
-			getUserNotify()->updateIcon();
-
-        }, this );
-	});
-}
 
 void GxsGroupFrameDialog::getServiceStatistics(GxsServiceStatistic& stats) const
 {
@@ -1282,3 +1245,42 @@ void GxsGroupFrameDialog::distantRequestGroupData()
     checkRequestGroup(group_id) ;
 }
 
+void GxsGroupFrameDialog::updateGroupStatistics(const RsGxsGroupId &groupId)
+{
+    mGroupStatisticsToUpdate.insert(groupId);
+    mShouldUpdateGroupStatistics = true;
+}
+
+void GxsGroupFrameDialog::updateGroupStatisticsReal(const RsGxsGroupId &groupId)
+{
+    RsThread::async([this,groupId]()
+    {
+        GxsGroupStatistic stats;
+
+        if(! getGroupStatistics(groupId, stats))
+        {
+            std::cerr << __PRETTY_FUNCTION__ << " failed to collect group statistics for group " << groupId << std::endl;
+            return;
+        }
+
+        RsQThreadUtils::postToObject( [this,stats, groupId]()
+        {
+            /* Here it goes any code you want to be executed on the Qt Gui
+             * thread, for example to update the data model with new information
+             * after a blocking call to RetroShare API complete, note that
+             * Qt::QueuedConnection is important!
+             */
+
+            QTreeWidgetItem *item = ui->groupTreeWidget->getItemFromId(QString::fromStdString(stats.mGrpId.toStdString()));
+
+            if (item)
+                // ui->groupTreeWidget->setUnreadCount(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread);
+				ui->groupTreeWidget->setCounts(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread, stats.mNumMsgs);
+
+            mCachedGroupStats[groupId] = stats;
+
+            getUserNotify()->updateIcon();
+
+        }, this );
+    });
+}


### PR DESCRIPTION
Code by Antigravity

Fix: Zero Post Counts in Channels/Forums on Startup
## Description
This Pull Request fixes a UI issue where the "Total Posts" counter in Channels and Forums lists would remain at `0` (or show stale data) for a significant time after startup, even though the actual statistics were available.
## The Issue
When RetroShare starts:
1. The GUI loads the list of Channels/Forums using cached metadata ([RsGroupMetaData], where `mVisibleMsgCount` is often outdated or zero.
2. The application then triggers a live statistics update ([getForumStatistics] / [updateGroupStatisticsReal] which retrieves accurate counts.
3. **Problem**: The callback for this update only refreshed the **"Unread"** column, completely ignoring the **"Total"** (Msg Count) column.
4. As a result, the "Total" column would only update much later, when a global event (like `STATISTICS_CHANGED`) forced a full reload of the entire list.
## The Fix
- Added `setCounts()` method to [GroupTreeWidget] to allow updating both "Unread" and "Total" columns simultaneously.
- Updated `GxsGroupFrameDialog::updateGroupStatisticsReal` to use `setCounts()` instead of [setUnreadCount()].
Now, as soon as the accurate statistics are computed (milliseconds after display), the UI immediately reflects the correct total post count without waiting for a full list refresh.