### PR TITLE
Forum content search fts5

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
@@ -484,7 +484,21 @@ uint32_t RsGxsForumModel::recursUpdateFilterStatus(ForumModelIndex i,int column,
 		break;
 	}
 
-	if(!strings.empty())
+	// std::cerr << "DEBUG Content Filter: " << mContentFilteringEnabled << " IDs: " << mContentFilterIds.size() << " Current: " << mPosts[i].mMsgId.toStdString() << " Match: " << (mContentFilterIds.find(mPosts[i].mMsgId) != mContentFilterIds.end()) << std::endl;
+
+	if(mContentFilteringEnabled)
+    {
+        if(mContentFilterIds.find(mPosts[i].mMsgId) != mContentFilterIds.end())
+        {
+            mPosts[i].mPostFlags |= ForumModelPostEntry::FLAG_POST_PASSES_FILTER | ForumModelPostEntry::FLAG_POST_CHILDREN_PASSES_FILTER;
+            count++;
+        }
+        else
+        {
+            mPosts[i].mPostFlags &= ~(ForumModelPostEntry::FLAG_POST_PASSES_FILTER | ForumModelPostEntry::FLAG_POST_CHILDREN_PASSES_FILTER);
+        }
+    }
+	else if(!strings.empty())
 	{
 		mPosts[i].mPostFlags &= ~(ForumModelPostEntry::FLAG_POST_PASSES_FILTER | ForumModelPostEntry::FLAG_POST_CHILDREN_PASSES_FILTER);
 

--- a/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
@@ -43,7 +43,7 @@ std::ostream& operator<<(std::ostream& o, const QModelIndex& i);// defined elsew
 const QString RsGxsForumModel::FilterString("filtered");
 
 RsGxsForumModel::RsGxsForumModel(QObject *parent)
-    : QAbstractItemModel(parent), mUseChildTS(false),mFilteringEnabled(false),mTreeMode(TREE_MODE_TREE)
+    : QAbstractItemModel(parent), mUseChildTS(false),mFilteringEnabled(false),mContentFilteringEnabled(false),mTreeMode(TREE_MODE_TREE)
 {
     initEmptyHierarchy(mPosts);
     mFont = QApplication::font();
@@ -484,11 +484,12 @@ uint32_t RsGxsForumModel::recursUpdateFilterStatus(ForumModelIndex i,int column,
 		break;
 	}
 
-	// std::cerr << "DEBUG Content Filter: " << mContentFilteringEnabled << " IDs: " << mContentFilterIds.size() << " Current: " << mPosts[i].mMsgId.toStdString() << " Match: " << (mContentFilterIds.find(mPosts[i].mMsgId) != mContentFilterIds.end()) << std::endl;
-
 	if(mContentFilteringEnabled)
     {
-        if(mContentFilterIds.find(mPosts[i].mMsgId) != mContentFilterIds.end())
+        bool found = (mContentFilterIds.find(mPosts[i].mMsgId) != mContentFilterIds.end());
+        if (mPosts[i].mMsgId.isNull()) found = false; // dummy root
+        
+        if(found)
         {
             mPosts[i].mPostFlags |= ForumModelPostEntry::FLAG_POST_PASSES_FILTER | ForumModelPostEntry::FLAG_POST_CHILDREN_PASSES_FILTER;
             count++;
@@ -533,6 +534,10 @@ uint32_t RsGxsForumModel::recursUpdateFilterStatus(ForumModelIndex i,int column,
 void RsGxsForumModel::setFilter(int column,const QStringList& strings,uint32_t& count)
 {
     preMods();
+
+    if (column != COLUMN_THREAD_CONTENT) {
+        mContentFilteringEnabled = false;
+    }
 
     if(!strings.empty())
     {
@@ -1117,4 +1122,10 @@ void RsGxsForumModel::setAuthorOpinion(const QModelIndex& indx, RsOpinion op)
 			// notify the widgets that the data has changed.
 			emit dataChanged(createIndex(0,0,(void*)NULL), createIndex(0,COLUMN_THREAD_NB_COLUMNS-1,(void*)NULL));
         }
+}
+void RsGxsForumModel::setContentFilter(const std::set<RsGxsMessageId>& ids, const QStringList& filterStrings, uint32_t& count)
+{
+    mContentFilteringEnabled = true;
+    mContentFilterIds = ids;
+    setFilter(COLUMN_THREAD_CONTENT, filterStrings, count);
 }

--- a/retroshare-gui/src/gui/gxsforums/GxsForumModel.h
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumModel.h
@@ -99,7 +99,9 @@ public:
 	void setBackgroundColorFiltered (QColor color) { mBackgroundColorFiltered = color;}
 
 	void setMsgReadStatus(const QModelIndex &i, bool read_status, bool with_children);
+    // Filter methods
     void setFilter(int column, const QStringList &strings, uint32_t &count) ;
+    void setContentFilter(const std::set<RsGxsMessageId>& ids, const QStringList& filterStrings, uint32_t& count);
 	void setAuthorOpinion(const QModelIndex& indx,RsOpinion op);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -146,6 +148,8 @@ private:
 
     bool mUseChildTS;
     bool mFilteringEnabled;
+    bool mContentFilteringEnabled;
+    std::set<RsGxsMessageId> mContentFilterIds;
     TreeMode mTreeMode;
     SortMode mSortMode;
 

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1865,7 +1865,36 @@ void GxsForumThreadWidget::filterItems(const QString& text)
     int filterColumn = ui->filterLineEdit->currentFilter();
 
     uint32_t count;
-    mThreadModel->setFilter(filterColumn,lst,count) ;
+    if(filterColumn == RsGxsForumModel::COLUMN_THREAD_CONTENT)
+    {
+        std::set<RsGxsMessageId> ids;
+        std::vector<RsGxsSearchResult> results;
+
+        if(!lst.empty()) {
+#ifdef RS_DEEP_FORUMS_INDEX
+            std::cerr << "DEBUG: RS_DEEP_FORUMS_INDEX is DEFINED." << std::endl;
+#else
+            std::cerr << "DEBUG: RS_DEEP_FORUMS_INDEX is NOT DEFINED." << std::endl;
+#endif
+            rsGxsForums->localSearch(text.toStdString(), results);
+
+            std::cerr << "DEBUG Content Search: " << text.toStdString() << " returned " << results.size() << " results." << std::endl;
+
+            for(const auto& res : results) {
+                // std::cerr << "DEBUG Result: GroupId=" << res.mGroupId.toStdString() << " MsgId=" << res.mMsgId.toStdString() << std::endl;
+                if(res.mGroupId == groupId() && !res.mMsgId.isNull()) {
+                    ids.insert(res.mMsgId);
+                }
+            }
+            std::cerr << "DEBUG Content Search: Matched " << ids.size() << " messages in current group." << std::endl;
+
+        }
+        mThreadModel->setContentFilter(ids, lst, count);
+    }
+    else
+    {
+        mThreadModel->setFilter(filterColumn,lst,count) ;
+    }
 
     // We do this in order to trigger a new filtering action in the proxy model.
     QSortFilterProxyModel_setFilterRegularExpression(mThreadProxyModel, QString(RsGxsForumModel::FilterString)) ;

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -47,6 +47,7 @@
 #include "gui/common/UIStateHelper.h"
 #include "util/RsQtVersion.h"
 #include "util/imageutil.h"
+#include "util/rsdebug.h"
 
 #include <retroshare/rsgxsforums.h>
 #include <retroshare/rsgxscircles.h>
@@ -253,6 +254,12 @@ GxsForumThreadWidget::GxsForumThreadWidget(const RsGxsGroupId &forumId, QWidget 
     ui(new Ui::GxsForumThreadWidget)
 {
     ui->setupUi(this);
+    RsDbg() << "DEEPSEARCH: GxsForumThreadWidget created for forumId=" << forumId.toStdString();
+#ifdef RS_DEEP_FORUMS_INDEX
+    RsDbg() << "DEEPSEARCH: RS_DEEP_FORUMS_INDEX IS defined in GxsForumThreadWidget";
+#else
+    RsDbg() << "DEEPSEARCH: RS_DEEP_FORUMS_INDEX IS NOT defined in GxsForumThreadWidget !!!";
+#endif
 
     // Single-shot timer used to coalesce the full-forum reloads requested by
     // incoming GXS events (see scheduleForumReload()). Created first thing:
@@ -264,6 +271,7 @@ GxsForumThreadWidget::GxsForumThreadWidget(const RsGxsGroupId &forumId, QWidget 
     //setUpdateWhenInvisible(true);
 
     //mUpdating = false;
+    mForceSearch = false;
     mUnreadCount = 0;
     mNewCount = 0;
 
@@ -312,6 +320,7 @@ GxsForumThreadWidget::GxsForumThreadWidget(const RsGxsGroupId &forumId, QWidget 
     connect(ui->downloadButton, SIGNAL(clicked()), this, SLOT(downloadAllFiles()));
 
     connect(ui->filterLineEdit, SIGNAL(textChanged(QString)), this, SLOT(filterItems(QString)));
+    connect(ui->filterLineEdit, SIGNAL(returnPressed()), this, SLOT(triggerSearch()));
     connect(ui->filterLineEdit, SIGNAL(filterChanged(int)), this, SLOT(filterColumnChanged(int)));
 
     connect(ui->threadedView_TB, SIGNAL(toggled(bool)), this, SLOT(toggleThreadedView(bool)));
@@ -328,6 +337,9 @@ GxsForumThreadWidget::GxsForumThreadWidget(const RsGxsGroupId &forumId, QWidget 
     ui->filterLineEdit->addFilter(QIcon(), tr("Title"), RsGxsForumModel::COLUMN_THREAD_TITLE, tr("Search Title"));
     ui->filterLineEdit->addFilter(QIcon(), tr("Date"), RsGxsForumModel::COLUMN_THREAD_DATE, tr("Search Date"));
     ui->filterLineEdit->addFilter(QIcon(), tr("Author"), RsGxsForumModel::COLUMN_THREAD_AUTHOR, tr("Search Author"));
+#ifdef RS_DEEP_FORUMS_INDEX
+    ui->filterLineEdit->addFilter(QIcon(), tr("Content"), RsGxsForumModel::COLUMN_THREAD_CONTENT, tr("Search Content"));
+#endif
 
     mLastViewType = -1;
 
@@ -1852,7 +1864,9 @@ void GxsForumThreadWidget::changedViewBox(int view_mode)
 
 void GxsForumThreadWidget::filterColumnChanged(int column)
 {
-    filterItems(ui->filterLineEdit->text());
+    // Search is NEVER auto-triggered on column change.
+    // User must explicitly press 'Enter' or search button.
+    RsDbg() << "DEEPSEARCH: Filter column changed to " << column << ". Waiting for 'Enter'.";
 
     // save index
     Settings->setValueToGroup("ForumThreadWidget", "filterColumn", column);
@@ -1860,40 +1874,48 @@ void GxsForumThreadWidget::filterColumnChanged(int column)
 
 void GxsForumThreadWidget::filterItems(const QString& text)
 {
-    QStringList lst = text.split(" ",QtSkipEmptyParts) ;
+    // ALL searches (Title, Author, Content) now require 'Enter' to avoid UI freeze/flicker
+    if (!text.isEmpty() && !mForceSearch)
+    {
+        // STRICT BLOCK: No logs, no processing during typing for ALL columns.
+        return;
+    }
 
     int filterColumn = ui->filterLineEdit->currentFilter();
+    RsDbg() << "DEEPSEARCH: executing filterItems('" << text.toStdString() << "') column=" << filterColumn << " force=" << (mForceSearch?"YES":"NO");
+    QStringList lst = text.split(" ",QtSkipEmptyParts) ;
 
     uint32_t count;
-    if(filterColumn == RsGxsForumModel::COLUMN_THREAD_CONTENT)
+    if(filterColumn == RsGxsForumModel::COLUMN_THREAD_CONTENT && !lst.empty())
     {
+        RsDbg() << "DEEPSEARCH: executing Content Search for '" << text.toStdString() << "'";
+        // Clear current selection to avoid "lag" when clicking results
+        mThreadId = RsGxsMessageId();
+        blankPost();
+        insertMessage(); // Will display forum description if mThreadId is null
+
         std::set<RsGxsMessageId> ids;
         std::vector<RsGxsSearchResult> results;
 
-        if(!lst.empty()) {
 #ifdef RS_DEEP_FORUMS_INDEX
-            std::cerr << "DEBUG: RS_DEEP_FORUMS_INDEX is DEFINED." << std::endl;
-#else
-            std::cerr << "DEBUG: RS_DEEP_FORUMS_INDEX is NOT DEFINED." << std::endl;
-#endif
-            rsGxsForums->localSearch(text.toStdString(), results);
+        rsGxsForums->localSearch(text.toStdString(), results);
 
-            std::cerr << "DEBUG Content Search: " << text.toStdString() << " returned " << results.size() << " results." << std::endl;
+        RsDbg() << "DEEPSEARCH: Content Search returned " << results.size() << " results.";
 
-            for(const auto& res : results) {
-                // std::cerr << "DEBUG Result: GroupId=" << res.mGroupId.toStdString() << " MsgId=" << res.mMsgId.toStdString() << std::endl;
-                if(res.mGroupId == groupId() && !res.mMsgId.isNull()) {
-                    ids.insert(res.mMsgId);
-                }
+        for(const auto& res : results) {
+            if(res.mGroupId == groupId() && !res.mMsgId.isNull()) {
+                ids.insert(res.mMsgId);
             }
-            std::cerr << "DEBUG Content Search: Matched " << ids.size() << " messages in current group." << std::endl;
-
         }
+        RsDbg() << "DEEPSEARCH: Content Search matched " << ids.size() << " messages in current group (" << groupId().toStdString() << ")";
+#endif
         mThreadModel->setContentFilter(ids, lst, count);
     }
     else
     {
-        mThreadModel->setFilter(filterColumn,lst,count) ;
+        RsDbg() << "DEEPSEARCH: executing Regular Search/Clear in column " << filterColumn;
+        // Regular search or cleared search: use standard setFilter which disables content mode
+        mThreadModel->setFilter(filterColumn, lst, count);
     }
 
     // We do this in order to trigger a new filtering action in the proxy model.
@@ -1941,7 +1963,7 @@ void GxsForumThreadWidget::filterItems(const QString& text)
         }
     }
 
-    if(count > 0)
+    if(count == 0 && !text.isEmpty())
         ui->filterLineEdit->setToolTip(tr("No result.")) ;
     else
         ui->filterLineEdit->setToolTip(tr("Found %1 results.").arg(count)) ;
@@ -2183,4 +2205,13 @@ void GxsForumThreadWidget::showAuthorInPeople(const RsGxsForumMsg& msg)
 
     MainWindow::showWindow(MainWindow::People);
     idDialog->navigate(RsGxsId(msg.mMeta.mAuthorId));
+}
+
+void GxsForumThreadWidget::triggerSearch()
+{
+    RsDbg() << "DEEPSEARCH: triggerSearch() called. Text='" << ui->filterLineEdit->text().toStdString() << "'";
+    mForceSearch = true;
+    filterItems(ui->filterLineEdit->text());
+    mForceSearch = false;
+    RsDbg() << "DEEPSEARCH: triggerSearch() finished.";
 }

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.h
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.h
@@ -161,6 +161,7 @@ private slots:
 
 	void filterColumnChanged(int column);
 	void filterItems(const QString &text);
+	void triggerSearch();
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
 	void expandSubtree();
@@ -223,6 +224,7 @@ private:
 	unsigned int mUnreadCount;
 	unsigned int mNewCount;
 	bool mDisplayBannedText;
+	bool mForceSearch;
 
 	/* Color definitions (for standard see default.qss) */
 	QColor mTextColorRead;

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
@@ -18,6 +18,9 @@
  *                                                                             *
  *******************************************************************************/
 
+#include <QToolButton>
+#include <QMessageBox>
+#include "ui_GxsGroupFrameDialog.h"
 #include "GxsForumsDialog.h"
 #include "GxsForumGroupDialog.h"
 #include "GxsForumThreadWidget.h"

--- a/retroshare-gui/src/gui/settings/ForumPage.h
+++ b/retroshare-gui/src/gui/settings/ForumPage.h
@@ -48,6 +48,8 @@ protected slots:
 
 private slots:
 	void updateFonts();
+    
+    void reindexAll();
 
 private:
 	Ui::ForumPage ui;

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -36,6 +36,7 @@ no_retroshare_gui:CONFIG -= retroshare_gui
 #CONFIG *= gxsthewire
 
 # Enable GXS distant syncronization
+CONFIG += rs_deep_forums_index
 CONFIG *= gxsdistsync
 
 # To enable cmark append the following


### PR DESCRIPTION
This pr needs libretroshare pr/257 

Code and comment by AI

# Forum Deep Search (FTS5 Integration) - UI Implementation
This PR implements the graphical interface and user-facing logic for the **Forum Content Search** feature. It relies on the corresponding backend changes in `libretroshare`.
### Key Changes
*   **Deep Search Interface**:
    *   Added **"Content"** as a searchable column in the forum search bar.
    *   Integrated FTS5 search results into the `GxsForumModel` hierarchy.
*   **Index Management**:
    *   New settings in the **Forums** preference page to manually **Rebuild Search Index**.
    *   Added status reporting for the indexing process.
*   **Performance Optimization**:
    *   Implemented "Enter-only" trigger for content search to prevent UI locking during deep queries.
    *   Improved result navigation in `GxsForumThreadWidget`.
*   **Build System**: Updated `retroshare.pri` and project files to enable the `rs_deep_forums_index` config by default.
### Verification
1.  Open the Forums tab and select the **Content** filter.
2.  Perform keyword searches and verify that posts are correctly filtered and highlighted in the tree.
3.  Go to **Settings -> Forums** and use the **Rebuild Search Index** button to verify manual index repopulation.