### PR TITLE
Turtle Router Statistics: improve sorting, data formatting, and memory usage

### DIFF
--- a/retroshare-gui/src/gui/statistics/TurtleRouterDialog.cpp
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterDialog.cpp
@@ -356,7 +356,7 @@ void TurtleRouterDialog::updateTunnelRequests(	const std::vector<std::vector<std
 	}
 	top_level_s_requests->setText(0, tr("Search requests") + " (" + QString::number(search_reqs_info.size()) + ")" ) ;
 
-	uint32_t limit = std::min((uint32_t)tunnel_reqs_info.size(), (uint32_t)100);
+	uint32_t limit = std::min((uint32_t)tunnel_reqs_info.size(), (uint32_t)50);
 
 	for(uint i=0;i<limit;++i)
 	{
@@ -371,7 +371,10 @@ void TurtleRouterDialog::updateTunnelRequests(	const std::vector<std::vector<std
 		tunnelr_item->setData(COL_REQ_TIME,  Qt::UserRole,    tunnel_reqs_info[i].age);
 	}
 
-	top_level_t_requests->setText(0, tr("Tunnel requests") + " ("+QString::number(tunnel_reqs_info.size()) + ")") ;
+	if (tunnel_reqs_info.size() > 50)
+		top_level_t_requests->setText(0, tr("Tunnel requests") + " (" + tr("last 50 received TRs out of %1").arg(tunnel_reqs_info.size()) + ")");
+	else
+		top_level_t_requests->setText(0, tr("Tunnel requests") + " (" + QString::number(tunnel_reqs_info.size()) + ")");
 
 	QTreeWidgetItem *unknown_hashs_item = findParentHashItem(RsFileHash().toStdString()) ;
 	unknown_hashs_item->setText(0,tr("Unknown hashes") + " (" + QString::number(unknown_hashs_item->childCount())+QString(")")) ;

--- a/retroshare-gui/src/gui/statistics/TurtleRouterDialog.cpp
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterDialog.cpp
@@ -19,6 +19,7 @@
  *******************************************************************************/
 
 #include <QObject>
+#include <QHideEvent>
 #include <util/rsprint.h>
 #include <retroshare/rsturtle.h>
 #include <retroshare/rspeers.h>
@@ -35,15 +36,16 @@
 #include "util/RsQtVersion.h"
 #include "gui/settings/rsharesettings.h"
 
-#define COL_ID                  0
-#define COL_FROM                1
-#define COL_TIME                2
-#define COL_STRING              3
+#define COL_REQ_ID              0
+#define COL_REQ_FROM            1
+#define COL_REQ_TIME            2
+#define COL_REQ_STRING          3
 
-#define COL_TUNNELID            0
-#define COL_SPEED               1
-#define COL_LASTTRANSFER        2
-#define COL_TO                  3
+#define COL_TUN_ID              0
+#define COL_TUN_SPEED           1
+#define COL_TUN_LASTTRANSFER    2
+#define COL_TUN_FROM            3
+#define COL_TUN_TO              4
 
 static const uint MAX_TUNNEL_REQUESTS_DISPLAY = 10 ;
 
@@ -70,8 +72,6 @@ void FTTunnelsListDelegate::paint(QPainter * painter, const QStyleOptionViewItem
 	QStyleOptionViewItem opt = option;
 
 	QString temp ;
-	float flValue;
-	qint64 qi64Value;
 
 	// prepare
 	painter->save();
@@ -103,38 +103,13 @@ void FTTunnelsListDelegate::paint(QPainter * painter, const QStyleOptionViewItem
 	}
 
 	switch(index.column()) {
-	/*case COLUMN_SERVICE :
-		//temp = QString::asprintf("%.3f ", index.data().toFloat());
-		//temp=QString::number(index.data().toFloat());
-		painter->drawText(option.rect, Qt::AlignLeft, index.data().toString());
-		break;
+	/*
+	case COLUMN_SERVICE :
 	case COLUMN_GROUPID:
-		//temp = QString::asprintf("%.3f ", index.data().toFloat());
-		//temp=QString::number(index.data().toFloat());
-		painter->drawText(option.rect, Qt::AlignLeft, index.data().toString());
-		break;
 	case COLUMN_POLICY:
-		//temp=QString::number(index.data().toInt());
-		painter->drawText(option.rect, Qt::AlignLeft, index.data().toString());
-		break;
 	case COLUMN_STATUS:
-		/*flValue = index.data().toFloat();
-		if (flValue < std::numeric_limits<float>::max()){
-			temp = QString::asprintf("%.3f ", flValue);
-		} else {
-			temp=strNA;
-		}*/
-		/*painter->drawText(option.rect, Qt::AlignHCenter, index.data().toString());
-		break;
 	case COLUMN_LASTCONTACT:
-		/*qi64Value = index.data().value<qint64>();
-		if (qi64Value < std::numeric_limits<qint64>::max()){
-			temp= QString::number(qi64Value);
-		} else {
-			temp = strNA;
-		}*/
-		/*painter->drawText(option.rect, Qt::AlignHCenter, index.data().toString());
-		break;*/
+	*/
 	default:
 		painter->drawText(option.rect, Qt::AlignLeft, index.data().toString());
 	}
@@ -172,12 +147,12 @@ TurtleRouterDialog::TurtleRouterDialog(QWidget *parent)
 
 	stl.clear() ;
 	stl.push_back(tr("Search requests")) ;
-	top_level_s_requests = new QTreeWidgetItem(_f2f_TW,stl) ;
+	top_level_s_requests = new TurtleTreeWidgetItem(_f2f_TW,stl) ;
 	_f2f_TW->insertTopLevelItem(n++,top_level_s_requests) ;
 
 	stl.clear() ;
 	stl.push_back(tr("Tunnel requests")) ;
-	top_level_t_requests = new QTreeWidgetItem(_f2f_TW,stl) ;
+	top_level_t_requests = new TurtleTreeWidgetItem(_f2f_TW,stl) ;
 	_f2f_TW->insertTopLevelItem(n++,top_level_t_requests) ;
 
 	top_level_hashes.clear() ;
@@ -186,9 +161,9 @@ TurtleRouterDialog::TurtleRouterDialog(QWidget *parent)
 	float fact = FS/14.0 ;
 
 	QHeaderView * _header = _f2f_TW->header () ;
-	_header->resizeSection ( COL_ID, 170*fact );
+	_header->resizeSection ( COL_REQ_ID, 170*fact );
 	QHeaderView * _header2 = tunnels_treeWidget->header () ;
-	_header2->resizeSection ( COL_TUNNELID, 270*fact );
+	_header2->resizeSection ( COL_TUN_ID, 270*fact );
 
 	// load settings
     processSettings(true);
@@ -225,7 +200,27 @@ void TurtleRouterDialog::processSettings(bool bLoad)
 
 }
 
-bool sr_Compare( TurtleSearchRequestDisplayInfo m1,  TurtleSearchRequestDisplayInfo m2)  { return m1.age < m2.age; }
+void TurtleRouterDialog::hideEvent(QHideEvent *event)
+{
+	// Clear tree widgets to save memory (Cyril's recommendation)
+
+	// Clear Requests tree children
+	for(int i=0; i<_f2f_TW->topLevelItemCount(); ++i)
+	{
+		QTreeWidgetItem *item = _f2f_TW->topLevelItem(i);
+		while(item->childCount() > 0)
+			delete item->takeChild(0);
+	}
+
+	// Clear Tunnels tree (everything)
+	tunnels_treeWidget->clear();
+	top_level_hashes.clear();
+
+	QWidget::hideEvent(event);
+}
+
+bool sr_Compare(const TurtleSearchRequestDisplayInfo& m1, const TurtleSearchRequestDisplayInfo& m2) { return m1.age < m2.age; }
+bool tr_Compare(const TurtleTunnelRequestDisplayInfo& m1, const TurtleTunnelRequestDisplayInfo& m2) { return m1.age < m2.age; }
 
 void TurtleRouterDialog::updateDisplay()
 {
@@ -237,6 +232,7 @@ void TurtleRouterDialog::updateDisplay()
 	rsTurtle->getInfo(hashes_info,tunnels_info,search_reqs_info,tunnel_reqs_info) ;
 	
 	std::sort(search_reqs_info.begin(),search_reqs_info.end(),sr_Compare) ;
+	std::sort(tunnel_reqs_info.begin(),tunnel_reqs_info.end(),tr_Compare) ;
 	
 	updateTunnelRequests(hashes_info,tunnels_info,search_reqs_info,tunnel_reqs_info) ;
 
@@ -309,18 +305,25 @@ void TurtleRouterDialog::updateTunnelRequests(	const std::vector<std::vector<std
 		int k=0 ;
 		while(num >= 800.0f && k<4)
 			num /= 1024.0f,++k;
-		sprintf(tmp,"%3.2f %s",num,units[k].c_str()) ;
 
-		QTreeWidgetItem *tunnel_item = NULL;
-		tunnel_item = new QTreeWidgetItem();
+		if (k == 0)
+			sprintf(tmp,"%d %s", (int)num, units[k].c_str());
+		else
+			sprintf(tmp,"%3.2f %s",num,units[k].c_str()) ;
 
-		tunnel_item->setData(COL_TUNNELID,       Qt::DisplayRole, QString::fromUtf8(tunnels_info[i][0].c_str()));
-		tunnel_item->setData(COL_SPEED,          Qt::DisplayRole, QString::fromStdString(tmp)) ;
-		tunnel_item->setData(COL_LASTTRANSFER,   Qt::DisplayRole, QString::fromStdString(tunnels_info[i][4]));
-		tunnel_item->setData(COL_TO,             Qt::DisplayRole, QString::fromUtf8(tunnels_info[i][2].c_str()) + " -> " + QString::fromUtf8(tunnels_info[i][1].c_str()));
+		TurtleTreeWidgetItem *tunnel_item = NULL;
+		tunnel_item = new TurtleTreeWidgetItem();
 
-		tunnel_item->setTextAlignment(COL_SPEED, Qt::AlignRight);
-		tunnel_item->setTextAlignment(COL_LASTTRANSFER, Qt::AlignCenter);
+		tunnel_item->setData(COL_TUN_ID,           Qt::DisplayRole, QString::fromUtf8(tunnels_info[i][0].c_str()));
+		tunnel_item->setData(COL_TUN_SPEED,        Qt::DisplayRole, QString::fromStdString(tmp)) ;
+		tunnel_item->setData(COL_TUN_SPEED,        Qt::UserRole,    strtof(tunnels_info[i][5].c_str(), NULL));
+		tunnel_item->setData(COL_TUN_LASTTRANSFER, Qt::DisplayRole, QString::fromStdString(tunnels_info[i][4]));
+		tunnel_item->setData(COL_TUN_LASTTRANSFER, Qt::UserRole,    (qlonglong)strtol(tunnels_info[i][4].c_str(), NULL, 0));
+		tunnel_item->setData(COL_TUN_FROM,         Qt::DisplayRole, QString::fromUtf8(tunnels_info[i][2].c_str()));
+		tunnel_item->setData(COL_TUN_TO,           Qt::DisplayRole, QString::fromUtf8(tunnels_info[i][1].c_str()));
+
+		tunnel_item->setTextAlignment(COL_TUN_SPEED, Qt::AlignRight);
+		tunnel_item->setTextAlignment(COL_TUN_LASTTRANSFER, Qt::AlignCenter);
 
 		parent->addChild(tunnel_item) ;
 
@@ -340,37 +343,33 @@ void TurtleRouterDialog::updateTunnelRequests(	const std::vector<std::vector<std
 	for(uint i=0;i<search_reqs_info.size();++i)
 	{
 
-		QTreeWidgetItem *sr_item = NULL;
-		sr_item = new QTreeWidgetItem();
+		TurtleTreeWidgetItem *sr_item = NULL;
+		sr_item = new TurtleTreeWidgetItem();
 		top_level_s_requests->addChild(sr_item) ;
 
-		sr_item->setData(COL_ID,      Qt::DisplayRole, QString::number(search_reqs_info[i].request_id));
-		sr_item->setData(COL_FROM,    Qt::DisplayRole, getPeerName(search_reqs_info[i].source_peer_id) ) ;
-		sr_item->setData(COL_TIME,    Qt::DisplayRole, QString::number(search_reqs_info[i].age) + " secs ago");
-		sr_item->setData(COL_STRING,  Qt::DisplayRole, QString::fromUtf8(search_reqs_info[i].keywords.c_str()) + QString::number(search_reqs_info[i].keywords.length()) + " (" + QString::number(search_reqs_info[i].hits) + " hits)");
+		sr_item->setData(COL_REQ_ID,      Qt::DisplayRole, QString::number(search_reqs_info[i].request_id, 16).rightJustified(8, '0'));
+		sr_item->setData(COL_REQ_FROM,    Qt::DisplayRole, getPeerName(search_reqs_info[i].source_peer_id) ) ;
+		sr_item->setData(COL_REQ_TIME,    Qt::DisplayRole, QString::number(search_reqs_info[i].age) + " secs ago");
+		sr_item->setData(COL_REQ_TIME,    Qt::UserRole,    search_reqs_info[i].age);
+		sr_item->setData(COL_REQ_STRING,  Qt::DisplayRole, QString::fromUtf8(search_reqs_info[i].keywords.c_str()) + " " + QString::number(search_reqs_info[i].keywords.length()) + " (" + QString::number(search_reqs_info[i].hits) + " hits)");
 
 	}
 	top_level_s_requests->setText(0, tr("Search requests") + " (" + QString::number(search_reqs_info.size()) + ")" ) ;
 
-	for(uint i=0;i<tunnel_reqs_info.size();++i)
-		if(i+MAX_TUNNEL_REQUESTS_DISPLAY >= tunnel_reqs_info.size() || i < MAX_TUNNEL_REQUESTS_DISPLAY)
-		{
-			/* find the entry */
-			QTreeWidgetItem *tunnelr_item = NULL;
-			tunnelr_item = new QTreeWidgetItem();
-			top_level_t_requests->addChild(tunnelr_item) ;
+	uint32_t limit = std::min((uint32_t)tunnel_reqs_info.size(), (uint32_t)100);
 
-			tunnelr_item->setData(COL_ID,    Qt::DisplayRole, QString::number(tunnel_reqs_info[i].request_id));
-			tunnelr_item->setData(COL_FROM,  Qt::DisplayRole, getPeerName(tunnel_reqs_info[i].source_peer_id) ) ;
-			tunnelr_item->setData(COL_TIME,  Qt::DisplayRole, QString::number(tunnel_reqs_info[i].age) + " secs ago");
-		}
-		else if(i == MAX_TUNNEL_REQUESTS_DISPLAY)
-		{
-			stl.clear() ;
-			stl.push_back(QString("...")) ;
-			top_level_t_requests->addChild(new QTreeWidgetItem(stl)) ;
+	for(uint i=0;i<limit;++i)
+	{
+		/* find the entry */
+		TurtleTreeWidgetItem *tunnelr_item = NULL;
+		tunnelr_item = new TurtleTreeWidgetItem();
+		top_level_t_requests->addChild(tunnelr_item) ;
 
-		} 
+		tunnelr_item->setData(COL_REQ_ID,    Qt::DisplayRole, QString::number(tunnel_reqs_info[i].request_id, 16).rightJustified(8, '0'));
+		tunnelr_item->setData(COL_REQ_FROM,  Qt::DisplayRole, getPeerName(tunnel_reqs_info[i].source_peer_id) ) ;
+		tunnelr_item->setData(COL_REQ_TIME,  Qt::DisplayRole, QString::number(tunnel_reqs_info[i].age) + " secs ago");
+		tunnelr_item->setData(COL_REQ_TIME,  Qt::UserRole,    tunnel_reqs_info[i].age);
+	}
 
 	top_level_t_requests->setText(0, tr("Tunnel requests") + " ("+QString::number(tunnel_reqs_info.size()) + ")") ;
 
@@ -411,7 +410,7 @@ QTreeWidgetItem *TurtleRouterDialog::findParentHashItem(const std::string& hash)
 	{	
 		QStringList stl ;
 		stl.push_back((hash==null_hash)?tr("Unknown hashes"):QString::fromStdString(hash)) ;
-		QTreeWidgetItem *item = new QTreeWidgetItem(tunnels_treeWidget,stl) ;
+		QTreeWidgetItem *item = new TurtleTreeWidgetItem(tunnels_treeWidget,stl) ;
 		tunnels_treeWidget->insertTopLevelItem(0,item) ;
 
 		return item ;

--- a/retroshare-gui/src/gui/statistics/TurtleRouterDialog.cpp
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterDialog.cpp
@@ -203,16 +203,7 @@ void TurtleRouterDialog::processSettings(bool bLoad)
 void TurtleRouterDialog::hideEvent(QHideEvent *event)
 {
 	// Clear tree widgets to save memory (Cyril's recommendation)
-
-	// Clear Requests tree children
-	for(int i=0; i<_f2f_TW->topLevelItemCount(); ++i)
-	{
-		QTreeWidgetItem *item = _f2f_TW->topLevelItem(i);
-		while(item->childCount() > 0)
-			delete item->takeChild(0);
-	}
-
-	// Clear Tunnels tree (everything)
+	_f2f_TW->clear();
 	tunnels_treeWidget->clear();
 	top_level_hashes.clear();
 

--- a/retroshare-gui/src/gui/statistics/TurtleRouterDialog.h
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterDialog.h
@@ -25,12 +25,61 @@
 
 #include <retroshare-gui/RsAutoUpdatePage.h>
 
+#include <QTreeWidgetItem>
 #include "ui_TurtleRouterDialog.h"
 #include "ui_TurtleRouterStatistics.h"
 
 class QModelIndex;
 class QPainter;
 class FTTunnelsListDelegate ;
+
+class TurtleTreeWidgetItem : public QTreeWidgetItem
+{
+public:
+	using QTreeWidgetItem::QTreeWidgetItem;
+
+	bool operator<(const QTreeWidgetItem &other) const override
+	{
+		int column = treeWidget()->sortColumn();
+
+		if (treeWidget()->indexOfTopLevelItem(const_cast<TurtleTreeWidgetItem*>(this)) != -1)
+		{
+			// Top level items are always sorted by text (or just stay where they are if they are headers)
+			return QTreeWidgetItem::operator<(other);
+		}
+
+		// Check for numeric sorting in UserRole
+		QVariant v1 = data(column, Qt::UserRole);
+		QVariant v2 = other.data(column, Qt::UserRole);
+
+		if (v1.isValid() && v2.isValid())
+		{
+			return v1.toDouble() < v2.toDouble();
+		}
+
+		// Specialized sorting for the "String" column in Requests tab
+		// We want complex expressions to be last.
+		if (column == 3 && treeWidget()->objectName() == "_f2f_TW")
+		{
+			QString s1 = text(column);
+			QString s2 = other.text(column);
+
+			auto isComplex = [](const QString& s) {
+				return s.startsWith("(") || s.startsWith("NAME") || s.startsWith("SIZE") || 
+				       s.startsWith("DATE") || s.startsWith("EXTENSION") || s.startsWith("PATH") || 
+				       s.startsWith("HASH") || s.startsWith("POPULARITY") || s.startsWith("Generic search");
+			};
+
+			bool complex1 = isComplex(s1);
+			bool complex2 = isComplex(s2);
+
+			if (complex1 && !complex2) return false;
+			if (!complex1 && complex2) return true;
+		}
+
+		return QTreeWidgetItem::operator<(other);
+	}
+};
 
 class TurtleRouterDialog: public RsAutoUpdatePage, public Ui::TurtleRouterDialogForm
 {
@@ -61,6 +110,7 @@ class TurtleRouterDialog: public RsAutoUpdatePage, public Ui::TurtleRouterDialog
 		QTreeWidgetItem *top_level_t_requests ;
 
 protected:
+	void hideEvent(QHideEvent *event) override;
 	FTTunnelsListDelegate *FTTDelegate;
 
 } ;

--- a/retroshare-gui/src/gui/statistics/TurtleRouterDialog.h
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterDialog.h
@@ -40,9 +40,12 @@ public:
 
 	bool operator<(const QTreeWidgetItem &other) const override
 	{
-		int column = treeWidget()->sortColumn();
+		QTreeWidget *tw = treeWidget();
+		if (!tw) return false;
 
-		if (treeWidget()->indexOfTopLevelItem(const_cast<TurtleTreeWidgetItem*>(this)) != -1)
+		int column = tw->sortColumn();
+
+		if (!parent())
 		{
 			// Top level items are always sorted by text (or just stay where they are if they are headers)
 			return QTreeWidgetItem::operator<(other);
@@ -59,7 +62,7 @@ public:
 
 		// Specialized sorting for the "String" column in Requests tab
 		// We want complex expressions to be last.
-		if (column == 3 && treeWidget()->objectName() == "_f2f_TW")
+		if (column == 3 && tw->objectName() == "_f2f_TW")
 		{
 			QString s1 = text(column);
 			QString s2 = other.text(column);

--- a/retroshare-gui/src/gui/statistics/TurtleRouterDialog.ui
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterDialog.ui
@@ -107,6 +107,11 @@
          </column>
          <column>
           <property name="text">
+           <string>From</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
            <string>To</string>
           </property>
          </column>


### PR DESCRIPTION
### Memory Usage Optimization
* **Dynamic UI Cleanup**: Overloaded [hideEvent()] to clear all `QTreeWidget` items when the dialog is hidden. This prevents keeping thousands of inactive `QTreeWidgetItem` objects in RAM when the statistics are not being actively viewed.
* **Display Limiting**: Restricted the **Tunnel Requests** list to the 100 most recent entries. This provides a sufficient window for sorting and analysis while preventing excessive memory consumption and UI sluggishness on highly active routing nodes.
* **Resource Management**: Implemented [TurtleTreeWidgetItem] to handle numeric and complex string sorting efficiently without redundant data duplication.