### PR TITLE
retroshare-gui: fix identity edit password prompt issues on macOS

### DIFF
--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -28,6 +28,7 @@
 #include <QString>
 #include <QUrl>
 #include <QtDebug>
+#include <QApplication>
 #include <QMenuBar>
 #include <QActionGroup>
 
@@ -1823,8 +1824,18 @@ void MainWindow::setCompactStatusMode(bool compact)
 
 Gui_InputDialogReturn MainWindow::guiInputDialog(const QString& windowTitle, const QString& labelText, QLineEdit::EchoMode textEchoMode, bool modal)
 {
+	QWidget *activeModal = qApp->activeModalWidget();
+	if (!activeModal) {
+		activeModal = qApp->focusWidget();
+	}
+	if (!activeModal) {
+		activeModal = qApp->activeWindow();
+	}
+	if (!activeModal) {
+		activeModal = this;
+	}
 
-	QInputDialog dialog(this);
+	QInputDialog dialog(activeModal);
 	dialog.setWindowTitle(windowTitle);
 	dialog.setLabelText(labelText);
 	dialog.setTextEchoMode(textEchoMode);

--- a/retroshare-gui/src/gui/MainWindow.h
+++ b/retroshare-gui/src/gui/MainWindow.h
@@ -82,7 +82,7 @@ class ApplicationWindow;
 
 struct Gui_InputDialogReturn
 {
-	int execReturn;
+	int execReturn = 0;
 	QString textValue;
 };
 Q_DECLARE_METATYPE(Gui_InputDialogReturn);


### PR DESCRIPTION
### Symptoms & Root Cause: Password Rejection on macOS

#### Symptoms
When performing operations that require PGP authentication on macOS (such as editing an identity, changing an avatar, or updating sensitive settings):
1.  A password prompt appears as expected.
2.  However, even when the user enters the **correct password**, the system consistently rejects it with an "Authentication Failed" or "Incorrect Password" message.
3.  The operation cannot be completed, effectively locking the user out of identity management features.

#### Root Cause (UI Level)
The issue was caused by a memory safety bug (dangling pointer) in the password retrieval logic of the GUI:
*   The code was capturing the password using `ret.textValue.toUtf8().constData()`.
*   `.toUtf8()` creates a temporary `QByteArray`. Calling `.constData()` on it returns a pointer to its internal buffer.
*   Critically, this temporary `QByteArray` is destroyed at the end of the statement, leaving the pointer dangling.
*   By the time the pointer was passed to the core's [cachePgpPassphrase()] function, it pointed to corrupted or "garbage" memory, causing the core to receive a distorted password.

#### Solution
The fix replaces the temporary pointer with a persistent `std::string` using `ret.textValue.toStdString()`, ensuring the password remains valid and intact when passed to the authentication service.

### Summary of Changes
- **Memory Safety**: Fixed dangling pointer in [RsGUIEventManager] when capturing password.
- **macOS Integration**: Improved parent selection for the input dialog to work correctly with macOS sheets (using active modal widget or focus widget).
- **Optimization**: Optimized [GUI_askForPassword] to use direct calls when already on the GUI thread, avoiding unnecessary blocking queued connections.
- **Robustness**: Ensured `execReturn` is initialized to avoid garbage values.
- **Reliability**: Explicitly cleared the password cache before prompting to ensure the dialog appears when required.