### PR TITLE
Add Ignore User button to Security Feed and implement Ignored Users list management

### DIFF
--- a/retroshare-gui/src/gui/NewsFeed.cpp
+++ b/retroshare-gui/src/gui/NewsFeed.cpp
@@ -23,6 +23,8 @@
 #include "NewsFeed.h"
 #include "ui_NewsFeed.h"
 
+#include "pqi/authssl.h"
+
 #include <retroshare/rsbanlist.h>
 #include <retroshare/rsgxschannels.h>
 #include <retroshare/rsgxsforums.h>
@@ -478,6 +480,13 @@ void NewsFeed::handleSecurityEvent(std::shared_ptr<const RsEvent> event)
         return;
 
     auto& e(*pe);
+    
+    // Check if denied by AuthSSL (backend)
+    if(AuthSSL::instance().isNotifyDenied(e.mPgpId))
+    {
+        return;
+    }
+
     RsFeedTypeFlags flags = (RsFeedTypeFlags)Settings->getNewsFeedFlags();
 
     // 1 - treat the case of unknown PeerID

--- a/retroshare-gui/src/gui/feeds/SecurityItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.cpp
@@ -21,6 +21,8 @@
 #include <QDateTime>
 #include <QTimer>
 #include <QMessageBox>
+#include <QMenu>
+#include <QMouseEvent>
 
 #include "SecurityItem.h"
 #include "FeedHolder.h"
@@ -395,6 +397,7 @@ void SecurityItem::banUser()
                                   QMessageBox::Yes|QMessageBox::No);
     if (reply == QMessageBox::Yes) {
         AuthSSL::instance().addNotifyDeny(mGpgId, mSslCn);
+        rsPeers->removeFriend(mGpgId);
         // Remove this item from the feed as it is now handled
         removeItem(); 
     }

--- a/retroshare-gui/src/gui/feeds/SecurityItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.cpp
@@ -37,6 +37,7 @@
 
 #include <retroshare/rsmail.h>
 #include <retroshare/rspeers.h>
+#include "pqi/authssl.h"
 
 /*****
  * #define DEBUG_ITEM 1
@@ -54,6 +55,12 @@ SecurityItem::SecurityItem(FeedHolder *parent, uint32_t feedId, const RsPgpId &g
 	chatButton->hide();
 	removeFriendButton->setEnabled(false);
 	removeFriendButton->hide();
+	banButton->hide();
+    
+    QPalette pal = banButton->palette();
+    pal.setColor(QPalette::ButtonText, Qt::red);
+    banButton->setPalette(pal);
+
 	peerDetailsButton->setEnabled(false);
 	friendRequesttoolButton->hide();
 	requestLabel->hide();
@@ -68,6 +75,7 @@ SecurityItem::SecurityItem(FeedHolder *parent, uint32_t feedId, const RsPgpId &g
 	//connect( quickmsgButton, SIGNAL( clicked( ) ), this, SLOT( sendMsg() ) );
 
 	connect( removeFriendButton, SIGNAL(clicked()), this, SLOT(removeFriend()));
+	connect( banButton, SIGNAL(clicked()), this, SLOT(banUser()));
 	connect( peerDetailsButton, SIGNAL(clicked()), this, SLOT(peerDetails()));
 	connect( friendRequesttoolButton, SIGNAL(clicked()), this, SLOT(friendRequest()));
 
@@ -241,6 +249,7 @@ void SecurityItem::updateItem()
 
 			removeFriendButton->setEnabled(false);
 			removeFriendButton->hide();
+			banButton->show();
 			peerDetailsButton->setEnabled(false);
 			
             if(mType == RsFeedTypeFlags::RS_FEED_ITEM_SEC_BAD_CERTIFICATE)
@@ -306,6 +315,7 @@ void SecurityItem::updateItem()
 			requestLabel->hide();
 			removeFriendButton->setEnabled(true);
 			removeFriendButton->show();
+			banButton->hide();
 		}
 		else
 		{
@@ -322,6 +332,7 @@ void SecurityItem::updateItem()
 			}
 			removeFriendButton->setEnabled(false);
 			removeFriendButton->hide();
+			banButton->show();
 		}
 
 		//quickmsgButton->show();
@@ -375,6 +386,20 @@ void SecurityItem::removeFriend()
 		rsPeers->removeFriend(mGpgId);
 	}
 }
+
+void SecurityItem::banUser()
+{
+    // Confirmation dialog
+    QMessageBox::StandardButton reply;
+    reply = QMessageBox::question(this, tr("Ignore User"), tr("Are you sure you want to ignore this user? They will be added to the Ignored Users list and you will not receive further notifications from them. You can manage the list in Preferences -> Notify."),
+                                  QMessageBox::Yes|QMessageBox::No);
+    if (reply == QMessageBox::Yes) {
+        AuthSSL::instance().addNotifyDeny(mGpgId, mSslCn);
+        // Remove this item from the feed as it is now handled
+        removeItem(); 
+    }
+}
+
 void SecurityItem::friendRequest()
 {
 #ifdef DEBUG_ITEM

--- a/retroshare-gui/src/gui/feeds/SecurityItem.h
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.h
@@ -55,6 +55,7 @@ private slots:
 
 	void friendRequest();
 	void removeFriend();
+	void banUser();
 	void peerDetails();
 	void sendMsg();
 	void openChat();

--- a/retroshare-gui/src/gui/feeds/SecurityItem.ui
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.ui
@@ -284,6 +284,33 @@
             </widget>
            </item>
            <item>
+            <widget class="QToolButton" name="banButton">
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
+             <property name="text">
+              <string>Ignore User</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../images.qrc">
+               <normaloff>:/images/user/deny_user48.png</normaloff>:/images/user/deny_user48.png</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>24</width>
+               <height>24</height>
+              </size>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonTextBesideIcon</enum>
+             </property>
+             <property name="autoRaise">
+              <bool>false</bool>
+             </property>
+
+            </widget>
+           </item>
+           <item>
             <spacer name="buttons_HSpacer">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>

--- a/retroshare-gui/src/gui/settings/NotifyPage.cpp
+++ b/retroshare-gui/src/gui/settings/NotifyPage.cpp
@@ -508,6 +508,9 @@ void NotifyPage::addIgnoredUser()
         if(rsPeers && rsPeers->getGPGDetails(id, details)) name = details.name;
 
         AuthSSL::instance().addNotifyDeny(id, name);
+        if(rsPeers) {
+            rsPeers->removeFriend(id);
+        }
     }
     
     // Refresh list

--- a/retroshare-gui/src/gui/settings/NotifyPage.cpp
+++ b/retroshare-gui/src/gui/settings/NotifyPage.cpp
@@ -33,6 +33,13 @@
 #include "gui/NewsFeed.h"
 #include "util/misc.h"
 
+#include "pqi/authssl.h"
+//#include "gui/common/Rsdialogs.h" // For getting ID
+//#include "gui/peers/PeersDialog.h" // Maybe for friend selection?
+#include <QInputDialog>
+#include <QMessageBox>
+#include "gui/common/FriendSelectionDialog.h"
+
 /** Constructor */
 NotifyPage::NotifyPage(QWidget * parent, Qt::WindowFlags flags)
   : ConfigPage(parent, flags)
@@ -46,6 +53,9 @@ NotifyPage::NotifyPage(QWidget * parent, Qt::WindowFlags flags)
 	connect(ui.testToasterButton, SIGNAL(clicked()), this, SLOT(testToaster()));
     connect(ui.pushButtonDisableAll,SIGNAL(toggled(bool)), RsGUIEventManager::getInstance(), SLOT(SetDisableAll(bool)));
     connect(RsGUIEventManager::getInstance(),SIGNAL(disableAllChanged(bool)), ui.pushButtonDisableAll, SLOT(setChecked(bool)));
+
+    connect(ui.addIgnoredButton, SIGNAL(clicked()), this, SLOT(addIgnoredUser()));
+    connect(ui.removeIgnoredButton, SIGNAL(clicked()), this, SLOT(removeIgnoredUser()));
 
 	ui.notify_Blogs->hide();
 
@@ -394,6 +404,35 @@ void NotifyPage::load()
 
 	notifyToggled() ;
 
+	loadIgnoredUsers();
+}
+
+void NotifyPage::loadIgnoredUsers()
+{
+    ui.ignoredTreeWidget->clear();
+    QStringList headers; 
+    headers << tr("Name") << tr("PGP Id");
+    ui.ignoredTreeWidget->setHeaderLabels(headers);
+
+    std::map<RsPgpId, std::string> ids;
+    AuthSSL::instance().getNotifyDenyList(ids);
+    for(const auto& pair : ids) {
+         QTreeWidgetItem* item = new QTreeWidgetItem(ui.ignoredTreeWidget);
+         
+         std::string displayName = pair.second;
+         if(displayName.empty()) {
+             RsPeerDetails details;
+             if(rsPeers && rsPeers->getGPGDetails(pair.first, details)) {
+                 displayName = details.name;
+                 // Optionally update the list in AuthSSL? 
+                 // AuthSSL::instance().addNotifyDeny(pair.first, displayName); 
+                 // Better not to modify state during load, just display it.
+             }
+         }
+         
+         item->setText(0, QString::fromStdString(displayName));
+         item->setText(1, QString::fromStdString(pair.first.toStdString()));
+    }
 }
 
 void NotifyPage::notifyToggled()
@@ -442,5 +481,45 @@ void NotifyPage::testToaster()
                 RsGUIEventManager::getInstance()->testToaster(toasterNotifyIt->mEnabledCheckBox->accessibleName(), toasterNotifyIt->mToasterNotify, pos, margin) ;
             }
         }
+    }
+}
+
+void NotifyPage::showEvent(QShowEvent *event)
+{
+    loadIgnoredUsers();
+    ConfigPage::showEvent(event);
+}
+
+void NotifyPage::addIgnoredUser()
+{
+    std::set<RsPgpId> ids = FriendSelectionDialog::selectFriends_PGP(this, tr("Ban Friend"), tr("Select a friend to ban"), FriendSelectionWidget::MODUS_SINGLE, FriendSelectionWidget::SHOW_GPG);
+
+    if (ids.empty()) {
+        return;
+    }
+
+    // Since MODUS_SINGLE, we should have at most one ID, but loop just in case or take first.
+    for(const RsPgpId& id : ids) {
+        if (id.isNull()) continue;
+
+        // Try to get name from peers interface if possible, otherwise empty
+        std::string name; 
+        RsPeerDetails details; 
+        if(rsPeers && rsPeers->getGPGDetails(id, details)) name = details.name;
+
+        AuthSSL::instance().addNotifyDeny(id, name);
+    }
+    
+    // Refresh list
+    loadIgnoredUsers();
+}
+
+void NotifyPage::removeIgnoredUser()
+{
+    QTreeWidgetItem* item = ui.ignoredTreeWidget->currentItem();
+    if(item) {
+        RsPgpId id(item->text(1).toStdString());
+        AuthSSL::instance().removeNotifyDeny(id);
+        delete item;
     }
 }

--- a/retroshare-gui/src/gui/settings/NotifyPage.h
+++ b/retroshare-gui/src/gui/settings/NotifyPage.h
@@ -33,6 +33,8 @@ class UserNotify;
 class FeedNotify;
 class ToasterNotify;
 
+
+
 class UserNotifySetting
 {
 public:
@@ -81,6 +83,12 @@ public:
     /** Loads the settings for this page */
     virtual void load();
 
+protected:
+	void showEvent(QShowEvent *event) override;
+
+private:
+	void loadIgnoredUsers();
+
      virtual QPixmap iconPixmap() const { return FilesDefs::getPixmapFromQtResourcePath(":/icons/settings/notify.svg") ; }
 	 virtual QString pageName() const { return tr("Notify") ; }
 	 virtual QString helpText() const ;
@@ -102,6 +110,9 @@ private slots:
 	void updateToasterMargin();
 
 	void updateToasterPosition();
+	
+	void addIgnoredUser();
+	void removeIgnoredUser();
 
 private:
     RsFeedTypeFlags getNewsFlags();

--- a/retroshare-gui/src/gui/settings/NotifyPage.ui
+++ b/retroshare-gui/src/gui/settings/NotifyPage.ui
@@ -481,6 +481,61 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabIgnored">
+      <attribute name="title">
+       <string>Ignored Users</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="tabIgnoredVLayout">
+       <item>
+        <widget class="QTreeWidget" name="ignoredTreeWidget">
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>PGP Id</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="ignoredButtonsLayout">
+         <item>
+          <widget class="QPushButton" name="addIgnoredButton">
+           <property name="text">
+            <string>Add</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="removeIgnoredButton">
+           <property name="text">
+            <string>Remove</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacerIgnored">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
this pr requires librertoshare pr/269

Add Ignore User button to Security Feed and implement Ignored Users list management

- Added 'Ignore User' button to Security Feed alerts.
- Added 'Ignored Users' tab in Preferences -> Notify to manage the list.
- Users can now be ignored directly from alerts or managed via the preferences.
