### PR TITLE
fix distant chat dialog showing grey status when tunnel is already established

### DIFF
--- a/retroshare-gui/src/gui/chat/PopupDistantChatDialog.cpp
+++ b/retroshare-gui/src/gui/chat/PopupDistantChatDialog.cpp
@@ -89,13 +89,47 @@ void PopupDistantChatDialog::init(const ChatId &chat_id, const QString &/*title*
     ui.ownAvatarWidget->setId(chat_id) ;	// sets the actual Id
 
     _status_label->setIcon(FilesDefs::getIconFromQtResourcePath(IMAGE_GRY_LED));
-    auto msg = tr("Remote status unknown.");
-    _status_label->setToolTip(msg);
-    getChatWidget()->updateStatusString("%1", msg, true);
-    getChatWidget()->blockSending(tr( "Can't send message immediately, "
-                      "because there is no tunnel "
-                      "available." ));
-    setPeerStatus(RsStatusValue::RS_STATUS_OFFLINE);
+
+    switch(tinfo.status)
+    {
+    case RS_DISTANT_CHAT_STATUS_CAN_TALK:
+        _status_label->setIcon(FilesDefs::getIconFromQtResourcePath(IMAGE_GRN_LED));
+        {
+            auto msg = tr("End-to-end encrypted conversation established");
+            _status_label->setToolTip(msg);
+            getChatWidget()->updateStatusString("%1", msg, true);
+        }
+        getChatWidget()->unblockSending();
+        setPeerStatus(RsStatusValue::RS_STATUS_ONLINE);
+        break;
+
+    case RS_DISTANT_CHAT_STATUS_REMOTELY_CLOSED:
+    case RS_DISTANT_CHAT_STATUS_TUNNEL_DN:
+        _status_label->setIcon(FilesDefs::getIconFromQtResourcePath(IMAGE_YEL_LED));
+        {
+            auto msg = tr("Tunnel is being established. Please wait...");
+            _status_label->setToolTip(msg);
+            getChatWidget()->updateStatusString("%1", msg, true);
+        }
+        getChatWidget()->blockSending(tr( "Can't send message immediately, "
+                          "because there is no tunnel "
+                          "available." ));
+        setPeerStatus(RsStatusValue::RS_STATUS_OFFLINE);
+        break;
+
+    default:
+    case RS_DISTANT_CHAT_STATUS_UNKNOWN:
+        {
+            auto msg = tr("Remote status unknown.");
+            _status_label->setToolTip(msg);
+            getChatWidget()->updateStatusString("%1", msg, true);
+        }
+        getChatWidget()->blockSending(tr( "Can't send message immediately, "
+                          "because there is no tunnel "
+                          "available." ));
+        setPeerStatus(RsStatusValue::RS_STATUS_OFFLINE);
+        break;
+    }
 }
 
 void PopupDistantChatDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> e)


### PR DESCRIPTION
Distant chat dialog shows grey/offline on recipient side (fixed)

When user A initiates a distant chat with user B, the PopupDistantChatDialog on B's side always opens with a grey LED and "Remote status unknown" message, even though the tunnel is already established and messages can be exchanged.

Root cause: PopupDistantChatDialog::init() unconditionally set the status to grey/offline without checking the actual tunnel status. The dialog is created when the first message arrives (via ChatDialog::chatMessageReceived()), but at that point the tunnel is already in CAN_TALK state — the code just never checked it.

Fix: In PopupDistantChatDialog::init(), after the existing call to getDistantChatStatus(), added a switch(tinfo.status) to set the correct LED and sending state based on the actual tunnel status:

CAN_TALK → green LED, sending unblocked, peer online
TUNNEL_DN / REMOTELY_CLOSED → yellow LED, sending blocked
UNKNOWN → grey LED, sending blocked