### PR TITLE
TheWire: Fix UI

### DIFF
--- a/retroshare-gui/src/gui/TheWire/WireDialog.cpp
+++ b/retroshare-gui/src/gui/TheWire/WireDialog.cpp
@@ -553,7 +553,7 @@ void WireDialog::deleteGroups()
 			std::cerr << std::endl;
 
 			item = alayout->takeAt(i);
-			delete item->widget();
+			item->widget()->deleteLater();
 			delete item;
 		}
 		else
@@ -936,7 +936,7 @@ void WireDialog::clearTwitterView()
 			std::cerr << std::endl;
 
 			item = alayout->takeAt(i);
-			delete item->widget();
+			item->widget()->deleteLater();
 			delete item;
 		}
 		else

--- a/retroshare-gui/src/gui/TheWire/WireDialog.cpp
+++ b/retroshare-gui/src/gui/TheWire/WireDialog.cpp
@@ -438,8 +438,7 @@ void WireDialog::subscribe(RsGxsGroupId &groupId)
 {
 	RsThread::async([groupId]()
 	{
-		uint32_t token;
-		rsWire->subscribeToGroup(token, groupId, true);
+		rsWire->subscribe(groupId, true);
 	});
 }
 
@@ -447,8 +446,7 @@ void WireDialog::unsubscribe(RsGxsGroupId &groupId)
 {
 	RsThread::async([groupId]()
 	{
-		uint32_t token;
-		rsWire->subscribeToGroup(token, groupId, false);
+		rsWire->subscribe(groupId, false);
 	});
 }
 
@@ -905,8 +903,7 @@ void WireDialog::PVHfollow(const RsGxsGroupId &groupId)
 
 	RsThread::async([groupId]()
 	{
-		uint32_t token;
-		rsWire->subscribeToGroup(token, groupId, true);
+		rsWire->subscribe(groupId, true);
 	});
 }
 

--- a/retroshare-gui/src/gui/TheWire/WireDialog.h
+++ b/retroshare-gui/src/gui/TheWire/WireDialog.h
@@ -163,7 +163,7 @@ private:
 	void deleteGroups();
 	void showGroups();
 	void showSelectedGroups();
-	void updateGroups(std::vector<RsWireGroup> &groups);
+	void updateGroups(const std::vector<RsWireGroup> &groups);
 
 	void processSettings(bool load);
 

--- a/retroshare-gui/src/gui/TheWire/WireDialog.h
+++ b/retroshare-gui/src/gui/TheWire/WireDialog.h
@@ -24,6 +24,8 @@
 #include "retroshare-gui/mainpage.h"
 #include "ui_WireDialog.h"
 
+#include <QTimer>
+
 #include <retroshare/rswire.h>
 
 #include <map>
@@ -116,8 +118,8 @@ public:
 	void showGroupFocus(const RsGxsGroupId groupId);
 	void postGroupFocus(RsWireGroupSPtr group, std::list<RsWirePulseSPtr> pulses);
 
-	void requestGroupsPulses(const std::list<RsGxsGroupId>& groupIds);
-	void showGroupsPulses(const std::list<RsGxsGroupId>& groupIds);
+	void requestGroupsPulses(const std::list<RsGxsGroupId>& groupIds, bool addToHistory = true);
+	void showGroupsPulses(const std::list<RsGxsGroupId>& groupIds, bool addToHistory = true);
 	void postGroupsPulses(std::list<RsWirePulseSPtr> pulses);
 
     void getServiceStatistics(GxsServiceStatistic& stats) const override;
@@ -161,7 +163,7 @@ private:
 	void addGroup(const RsWireGroup &group);
 
 	void deleteGroups();
-	void showGroups();
+	void showGroups(bool addToHistory = true);
 	void showSelectedGroups();
 	void updateGroups(const std::vector<RsWireGroup> &groups);
 
@@ -208,6 +210,8 @@ private:
 	/* UI - from Designer */
 	Ui::WireDialog ui;
 
+	QTimer *mUpdateTimer;
+	bool mRequestGroupDataInProgress;
 };
 
 #endif

--- a/retroshare-gui/src/gui/TheWire/WireGroupDialog.cpp
+++ b/retroshare-gui/src/gui/TheWire/WireGroupDialog.cpp
@@ -34,7 +34,7 @@ const uint32_t WireCreateEnabledFlags = (
 							GXS_GROUP_FLAGS_DISTRIBUTION  |
 							// GXS_GROUP_FLAGS_PUBLISHSIGN   |
 							// GXS_GROUP_FLAGS_SHAREKEYS     |	// disabled because the UI doesn't handle it yet.
-							GXS_GROUP_FLAGS_PERSONALSIGN  |
+							// GXS_GROUP_FLAGS_PERSONALSIGN  |
 							// GXS_GROUP_FLAGS_COMMENTS      |
 							GXS_GROUP_FLAGS_EXTRA         |
 						  0);


### PR DESCRIPTION
# Resolve UI Freezes in "The Wire" feature
## Description
This PR addresses recurring UI freezes associated with "The Wire" feature. The root cause was identified as synchronous, blocking calls to the background service (`rsWire->getGroups`) performed on the main UI thread. These freezes occurred not only when viewing the "The Wire" tab but also in the background due to event handlers triggering data refreshes upon receiving network updates.
## Changes
- **Asynchronous Data Loading**: Refactored `WireDialog::requestGroupData` to use `RsThread::async` for fetching group data in a background thread.
- **Thread-Safe UI Updates**: Used `RsQThreadUtils::postToObject` to safely update the UI components from the background thread once data is available.
- **Non-Blocking Actions**: Converted [subscribe], [unsubscribe], and [PVHfollow] methods to be asynchronous to prevent minor stalls during user interactions.
- **Code Optimization**: Updated `WireDialog::updateGroups` to take a `const std::vector<RsWireGroup>&` to improve efficiency and ensure compatibility with the new asynchronous patterns.