### PR TITLE
Fix the wire forced compilation

### DIFF
--- a/retroshare-gui/src/gui/RetroShareLink.cpp
+++ b/retroshare-gui/src/gui/RetroShareLink.cpp
@@ -33,7 +33,9 @@
 #include "FileTransfer/SearchDialog.h"
 #include "gxschannels/GxsChannelDialog.h"
 #include "gxsforums/GxsForumsDialog.h"
+#ifdef RS_USE_WIRE
 #include "TheWire/WireDialog.h"
+#endif
 #include "msgs/MessageComposer.h"
 #include "Posted/PostedDialog.h"
 #include "util/misc.h"
@@ -1527,6 +1529,7 @@ static void processList(const QStringList &list, const QString &textSingular, co
 
             case TYPE_WIRE:
             {
+#ifdef RS_USE_WIRE
     #ifdef DEBUG_RSLINK
                 std::cerr << " RetroShareLink::process WireRequest : name : " << link.name().toStdString() << ". id : " << link.hash().toStdString() << ". msgId : " << link.msgId().toStdString() << std::endl;
     #endif
@@ -1550,6 +1553,7 @@ static void processList(const QStringList &list, const QString &textSingular, co
                         wireMsgUnknown.append(link.name());
                     }
                 }
+#endif
             }
             break;
 

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -117,7 +117,7 @@ CONFIG += gxscircles
 
 ## To enable unfinished services
 #CONFIG += wikipoos
-CONFIG += gxsthewire
+#CONFIG += gxsthewire
 #CONFIG += gxsphotoshare
 
 DEFINES += RS_RELEASE_VERSION

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -34,7 +34,7 @@ CONFIG *= retroshare_gui
 no_retroshare_gui:CONFIG -= retroshare_gui
 
 # Enable TheWire - RsWire - is intended to be a Twitter clone
-CONFIG *= gxsthewire
+#CONFIG *= gxsthewire
 
 # Enable GXS distant syncronization
 CONFIG *= gxsdistsync


### PR DESCRIPTION
Make TheWire compilation optional
To build with TheWire use qmake "CONFIG+=rsgxsthwire"