### PR TITLE
fix: initialize mSamSettings to prevent i2p proxy fields being uneditable without SAM3

### DIFF
--- a/retroshare-gui/src/gui/settings/ServerPage.cpp
+++ b/retroshare-gui/src/gui/settings/ServerPage.cpp
@@ -88,6 +88,8 @@ ServerPage::ServerPage(QWidget * parent, Qt::WindowFlags flags)
   /* Invoke the Qt Designer generated object setup routine */
   ui.setupUi(this);
 
+  mSamSettings.initDefault();
+
 #ifndef RS_USE_I2P_SAM3
   ui.hiddenServiceTab->removeTab(TAB_HIDDEN_SERVICE_I2P);	// warning: the order of operation here is very important.
 #endif


### PR DESCRIPTION
When building with CONFIG+=no_rs_sam3 CONFIG+=no_rs_sam3_libsam3, the I2P proxy address and port fields on the Hidden Service outgoing tab become uneditable (grayed out).

Root cause: mSamSettings (type samSettings, inheriting i2p::settings) has no default constructor. Its enable field is left uninitialized. Without SAM3 compiled in, the p3I2pSam3 service is never registered in rsAutoProxyMonitor, so 
taskSync(getSettings, &mSamSettings) is a no-op — mSamSettings keeps its garbage value. When loadCommon() calls ui.cb_enableBob->setChecked(mSamSettings.enable), the garbage truthy value triggers setUpSamElements() which disables the proxy fields.

Fix: Call mSamSettings.initDefault() in the ServerPage constructor, ensuring enable is false before any code reads it.