### PR TITLE
gui: Fix GXS forum selection and display logic when filtering posts

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1850,13 +1850,34 @@ void GxsForumThreadWidget::filterItems(const QString& text)
     QSortFilterProxyModel_setFilterRegularExpression(mThreadProxyModel, QString(RsGxsForumModel::FilterString)) ;
 
     if(!lst.empty())
+    {
         ui->threadTreeWidget->expandAll();
+
+        if (!mThreadId.isNull())
+        {
+            QModelIndex src_index = mThreadModel->getIndexOfMessage(mThreadId);
+            QModelIndex proxy_index = mThreadProxyModel->mapFromSource(src_index);
+            if (proxy_index.isValid())
+            {
+                ui->threadTreeWidget->setCurrentIndex(proxy_index);
+                ui->threadTreeWidget->scrollTo(proxy_index);
+            }
+            else
+            {
+                blankPost();
+                mThreadId.clear();
+                mOrigThreadId.clear();
+            }
+        }
+    }
     else {
-        // currentIndex() not on the clicked message, so not this way
-        // if (!mThreadId.isNull()) {
-        // 	an_index = mThreadProxyModel->mapToSource(ui->threadTreeWidget->currentIndex());
-        // }
         ui->threadTreeWidget->collapseAll();
+
+        if (mThreadId.isNull())
+        {
+            mThreadId = mOrigThreadId = mLastSelectedPosts[groupId()];
+        }
+
         if (!mThreadId.isNull()) {
             // ...but this one
             QModelIndex an_index = mThreadModel->getIndexOfMessage(mThreadId);


### PR DESCRIPTION
fix following issues:

- if a post content is already displayed when a title date or author search is performed, that content is still displayed even if the post is filtered by the search
- the first click on the list of results has no effect
- if the search returns only 1 result, the post cannot be selected
