### PR TITLE
fix: forum details is displayed instead of post content

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1963,7 +1963,8 @@ void GxsForumThreadWidget::updateGroupData()
     // ui->threadTreeWidget->selectionModel()->reset();
     // mThreadProxyModel->clear();
 
-    setForumDescriptionLoading();
+    if(mThreadId.isNull())
+        setForumDescriptionLoading();
 
     RsThread::async([this]()
     {


### PR DESCRIPTION
fix bug or regression where the forum details are sometimes displayed instead of the post content
