### PR TITLE
GUI/Channels: Fix channel appearing unsubscribed after posting by reloading metadata instead of toggling flag

### DIFF
--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
@@ -899,14 +899,24 @@ void GxsChannelPostsWidgetWithModel::handleEvent_main_thread(std::shared_ptr<con
         {
             if(e->mChannelGroupId == groupId())
             {
-                // Toggle subscribe flag locally and refresh UI without GXS request
-                // to avoid concurrent request with parent dialog's tree rebuild
-                if(IS_GROUP_SUBSCRIBED(mGroup.mMeta.mSubscribeFlags))
-                    mGroup.mMeta.mSubscribeFlags &= ~GXS_SERV::GROUP_SUBSCRIBE_SUBSCRIBED;
-                else
-                    mGroup.mMeta.mSubscribeFlags |= GXS_SERV::GROUP_SUBSCRIBE_SUBSCRIBED;
-
-                insertChannelDetails(mGroup);
+                // Fix: Fetch the actual channel status from the back-end instead of blindly toggling the local flag,
+                // which was causing the UI to flip to "Unsubscribed" after a post (since core emits this event
+                // every time group metadata like mLastPost is updated).
+                RsThread::async([this, grpId = groupId()]()
+                {
+                    std::vector<RsGxsChannelGroup> groups;
+                    if(rsGxsChannels->getChannelsInfo(std::list<RsGxsGroupId>{ grpId }, groups) && !groups.empty())
+                    {
+                        RsQThreadUtils::postToObject( [this, group = groups[0]]()
+                        {
+                            if (group.mMeta.mGroupId == groupId())
+                            {
+                                mGroup = group;
+                                insertChannelDetails(mGroup);
+                            }
+                        }, this);
+                    }
+                });
             }
         }
         break;

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1761,7 +1761,7 @@ void GxsForumThreadWidget::editForumMessageData(const RsGxsForumMsg& msg)
         return;
     }
 
-    CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mMsgId, msg.mMeta.mAuthorId, mForumGroup.mAdminList.ids);
+    CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mOrigMsgId, msg.mMeta.mAuthorId, mForumGroup.mAdminList.ids);
 
     cfm->insertPastedText(QString::fromUtf8(msg.mMsg.c_str())) ;
     cfm->show();

--- a/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumThreadWidget.cpp
@@ -1761,7 +1761,7 @@ void GxsForumThreadWidget::editForumMessageData(const RsGxsForumMsg& msg)
         return;
     }
 
-    CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mOrigMsgId, msg.mMeta.mAuthorId, mForumGroup.mAdminList.ids);
+    CreateGxsForumMsg *cfm = new CreateGxsForumMsg(groupId(), msg.mMeta.mParentId, msg.mMeta.mMsgId, msg.mMeta.mAuthorId, mForumGroup.mAdminList.ids);
 
     cfm->insertPastedText(QString::fromUtf8(msg.mMsg.c_str())) ;
     cfm->show();


### PR DESCRIPTION
GUI/Channels: Fix channel appearing unsubscribed after posting by reloading metadata instead of toggling flag

bug likely introduced by pr/3159 FixChannelsDetailsAndSubscribedButton commit 1658f9bd