### PR TITLE
gui: Fixed "count occurrence of the following text" not being saved in Chat Preferences

### DIFF
--- a/retroshare-gui/src/gui/settings/ChatPage.cpp
+++ b/retroshare-gui/src/gui/settings/ChatPage.cpp
@@ -229,7 +229,7 @@ ChatPage::ChatPage(QWidget * parent, Qt::WindowFlags flags)
     connect(ui.chatLobbies_CountUnRead,        SIGNAL(toggled(bool)),this, SLOT(updateChatLobbyUserNotify())) ;
     connect(ui.chatLobbies_CheckNickName,      SIGNAL(toggled(bool)),this, SLOT(updateChatLobbyUserNotify())) ;
     connect(ui.chatLobbies_CountFollowingText, SIGNAL(toggled(bool)),this, SLOT(updateChatLobbyUserNotify())) ;
-    connect(ui.chatLobbies_TextToNotify,       SIGNAL(textChanged(QString)),this, SLOT(updateChatLobbyUserNotify()));
+    connect(ui.chatLobbies_TextToNotify,       SIGNAL(textChanged()),this, SLOT(updateChatLobbyUserNotify()));
     connect(ui.chatLobbies_TextCaseSensitive,  SIGNAL(toggled(bool)),this, SLOT(updateChatLobbyUserNotify())) ;
 
     connect(ui.distantChatComboBox,        SIGNAL(currentIndexChanged(int)), this, SLOT(distantChatComboBoxChanged(int)));


### PR DESCRIPTION
gui: Fixed "count occurrence of the following text" not being saved in Chat Preferences