### PR TITLE
Fix #3088: Add cumulative data transfer statistics display (KB/MB/GB)

### DIFF
--- a/retroshare-gui/src/gui/statistics/BWGraph.cpp
+++ b/retroshare-gui/src/gui/statistics/BWGraph.cpp
@@ -451,7 +451,27 @@ QString BWGraphSource::displayValue(float v) const
 
 QString BWGraphSource::legend(int i,float v,bool show_value) const
 {
-	return RSGraphSource::legend(i,v,show_value) ;
+	// Get base legend (name + current speed)
+	QString base_legend = RSGraphSource::legend(i,v,show_value);
+	
+	// Add cumulative data if showing KB/s
+	if(_current_unit == UNIT_KILOBYTES && show_value)
+	{
+		// Get cumulative total for this curve
+		std::vector<float> cum_vals;
+		getCumulatedValues(cum_vals);
+		
+		if(i >= 0 && i < (int)cum_vals.size())
+		{
+			float cum_val = cum_vals[i];
+			// Convert to total bytes and format
+			float total_bytes = cum_val * _total_duration_seconds * 1024.0f; // cum_val is in KB/s * seconds
+			QString cum_str = niceNumber(total_bytes);
+			base_legend += QString(" [Total: %1]").arg(cum_str);
+		}
+	}
+	
+	return base_legend;
 }
 QString BWGraphSource::niceNumber(float v) const
 {

--- a/retroshare-gui/src/gui/statistics/TurtleRouterStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterStatistics.cpp
@@ -27,6 +27,7 @@
 
 #include <retroshare/rsturtle.h>
 #include <retroshare/rspeers.h>
+#include <retroshare/rsconfig.h>
 #include "TurtleRouterStatistics.h"
 #include "TurtleRouterDialog.h"
 #include "GxsNetTunnelsDialog.h"
@@ -345,7 +346,22 @@ void TurtleRouterStatisticsWidget::updateTunnelStatistics(const std::vector<std:
 
 	painter.drawText(ox+2*cellx,oy+celly,tr("TR Forward probabilities")+"\t: " + prob_string ) ; 
 	oy += celly ;
-	oy += celly ;
+	oy += celly;
+
+	// Display cumulative turtle traffic statistics (KB/MB/GB)
+	RsCumulativeTrafficStats turtleCumStats;
+	if(rsConfig->getTotalCumulativeTraffic(turtleCumStats)) {
+		painter.setPen(QColor::fromRgb(70,70,70)) ;
+		painter.drawLine(0,oy,maxWidth,oy) ;
+		oy += celly ;
+		
+		painter.drawText(ox,oy+celly,tr("Cumulative Total Traffic")+":") ; 
+		oy += celly*2 ;
+		painter.drawText(ox+2*cellx,oy+celly,tr("Total Received")+"\t: " + dataSizeString(turtleCumStats.bytesIn)) ; 
+		oy += celly ;
+		painter.drawText(ox+2*cellx,oy+celly,tr("Total Sent")+"\t: " + dataSizeString(turtleCumStats.bytesOut)) ; 
+		oy += celly ;
+	}
 
 	// update the pixmap
 	//
@@ -361,6 +377,19 @@ QString TurtleRouterStatisticsWidget::speedString(float f)
 		return QString::number((int)f)+" B/s" ;
 
 	return QString::number(f/1024.0,'f',2) + " KB/s";
+}
+
+QString TurtleRouterStatisticsWidget::dataSizeString(uint64_t bytes)
+{
+	// Format bytes into human-readable KB/MB/GB
+	if(bytes < 1024ULL)
+		return QString::number(bytes) + " B";
+	if(bytes < 1024ULL * 1024ULL)
+		return QString::number(bytes / 1024.0, 'f', 2) + " KB";
+	if(bytes < 1024ULL * 1024ULL * 1024ULL)
+		return QString::number(bytes / (1024.0 * 1024.0), 'f', 2) + " MB";
+	
+	return QString::number(bytes / (1024.0 * 1024.0 * 1024.0), 'f', 2) + " GB";
 }
 
 void TurtleRouterStatisticsWidget::paintEvent(QPaintEvent */*event*/)

--- a/retroshare-gui/src/gui/statistics/TurtleRouterStatistics.h
+++ b/retroshare-gui/src/gui/statistics/TurtleRouterStatistics.h
@@ -68,6 +68,7 @@ class TurtleRouterStatisticsWidget:  public QWidget
 
 	private:
 		static QString speedString(float f) ;
+		static QString dataSizeString(uint64_t bytes) ;
 
 		QPixmap pixmap ;
 		int maxWidth,maxHeight ;


### PR DESCRIPTION
## Summary
This PR implements the feature requested in Issue #3088 to display cumulative data transfer statistics in KB/MB/GB format across the statistics pages.

## Changes Made

### 1. TurtleRouterStatistics.cpp/h
- Added `dataSizeString(uint64_t bytes)` function to format bytes into human-readable KB/MB/GB
- Added cumulative traffic display section showing "Total Received" and "Total Sent"
- Added include for `rsconfig.h` to access cumulative traffic APIs

### 2. BWGraph.cpp
- Modified `legend()` function to show total cumulative data alongside current speed
- Format: "Service Name (123 KB/s) [Total: 1.5 GB]"

## Implementation Details

The implementation uses the existing `RsCumulativeTrafficStats` API from libretroshare:
- `rsConfig->getTotalCumulativeTraffic()` - Gets total traffic stats
- `RsCumulativeTrafficStats.bytesIn` / `bytesOut` - Total bytes transferred

## Testing
The code builds successfully and integrates with existing RetroShare statistics infrastructure.

## Screenshot (Conceptual)
```
Turtle Router Traffic:
  Tunnel requests Dn: 12.5 KB/s
  Tunnel requests Up: 8.2 KB/s
  
Cumulative Total Traffic:
  Total Received: 2.45 GB
  Total Sent: 1.82 GB
```

Fixes #3088