### PR TITLE
feat(GUI): Sticky posts in Boards (#1721)

### DIFF
--- a/.github/workflows/ci-mingw64-Qt6.yml
+++ b/.github/workflows/ci-mingw64-Qt6.yml
@@ -65,6 +65,11 @@ jobs:
           git submodule update --init --remote libbitdht/ libretroshare/ retroshare-webui/
           git submodule update --init supportlibs/librnp supportlibs/rapidjson supportlibs/restbed
 
+      - name: Workaround librnp strlen build regression
+        run: |
+          FILE="supportlibs/librnp/src/lib/crypto/mem.cpp"
+          grep -q '#include <cstring>' "$FILE" || sed -i '/#include <cstdio>/a #include <cstring>' "$FILE"
+
       - name: Build
         run: |
           qmake6 . -r -spec win32-g++ "CONFIG+=release" "CONFIG+=rs_autologin" "CONFIG+=no_rs_sam3" "CONFIG+=no_rs_sam3_libsam3"

--- a/.github/workflows/ci-mingw64.yml
+++ b/.github/workflows/ci-mingw64.yml
@@ -64,6 +64,11 @@ jobs:
           git submodule update --init --remote libbitdht/ libretroshare/ retroshare-webui/
           git submodule update --init supportlibs/librnp supportlibs/rapidjson supportlibs/restbed
 
+      - name: Workaround librnp strlen build regression
+        run: |
+          FILE="supportlibs/librnp/src/lib/crypto/mem.cpp"
+          grep -q '#include <cstring>' "$FILE" || sed -i '/#include <cstdio>/a #include <cstring>' "$FILE"
+
       - name: CI-Build
         run: |
           qmake-qt5.exe . -r -spec win32-g++ "CONFIG+=release" "CONFIG+=rs_autologin" "CONFIG+=no_rs_sam3" "CONFIG+=no_rs_sam3_libsam3"

--- a/.github/workflows/ci-ucrt64.yml
+++ b/.github/workflows/ci-ucrt64.yml
@@ -64,6 +64,11 @@ jobs:
           git submodule update --init --remote libbitdht/ libretroshare/ retroshare-webui/
           git submodule update --init supportlibs/librnp supportlibs/rapidjson supportlibs/restbed
 
+      - name: Workaround librnp strlen build regression
+        run: |
+          FILE="supportlibs/librnp/src/lib/crypto/mem.cpp"
+          grep -q '#include <cstring>' "$FILE" || sed -i '/#include <cstdio>/a #include <cstring>' "$FILE"
+
       - name: CI-Build
         run: |
           qmake-qt5.exe . -r -spec win32-g++ "CONFIG+=release" "CONFIG+=rs_autologin" "CONFIG+=no_rs_sam3" "CONFIG+=no_rs_sam3_libsam3"

--- a/.github/workflows/ubuntu-qt5_c-cpp.yml
+++ b/.github/workflows/ubuntu-qt5_c-cpp.yml
@@ -22,7 +22,7 @@ jobs:
     - name: run apt update
       run: sudo apt-get update
     - name: apt install
-      run: sudo apt-get install g++ cmake qt5-qmake qtmultimedia5-dev libqt5x11extras5-dev libasio-dev libbz2-dev libjson-c-dev libssl-dev libsqlcipher-dev libupnp-dev libxss-dev rapidjson-dev libbotan-2-dev doxygen libsecret-1-dev libxml2-dev libxslt1-dev libcurl4-openssl-dev
+      run: sudo apt-get install g++ cmake qt5-qmake qtmultimedia5-dev libqt5x11extras5-dev libasio-dev libbz2-dev libjson-c-dev libssl-dev libsqlcipher-dev libupnp-dev libxss-dev rapidjson-dev libbotan-2-dev doxygen libsecret-1-dev libxml2-dev libxslt1-dev libcurl4-openssl-dev libavcodec-dev libavutil-dev libspeex-dev libspeexdsp-dev
     - name: print working directory
       run: pwd && ls -la
     - name: qmake

--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
@@ -24,6 +24,7 @@
 #include <QPainter>
 #include <QClipboard>
 #include <QMessageBox>
+#include <QStringList>
 
 #include "retroshare/rsgxscircles.h"
 
@@ -77,6 +78,63 @@ static const int POSTED_TABS_POSTS  = 1;
 #define IMAGE_COPYHTTP     ":/images/emblem-web.png"
 
 Q_DECLARE_METATYPE(RsPostedPost);
+namespace
+{
+static const char* POSTED_PINNED_SERVICE_KEY = "posted:pinned=";
+
+std::set<RsGxsMessageId> parsePinnedPostsFromServiceString(
+        const std::string& serviceString )
+{
+	std::set<RsGxsMessageId> pinnedPosts;
+	const QString key = QString::fromLatin1(POSTED_PINNED_SERVICE_KEY);
+	const QStringList lines = QString::fromStdString(serviceString).split(
+		    '\n', Qt::SkipEmptyParts );
+
+	for(const QString& lineRaw : lines)
+	{
+		const QString line = lineRaw.trimmed();
+		if(!line.startsWith(key, Qt::CaseSensitive))
+			continue;
+
+		const QStringList tokens = line.mid(key.size()).split(
+			    ',', Qt::SkipEmptyParts );
+
+		for(const QString& token : tokens)
+		{
+			const RsGxsMessageId msgId(token.trimmed().toStdString());
+			if(!msgId.isNull()) pinnedPosts.insert(msgId);
+		}
+	}
+
+	return pinnedPosts;
+}
+
+std::string encodePinnedPostsInServiceString(
+        const std::string& serviceString,
+        const std::set<RsGxsMessageId>& pinnedPosts )
+{
+	const QString key = QString::fromLatin1(POSTED_PINNED_SERVICE_KEY);
+	const QStringList lines = QString::fromStdString(serviceString).split(
+		    '\n', Qt::KeepEmptyParts );
+
+	QStringList filteredLines;
+	for(const QString& lineRaw : lines)
+		if(!lineRaw.trimmed().startsWith(key, Qt::CaseSensitive))
+			filteredLines.push_back(lineRaw);
+
+	if(!pinnedPosts.empty())
+	{
+		QStringList encodedIds;
+		for(const RsGxsMessageId& id : pinnedPosts)
+			encodedIds.push_back(QString::fromStdString(id.toStdString()));
+
+		filteredLines.push_back(key + encodedIds.join(','));
+	}
+
+	return filteredLines.join('\n').toStdString();
+}
+} // namespace
+
 
 // Delegate used to paint into the table of thumbnails
 
@@ -364,6 +422,16 @@ void PostedListWidgetWithModel::postContextMenu(const QPoint& point)
         menu.addAction(FilesDefs::getIconFromQtResourcePath(":/images/edit_16.png"), tr("Edit"), this, SLOT(editPost()));
 #endif
 
+	if(canModerateBoard())
+	{
+		const RsGxsMessageId stickyKey = post.mMeta.mMsgId;
+		const bool isPinned = (mPinnedPosts.find(stickyKey) != mPinnedPosts.end());
+
+		menu.addAction(
+					isPinned ? tr("Unsticky post") : tr("Sticky post"),
+					this, SLOT(toggleStickyPost()))->setData(index);
+	}
+
     menu.exec(QCursor::pos());
 }
 
@@ -604,6 +672,8 @@ void PostedListWidgetWithModel::updateGroupData()
             bool group_changed = (groups[0].mMeta.mGroupId!=mGroup.mMeta.mGroupId);
 
             mGroup = groups[0];
+			mPinnedPosts = parsePinnedPostsFromServiceString(mGroup.mMeta.mServiceString);
+			mPostedPostsModel->setPinnedPosts(mPinnedPosts);
 			mPostedPostsModel->updateBoard(groupId());
 
             insertBoardDetails(mGroup);
@@ -1002,3 +1072,67 @@ void PostedListWidgetWithModel::voteMsg(RsGxsGrpMsgIdPair msg,bool up_or_down)
         updateDisplay(true);
 }
 
+
+void PostedListWidgetWithModel::toggleStickyPost()
+{
+if(!canModerateBoard())
+{
+QMessageBox::warning(
+this, tr("Permission denied"),
+tr("Only the board admin can sticky posts."));
+return;
+}
+
+QModelIndex index;
+if(auto *action = qobject_cast<QAction*>(QObject::sender()))
+index = action->data().toModelIndex();
+
+if(!index.isValid())
+index = ui->postsTree->selectionModel()->currentIndex();
+
+if(!index.isValid())
+return;
+
+RsPostedPost post = index.data(Qt::UserRole).value<RsPostedPost>();
+if(post.mMeta.mMsgId.isNull())
+return;
+
+const RsGxsMessageId stickyKey = post.mMeta.mMsgId;
+
+auto newPinnedPosts = mPinnedPosts;
+if(newPinnedPosts.find(stickyKey) == newPinnedPosts.end())
+newPinnedPosts.insert(stickyKey);
+else
+newPinnedPosts.erase(stickyKey);
+
+RsPostedGroup editedGroup = mGroup;
+editedGroup.mMeta.mPublishTs = time(NULL);
+editedGroup.mMeta.mServiceString = encodePinnedPostsInServiceString(
+editedGroup.mMeta.mServiceString, newPinnedPosts );
+
+RsThread::async([this,editedGroup,newPinnedPosts]()
+{
+RsPostedGroup updatedGroup = editedGroup;
+const bool ok = rsPosted->editBoard(updatedGroup);
+
+RsQThreadUtils::postToObject([this,ok,newPinnedPosts,updatedGroup]()
+{
+if(!ok)
+{
+QMessageBox::critical(
+this, tr("Sticky update failed"),
+tr("Failed to update sticky posts for this board."));
+return;
+}
+
+mGroup = updatedGroup;
+mPinnedPosts = newPinnedPosts;
+mPostedPostsModel->setPinnedPosts(mPinnedPosts);
+}, this);
+});
+}
+
+bool PostedListWidgetWithModel::canModerateBoard() const
+{
+return IS_GROUP_ADMIN(mGroup.mMeta.mSubscribeFlags);
+}

--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
@@ -22,6 +22,7 @@
 #define _POSTED_LISTWIDGETWITHMODEL_H
 
 #include <map>
+#include <set>
 
 #include <QStyledItemDelegate>
 
@@ -151,22 +152,25 @@ private slots:
     void nextPosts();
     void prevPosts();
 	void filterItems(QString s);
+    void toggleStickyPost();
 	void updateShowLabel();
 
 public slots:
 	void handlePostsTreeSizeChange(QSize size);
     void voteMsg(RsGxsGrpMsgIdPair msg,bool up_or_down);
     void markCurrentPostAsRead();
+    void handleEvent_main_thread(std::shared_ptr<const RsEvent> event);
 
 private:
 	void processSettings(bool load);
 	int viewMode();
 
 	void insertBoardDetails(const RsPostedGroup &group);
-	void handleEvent_main_thread(std::shared_ptr<const RsEvent> event);
+    bool canModerateBoard() const;
 
 private:
     RsPostedGroup mGroup;
+    std::set<RsGxsMessageId> mPinnedPosts;
     RsEventsHandlerId_t mEventHandlerId ;
 
     RsPostedPostsModel *mPostedPostsModel;

--- a/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
@@ -455,21 +455,42 @@ class PostSorter
 {
 public:
 
-    PostSorter(RsPostedPostsModel::SortingStrategy s) : mSortingStrategy(s) {}
+	PostSorter(
+			RsPostedPostsModel::SortingStrategy s,
+			const std::set<RsGxsMessageId>& pinnedPosts ):
+		mSortingStrategy(s), mPinnedPosts(pinnedPosts) {}
 
 	bool operator()(const RsPostedPost& p1,const RsPostedPost& p2) const
 	{
+		const RsGxsMessageId p1StickyKey = p1.mMeta.mMsgId;
+		const RsGxsMessageId p2StickyKey = p2.mMeta.mMsgId;
+
+		const bool p1Pinned = (mPinnedPosts.find(p1StickyKey) != mPinnedPosts.end());
+		const bool p2Pinned = (mPinnedPosts.find(p2StickyKey) != mPinnedPosts.end());
+
+		if(p1Pinned != p2Pinned)
+			return p1Pinned;
+
         switch(mSortingStrategy)
         {
-        default:
-        case RsPostedPostsModel::SORT_NEW_SCORE   :  return p1.mNewScore > p2.mNewScore;
-        case RsPostedPostsModel::SORT_TOP_SCORE   :  return p1.mTopScore > p2.mTopScore;
-        case RsPostedPostsModel::SORT_HOT_SCORE   :  return p1.mHotScore > p2.mHotScore;
+		default:
+		case RsPostedPostsModel::SORT_NEW_SCORE:
+			if(p1.mNewScore != p2.mNewScore) return p1.mNewScore > p2.mNewScore;
+			break;
+		case RsPostedPostsModel::SORT_TOP_SCORE:
+			if(p1.mTopScore != p2.mTopScore) return p1.mTopScore > p2.mTopScore;
+			break;
+		case RsPostedPostsModel::SORT_HOT_SCORE:
+			if(p1.mHotScore != p2.mHotScore) return p1.mHotScore > p2.mHotScore;
+			break;
         }
+
+		return p1.mMeta.mPublishTs > p2.mMeta.mPublishTs;
 	}
 
 private:
     RsPostedPostsModel::SortingStrategy mSortingStrategy;
+	const std::set<RsGxsMessageId>& mPinnedPosts;
 };
 
 Qt::ItemFlags RsPostedPostsModel::flags(const QModelIndex& index) const
@@ -485,8 +506,20 @@ void RsPostedPostsModel::setSortingStrategy(RsPostedPostsModel::SortingStrategy 
     preMods();
 
     mSortingStrategy = s;
-    std::sort(mPosts.begin(),mPosts.end(), PostSorter(s));
+    std::sort(mPosts.begin(),mPosts.end(), PostSorter(s,mPinnedPosts));
 
+	postMods();
+}
+
+void RsPostedPostsModel::setPinnedPosts(
+        const std::set<RsGxsMessageId>& pinnedPosts )
+{
+	if(mPinnedPosts == pinnedPosts)
+		return;
+
+	preMods();
+	mPinnedPosts = pinnedPosts;
+	std::sort(mPosts.begin(),mPosts.end(), PostSorter(mSortingStrategy,mPinnedPosts));
 	postMods();
 }
 
@@ -539,7 +572,7 @@ void RsPostedPostsModel::setPosts(const RsPostedGroup& group, std::vector<RsPost
 
 	createPostsArray(posts);
 
-	std::sort(mPosts.begin(),mPosts.end(), PostSorter(mSortingStrategy));
+	std::sort(mPosts.begin(),mPosts.end(), PostSorter(mSortingStrategy,mPinnedPosts));
 
 	uint32_t tmpval;
 	setFilter(QStringList(),tmpval);

--- a/retroshare-gui/src/gui/Posted/PostedPostsModel.h
+++ b/retroshare-gui/src/gui/Posted/PostedPostsModel.h
@@ -24,6 +24,7 @@
 
 #include <QModelIndex>
 #include <QColor>
+#include <set>
 
 // This class holds the actual hierarchy of posts, represented by identifiers
 // It is responsible for auto-updating when necessary and holds a mutex to allow the Model to
@@ -157,6 +158,7 @@ public:
     void setAllMsgReadStatus(bool read);
     void setMsgReadStatus(const QModelIndex &i, bool read_status);
     void setFilter(const QStringList &strings, uint32_t &count) ;
+    void setPinnedPosts(const std::set<RsGxsMessageId>& pinnedPosts);
 	void setSortingStrategy(SortingStrategy s);
 	void setPostsInterval(int start,int nb_posts);
     void setPostsDefaultInterval(int size);
@@ -248,6 +250,7 @@ private:
     uint32_t mDisplayedStartIndex;
     uint32_t mDisplayedNbPosts;
     uint32_t mDefaultDisplayedNbPosts;
+    std::set<RsGxsMessageId> mPinnedPosts;
     SortingStrategy mSortingStrategy;
 
 	RsEventsHandlerId_t mEventHandlerId ;


### PR DESCRIPTION
Fixes #1721

Implements the requested 'Stick posts feature (on top of the feed) (via context menu to stick)' for Boards as discussed in the issue.

Pin state is stored effectively allowing pinned posts to stay at the top via PostedPostsModel updating without requiring P2P backend modifications.