### PR TITLE
Implement edit and sticky posts for Posted boards 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,8 +31,8 @@
 	branch = master
 [submodule "libretroshare"]
 	path = libretroshare
-	url = https://github.com/RetroShare/libretroshare.git
-	branch = master
+	url = https://github.com/samuel-asleep/libretroshare.git
+	branch = board-improvement
 [submodule "retroshare-webui"]
 	path = retroshare-webui
 	url = https://github.com/RetroShare/RSNewWebUI.git

--- a/retroshare-gui/src/gui/Posted/PostedCreatePostDialog.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedCreatePostDialog.cpp
@@ -18,7 +18,6 @@
  *                                                                             *
  *******************************************************************************/
 
-#include <QBuffer>
 #include <QClipboard>
 #include <QMessageBox>
 #include <QByteArray>
@@ -38,12 +37,12 @@
 
 #include "gui/settings/rsharesettings.h"
 #include "BoardPostImageHelper.h"
-#include <QBuffer>
 
 #include <iostream>
 #include <gui/RetroShareLink.h>
 #include <util/imageutil.h>
 #include "gui/common/FilesDefs.h"
+#include "util/rsurl.h"
 
 /* View Page */
 #define VIEW_POST   0
@@ -136,6 +135,13 @@ void PostedCreatePostDialog::processSettings(bool load)
 	Settings->endGroup();
 }
 
+void PostedCreatePostDialog::setOrigPostId(const RsGxsMessageId& origPostId)
+{
+	mOrigPostId = origPostId;
+	if(!origPostId.isNull())
+		ui->headerFrame->setHeaderText(tr("Edit Post"));
+}
+
 void PostedCreatePostDialog::createPost()
 {
 	if(ui->titleEdit->text().isEmpty()) {
@@ -160,46 +166,46 @@ void PostedCreatePostDialog::createPost()
 		return;
 	}//switch (ui->idChooser->getChosenId(authorId))
 
-	RsPostedPost post;
-	post.mMeta.mGroupId = mGrpId;
-	post.mLink = std::string(ui->linkEdit->text().toUtf8());
-	
-	if(!ui->RichTextEditWidget->toPlainText().trimmed().isEmpty()) {
-		QString text;
-		text = ui->RichTextEditWidget->toHtml();
-		post.mNotes = std::string(text.toUtf8());
-	}
+	std::string title = std::string(ui->titleEdit->text().toUtf8());
+	std::string link  = std::string(ui->linkEdit->text().toUtf8());
+	std::string notes;
 
-	post.mMeta.mAuthorId = authorId;
-	post.mMeta.mMsgName = std::string(ui->titleEdit->text().toUtf8());
-	
+	if(!ui->RichTextEditWidget->toPlainText().trimmed().isEmpty())
+		notes = std::string(ui->RichTextEditWidget->toHtml().toUtf8());
+
+	RsGxsImage image;
 	if(imagebytes.size() > 0)
-	{
-		// send posted image
-		post.mImage.copy((uint8_t *) imagebytes.data(), imagebytes.size());
-	}	
+		image.copy((uint8_t *) imagebytes.data(), imagebytes.size());
 
-	int msgsize = post.mLink.length() + post.mMeta.mMsgName.length() + post.mNotes.length() + imagebytes.size();
+	int msgsize = link.length() + title.length() + notes.length() + imagebytes.size();
 	if(msgsize > MAXMESSAGESIZE) {
 		QString errormessage = QString(tr("Message is too large.<br />actual size: %1 bytes, maximum size: %2 bytes.")).arg(msgsize).arg(MAXMESSAGESIZE);
 		QMessageBox::warning(this, "RetroShare", errormessage, QMessageBox::Ok, QMessageBox::Ok);
 		return;
 	}
 
-    RsThread::async([this,post]()
-    {
-        RsGxsMessageId post_id;
+	RsGxsGroupId boardId = mGrpId;
+	RsGxsMessageId origPostId = mOrigPostId;
 
-        bool res = rsPosted->createPost(post,post_id);
+	RsThread::async([this, boardId, title, link, notes, authorId, image, origPostId]()
+	{
+		RsGxsMessageId post_id;
+		std::string error_message;
 
-        RsQThreadUtils::postToObject( [res,this]()
-        {
-            if(!res)
-                QMessageBox::information(nullptr,tr("Error while creating post"),tr("An error occurred while creating the post."));
+		bool res = rsPosted->createPostV2(boardId, title, RsUrl(link), notes, authorId, image, post_id, error_message, origPostId);
 
-            accept();
-        }, this );
-    });
+		RsQThreadUtils::postToObject( [res, error_message, this]()
+		{
+			if(!res)
+			{
+				QMessageBox::warning(nullptr, tr("Error while saving post"),
+				                     QString("%1\n\n%2").arg(tr("An error occurred while saving the post."),
+				                                            QString::fromStdString(error_message)));
+				return;
+			}
+			accept();
+		}, this );
+	});
 }
 
 void PostedCreatePostDialog::fileHashingFinished(QList<HashedFile> hashedFiles)

--- a/retroshare-gui/src/gui/Posted/PostedCreatePostDialog.h
+++ b/retroshare-gui/src/gui/Posted/PostedCreatePostDialog.h
@@ -45,6 +45,9 @@ public:
 	void setNotes(const QString& notes);
 	void setLink(const QString& link);
 
+	/** Set the original post ID to enable edit mode. Must be called before show(). */
+	void setOrigPostId(const RsGxsMessageId& origPostId);
+
 	static bool optimizeImage(const QImage &image, QByteArray &imagebytes, QImage &imageOpt);
 
 private:
@@ -68,6 +71,7 @@ private:
 	QString mNotes;
 	RsPosted* mPosted;
 	RsGxsGroupId mGrpId;
+	RsGxsMessageId mOrigPostId;
 
 	Ui::PostedCreatePostDialog *ui;
 };

--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
@@ -357,12 +357,16 @@ void PostedListWidgetWithModel::postContextMenu(const QPoint& point)
 
     menu.addAction(FilesDefs::getIconFromQtResourcePath(IMAGE_AUTHOR), tr("Show author in People tab"), this, SLOT(showAuthorInPeople()))->setData(index);
 
-#ifdef TODO
-    // This feature is not implemented yet in libretroshare.
+    if(IS_GROUP_SUBSCRIBED(mGroup.mMeta.mSubscribeFlags))
+        menu.addAction(FilesDefs::getIconFromQtResourcePath(":/icons/png/pencil-edit-button.png"), tr("Edit"), this, SLOT(editPost()))->setData(index);
 
-    if(IS_GROUP_PUBLISHER(mGroup.mMeta.mSubscribeFlags))
-        menu.addAction(FilesDefs::getIconFromQtResourcePath(":/images/edit_16.png"), tr("Edit"), this, SLOT(editPost()));
-#endif
+    if(IS_GROUP_ADMIN(mGroup.mMeta.mSubscribeFlags))
+    {
+        bool is_pinned = mGroup.mPinnedPosts.ids.find(post.mMeta.mMsgId) != mGroup.mPinnedPosts.ids.end();
+        menu.addAction(FilesDefs::getIconFromQtResourcePath(":/images/pin32.png"),
+                       is_pinned ? tr("Un-pin this post") : tr("Pin this post"),
+                       this, SLOT(togglePinPost()))->setData(index);
+    }
 
     menu.exec(QCursor::pos());
 }
@@ -830,6 +834,47 @@ std::cerr << "Chosing default ID " << author_id<< std::endl;
 	/* window will destroy itself! */
 }
 
+void PostedListWidgetWithModel::editPost()
+{
+    QModelIndex index = qobject_cast<QAction*>(QObject::sender())->data().toModelIndex();
+
+    if(!index.isValid())
+        return;
+
+    RsPostedPost post = index.data(Qt::UserRole).value<RsPostedPost>();
+
+    PostedCreatePostDialog *msgDialog = new PostedCreatePostDialog(
+                rsPosted, groupId(), post.mMeta.mAuthorId );
+    msgDialog->setTitle(QString::fromUtf8(post.mMeta.mMsgName.c_str()));
+    msgDialog->setNotes(QString::fromUtf8(post.mNotes.c_str()));
+    msgDialog->setLink(QString::fromUtf8(post.mLink.c_str()));
+    msgDialog->setOrigPostId(post.mMeta.mMsgId);
+    msgDialog->show();
+
+    /* window will destroy itself! */
+}
+
+void PostedListWidgetWithModel::togglePinPost()
+{
+    QModelIndex index = qobject_cast<QAction*>(QObject::sender())->data().toModelIndex();
+
+    if(!index.isValid())
+        return;
+
+    RsPostedPost post = index.data(Qt::UserRole).value<RsPostedPost>();
+
+    if(mGroup.mPinnedPosts.ids.find(post.mMeta.mMsgId) == mGroup.mPinnedPosts.ids.end())
+        mGroup.mPinnedPosts.ids.insert(post.mMeta.mMsgId);
+    else
+        mGroup.mPinnedPosts.ids.erase(post.mMeta.mMsgId);
+
+    RsPostedGroup updatedGroup = mGroup;
+    RsThread::async([updatedGroup]() mutable
+    {
+        rsPosted->editBoard(updatedGroup);
+    });
+}
+
 void PostedListWidgetWithModel::insertBoardDetails(const RsPostedGroup& group)
 {
     // save selection if needed
@@ -1001,4 +1046,3 @@ void PostedListWidgetWithModel::voteMsg(RsGxsGrpMsgIdPair msg,bool up_or_down)
     else
         updateDisplay(true);
 }
-

--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
@@ -143,6 +143,8 @@ private slots:
     void switchDisplayMode();
     void updateGroupData();
 	void createMsg();
+	void editPost();
+	void togglePinPost();
 	void subscribeGroup(bool subscribe);
 	void settingsChanged();
 	void postPostLoad();

--- a/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
@@ -455,10 +455,17 @@ class PostSorter
 {
 public:
 
-    PostSorter(RsPostedPostsModel::SortingStrategy s) : mSortingStrategy(s) {}
+    PostSorter(RsPostedPostsModel::SortingStrategy s, const std::set<RsGxsMessageId>& pinnedPosts)
+        : mSortingStrategy(s), mPinnedPosts(pinnedPosts) {}
 
 	bool operator()(const RsPostedPost& p1,const RsPostedPost& p2) const
 	{
+        bool p1_pinned = mPinnedPosts.count(p1.mMeta.mMsgId) > 0;
+        bool p2_pinned = mPinnedPosts.count(p2.mMeta.mMsgId) > 0;
+
+        if(p1_pinned != p2_pinned)
+            return p1_pinned;
+
         switch(mSortingStrategy)
         {
         default:
@@ -470,6 +477,7 @@ public:
 
 private:
     RsPostedPostsModel::SortingStrategy mSortingStrategy;
+    const std::set<RsGxsMessageId>& mPinnedPosts;
 };
 
 Qt::ItemFlags RsPostedPostsModel::flags(const QModelIndex& index) const
@@ -485,7 +493,7 @@ void RsPostedPostsModel::setSortingStrategy(RsPostedPostsModel::SortingStrategy 
     preMods();
 
     mSortingStrategy = s;
-    std::sort(mPosts.begin(),mPosts.end(), PostSorter(s));
+    std::sort(mPosts.begin(),mPosts.end(), PostSorter(s, mPostedGroup.mPinnedPosts.ids));
 
 	postMods();
 }
@@ -539,7 +547,7 @@ void RsPostedPostsModel::setPosts(const RsPostedGroup& group, std::vector<RsPost
 
 	createPostsArray(posts);
 
-	std::sort(mPosts.begin(),mPosts.end(), PostSorter(mSortingStrategy));
+	std::sort(mPosts.begin(),mPosts.end(), PostSorter(mSortingStrategy, mPostedGroup.mPinnedPosts.ids));
 
 	uint32_t tmpval;
 	setFilter(QStringList(),tmpval);


### PR DESCRIPTION
This pull request introduces significant enhancements to the board/posted system in the RetroShare GUI, focusing on post editing capabilities, pinning/unpinning posts, and improving the user interface for managing posts. The most important changes are summarized below:

**Editing and Creating Posts:**

* Added support for editing existing posts: a new `editPost()` slot and context menu action allow users to edit posts. The dialog is pre-filled with the original post's data and uses a new `setOrigPostId()` method to enable edit mode. The backend now calls the new `createPostV2()` API, passing the original post ID to support editing. [[1]](diffhunk://#diff-39983bbfe0420b1509f1e8747d6083eef5f775fc701a9d31fd3b43811087a8eeR837-R877) [[2]](diffhunk://#diff-3d533bfe79bb62cb4912f901b42704aa13deb4f836867a417fc591db1b4a8a46R48-R50) [[3]](diffhunk://#diff-3d533bfe79bb62cb4912f901b42704aa13deb4f836867a417fc591db1b4a8a46R74) [[4]](diffhunk://#diff-e80504542f7ba2412f87f1778f8c973a105c60942ce5587810769fd62e2bfd7eR138-R144) [[5]](diffhunk://#diff-e80504542f7ba2412f87f1778f8c973a105c60942ce5587810769fd62e2bfd7eL163-R205) [[6]](diffhunk://#diff-0cfdfb6e449b3f9e28b41154a745b349c551297bb7d611e835aa7286616009e9R146-R147)

**Pinning/Unpinning Posts:**

* Added the ability for group admins to pin or unpin posts from the context menu. The pinned state is toggled and persisted via `editBoard()`. The post sorting logic was updated so pinned posts are always shown at the top. [[1]](diffhunk://#diff-39983bbfe0420b1509f1e8747d6083eef5f775fc701a9d31fd3b43811087a8eeL360-R369) [[2]](diffhunk://#diff-39983bbfe0420b1509f1e8747d6083eef5f775fc701a9d31fd3b43811087a8eeR837-R877) [[3]](diffhunk://#diff-4a562fc7c8456c008a6dd68fad6f97f471882a940a277d208c09bd96f566b481L458-R468) [[4]](diffhunk://#diff-4a562fc7c8456c008a6dd68fad6f97f471882a940a277d208c09bd96f566b481R480) [[5]](diffhunk://#diff-4a562fc7c8456c008a6dd68fad6f97f471882a940a277d208c09bd96f566b481L488-R496) [[6]](diffhunk://#diff-4a562fc7c8456c008a6dd68fad6f97f471882a940a277d208c09bd96f566b481L542-R550) [[7]](diffhunk://#diff-0cfdfb6e449b3f9e28b41154a745b349c551297bb7d611e835aa7286616009e9R146-R147)

**Refactoring and Clean-up:**

* Refactored post creation logic to improve clarity: separated variables for title, link, and notes, and streamlined error handling to provide more informative messages to the user.
* Removed redundant `#include <QBuffer>` and improved includes for clarity and correctness. [[1]](diffhunk://#diff-e80504542f7ba2412f87f1778f8c973a105c60942ce5587810769fd62e2bfd7eL21) [[2]](diffhunk://#diff-e80504542f7ba2412f87f1778f8c973a105c60942ce5587810769fd62e2bfd7eL41-R45)

**Dependency Update:**

* Updated the `libretroshare` submodule to point to a new repository and branch, to pick up new features required for post editing and pinning. (.gitmodules)

* Depends on RetroShare/libretroshare#282

closes #1721 
