### PR TITLE
closes #1721 , add stick posts UI for boards

### DIFF
--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
@@ -364,6 +364,9 @@ void PostedListWidgetWithModel::postContextMenu(const QPoint& point)
         menu.addAction(FilesDefs::getIconFromQtResourcePath(":/images/edit_16.png"), tr("Edit"), this, SLOT(editPost()));
 #endif
 
+   if(IS_GROUP_PUBLISHER(mGroup.mMeta.mSubscribeFlags))
+        menu.addAction(QIcon(":/images/pin.png"), tr("Pin to top"), this, SLOT(pinPost()))->setData(index);
+
     menu.exec(QCursor::pos());
 }
 
@@ -526,6 +529,19 @@ void PostedListWidgetWithModel::copyMessageLink()
     {
         QMessageBox::critical(NULL,tr("Link creation error"),tr("Link could not be created: ")+e.what());
     }
+}
+void PostedListWidgetWithModel::pinPost()
+{
+    QModelIndex index = qobject_cast<QAction*>(QObject::sender())->data().toModelIndex();
+    if(!index.isValid())
+        return;
+
+    RsPostedPost post = index.data(Qt::UserRole).value<RsPostedPost>();
+    if(post.mMeta.mMsgId.isNull())
+        return;
+
+    bool currently_pinned = mGroup.mPinnedPosts.count(post.mMeta.mMsgId) > 0;
+    rsPosted->pinPost(groupId(), post.mMeta.mMsgId, !currently_pinned);
 }
 
 #ifdef TODO

--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
@@ -137,6 +137,7 @@ private slots:
 	void showPostDetails();
 #endif
     void postContextMenu(const QPoint&);
+    void pinPost();
     void showAuthorInPeople();
     void tabCloseRequested(int index);
     void updateSorting(int);

--- a/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
@@ -486,6 +486,7 @@ void RsPostedPostsModel::setSortingStrategy(RsPostedPostsModel::SortingStrategy 
 
     mSortingStrategy = s;
     std::sort(mPosts.begin(),mPosts.end(), PostSorter(s));
+    std::stable_partition(mPosts.begin(),mPosts.end(),[this](const RsPostedPost& p){ return mPostedGroup.mPinnedPosts.count(p.mMeta.mMsgId) > 0; });
 
 	postMods();
 }
@@ -540,6 +541,7 @@ void RsPostedPostsModel::setPosts(const RsPostedGroup& group, std::vector<RsPost
 	createPostsArray(posts);
 
 	std::sort(mPosts.begin(),mPosts.end(), PostSorter(mSortingStrategy));
+    std::stable_partition(mPosts.begin(),mPosts.end(),[this](const RsPostedPost& p){ return mPostedGroup.mPinnedPosts.count(p.mMeta.mMsgId) > 0; });
 
 	uint32_t tmpval;
 	setFilter(QStringList(),tmpval);


### PR DESCRIPTION
closes RetroShare/RetroShare#1721

so this implements the pin/stick posts thing for boards. basically right click any post → "Pin to top" and it stays at the top regardless of what sorting you pick. works the same way forums already does it with mPinnedPosts, just ported over to posted.

whats changed:
- stable_partition after sort in PostedPostsModel so pinned posts float to top
- pinPost() slot wired to context menu
- mPinnedPosts field added to mPostedGroup, reads from there in the model

tested manually, pin/unpin works and survives sort changes. not 100% sure how it behaves with like 5+ pinned posts at once but basic flow seems solid. lmk if i missed anything

ref: https://github.com/RetroShare/RetroShare/issues/2802