### PR TITLE
gui: add latest channel content to HomePage V2 (closes #1424)

### DIFF
--- a/retroshare-gui/src/gui/HomePage.cpp
+++ b/retroshare-gui/src/gui/HomePage.cpp
@@ -25,14 +25,15 @@
 
 #include "util/qtthreadsutils.h"
 #include "util/misc.h"
+#include "util/DateTime.h"
 
 #include "gui/common/FilesDefs.h"
 #include "gui/msgs/MessageComposer.h"
 #include "gui/connect/ConnectFriendWizard.h"
 #include "gui/connect/ConfCertDialog.h"
-#include <gui/QuickStartWizard.h>
 #include "gui/connect/FriendRecommendDialog.h"
 #include "settings/rsharesettings.h"
+#include "retroshare/rsgxschannels.h"
 
 #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 #include <QUrlQuery>
@@ -393,6 +394,7 @@ void HomePage::showEvent(QShowEvent *event)
 {
 	if (!event->spontaneous()) {
 		updateHomeLogo();
+		loadChannelContent();
 	}
 }
 
@@ -402,4 +404,83 @@ void HomePage::updateHomeLogo()
 		ui->label->setPixmap(FilesDefs::getPixmapFromQtResourcePath(":images/logo/logo_web_nobackground_black.png"));
 	else
 		ui->label->setPixmap(FilesDefs::getPixmapFromQtResourcePath(":images/logo/logo_web_nobackground.png"));
+}
+
+void HomePage::loadChannelContent()
+{
+	if(!rsGxsChannels)
+		return;
+
+	// Get all subscribed channels
+	std::list<RsGroupMetaData> channelSummaries;
+	if(!rsGxsChannels->getChannelsSummaries(channelSummaries))
+		return;
+
+	QWidget *channelWidget = ui->channelContentWidget;
+	QVBoxLayout *layout = qobject_cast<QVBoxLayout *>(channelWidget->layout());
+	if(!layout)
+	{
+		mChannelContentLayout = new QVBoxLayout(channelWidget);
+		layout = mChannelContentLayout;
+	}
+
+	// Clear existing items (except label and spacer)
+	while(layout->count() > 2)
+	{
+		QLayoutItem *item = layout->takeAt(1);
+		if(item->widget())
+			delete item->widget();
+		delete item;
+	}
+
+	std::vector<RsGxsChannelGroup> groups;
+	std::vector<RsGxsChannelPost> posts;
+	std::vector<RsGxsComment> comments;
+	std::vector<RsGxsVote> votes;
+
+	int itemCount = 0;
+	const int MAX_ITEMS = 10;
+
+	for(const auto &summary : channelSummaries)
+	{
+		if(itemCount >= MAX_ITEMS)
+			break;
+
+		if(!IS_GROUP_SUBSCRIBED(summary.mSubscribeFlags))
+			continue;
+
+
+		RsGxsGroupId grpId(summary.mGroupId);
+
+		// Get latest post for this channel
+		std::vector<RsGxsChannelPost> channelPosts;
+		std::vector<RsGxsComment> channelComments;
+		std::vector<RsGxsVote> channelVotes;
+
+		if(!rsGxsChannels->getChannelContent(grpId, std::set<RsGxsMessageId>(), channelPosts, channelComments, channelVotes))
+			continue;
+
+		if(channelPosts.empty())
+			continue;
+
+		// Get most recent post
+		RsGxsChannelPost mostRecentPost = channelPosts[0];
+		for(const auto &post : channelPosts)
+		{
+			if(post.mMeta.mPublishTs > mostRecentPost.mMeta.mPublishTs)
+				mostRecentPost = post;
+		}
+
+		// Create a simple label for each post
+		QLabel *postLabel = new QLabel(channelWidget);
+		QString title = QString::fromUtf8(mostRecentPost.mMeta.mMsgName.c_str());
+		QString channelName = QString::fromUtf8(summary.mGroupName.c_str());
+		QString timestamp = DateTime::formatDateTime(DateTime::DateTimeFromTime_t(mostRecentPost.mMeta.mPublishTs));
+
+		postLabel->setText(QString("<b>%1</b> - %2<br/><font color='gray'>%3</font>").arg(channelName, title, timestamp));
+		postLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+		layout->insertWidget(layout->count() - 1, postLabel);
+
+		itemCount++;
+	}
 }

--- a/retroshare-gui/src/gui/HomePage.h
+++ b/retroshare-gui/src/gui/HomePage.h
@@ -24,9 +24,10 @@
 #include <retroshare-gui/mainpage.h>
 #include <retroshare/rsfiles.h>
 #include <retroshare/rspeers.h>
+#include <retroshare/rsgxschannels.h>
 
 #include <QWidget>
-
+#include <QVBoxLayout>
 
 class QAction;
 
@@ -67,6 +68,7 @@ private slots:
 	void openWebHelp() ;
 	void recommendFriends();
 	void updateHomeLogo();
+	void loadChannelContent();
 
 private:
 	Ui::HomePage *ui;
@@ -80,6 +82,8 @@ private:
     RsEventsHandlerId_t mEventHandlerId;
 
     void handleEvent(std::shared_ptr<const RsEvent> event);
+
+    QVBoxLayout *mChannelContentLayout;
 };
 
 #endif // HomePage_H

--- a/retroshare-gui/src/gui/HomePage.ui
+++ b/retroshare-gui/src/gui/HomePage.ui
@@ -325,6 +325,63 @@ private and secure decentralized communication platform.
     </widget>
    </item>
    <item row="5" column="1" colspan="3">
+    <widget class="QScrollArea" name="channelContentScroll">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <property name="objectName">
+      <string>channelContentScroll</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <widget class="QWidget" name="channelContentWidget">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>680</width>
+        <height>200</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="channelContentLayout">
+       <item>
+        <widget class="QLabel" name="channelContentLabel">
+         <property name="text">
+          <string>Latest Channel Content</string>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="channelContentSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="3">
     <widget class="QFrame" name="helpframe">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">


### PR DESCRIPTION
## Description
Adds a new section to HomePage showing the latest posts from subscribed channels, similar to YouTube home page.

## Changes
- Added QScrollArea with channel content widget to HomePage.ui
- Added loadChannelContent() method that:
  - Gets subscribed channels via getChannelsSummaries()
  - Fetches latest posts via getChannelContent()
  - Displays up to 10 most recent posts with channel name, title, and timestamp
- Called on showEvent to refresh when page is displayed

## Testing
- Built on Linux (Qt-based)
- HomePage shows new section for latest channel content

## Related Issue
Closes #1424 - Home V2 Display the latest Channel content