### PR TITLE
Fix FeedReader: truncate oversized feed messages to prevent deserialization failure on startup

### DIFF
--- a/plugins/FeedReader/services/p3FeedReader.cc
+++ b/plugins/FeedReader/services/p3FeedReader.cc
@@ -1314,6 +1314,7 @@ bool p3FeedReader::retransformMsg(uint32_t feedId, const std::string &msgId)
 		std::string errorString;
 		std::string descriptionTransformed = mi->descriptionTransformed;
 		if (p3FeedReaderThread::processTransformation(*fi, mi, errorString) == RS_FEED_ERRORSTATE_OK) {
+			RsFeedReaderSerialiser::correctMsgSize(mi);
 			if (mi->descriptionTransformed != descriptionTransformed) {
 				msgChanged = true;
 			}
@@ -1609,8 +1610,11 @@ bool p3FeedReader::saveList(bool &cleanup, std::list<RsItem *> &saveData)
 			RsFeedReaderMsg *msg = it2->second;
 
 			if (cleanup) {
-				saveData.push_back(new RsFeedReaderMsg(*msg));
+				RsFeedReaderMsg *clonedMsg = new RsFeedReaderMsg(*msg);
+				RsFeedReaderSerialiser::correctMsgSize(clonedMsg);
+				saveData.push_back(clonedMsg);
 			} else {
+				RsFeedReaderSerialiser::correctMsgSize(msg);
 				saveData.push_back(msg);
 			}
 		}
@@ -2125,6 +2129,7 @@ void p3FeedReader::onProcessSuccess_addMsgs(uint32_t feedId, std::list<RsFeedRea
 					miNew->flag = RS_FEEDMSG_FLAG_NEW;
 					addedMsgs.push_back(miNew->msgId);
 				}
+				RsFeedReaderSerialiser::correctMsgSize(miNew);
 				fi->msgs[miNew->msgId] = miNew;
 				newMsgIt = msgs.erase(newMsgIt);
 

--- a/plugins/FeedReader/services/rsFeedReaderItems.cc
+++ b/plugins/FeedReader/services/rsFeedReaderItems.cc
@@ -284,8 +284,10 @@ std::ostream &RsFeedReaderMsg::print(std::ostream &out, uint16_t /*indent*/)
 	return out;
 }
 
-uint32_t RsFeedReaderSerialiser::sizeMsg(RsFeedReaderMsg *item)
+void RsFeedReaderSerialiser::correctMsgSize(RsFeedReaderMsg *item)
 {
+	if (!item) return;
+
 	uint32_t s = 8; /* header */
 	s += 2; /* version */
 	s += GetTlvStringSize(item->msgId);
@@ -326,23 +328,26 @@ uint32_t RsFeedReaderSerialiser::sizeMsg(RsFeedReaderMsg *item)
 					}
 				}
 			}
-			/* Re-calculate the size after modification */
-			s = 8;
-			s += 2;
-			s += GetTlvStringSize(item->msgId);
-			s += sizeof(uint32_t);
-			s += GetTlvStringSize(item->title);
-			s += GetTlvStringSize(item->link);
-			s += GetTlvStringSize(item->author);
-			s += GetTlvStringSize(item->description);
-			s += GetTlvStringSize(item->descriptionTransformed);
-			s += sizeof(uint32_t);
-			s += sizeof(uint32_t);
-			s += GetTlvStringSize(item->attachmentLink);
-			s += GetTlvStringSize(item->attachment);
-			s += GetTlvStringSize(item->attachmentMimeType);
 		}
 	}
+}
+
+uint32_t RsFeedReaderSerialiser::sizeMsg(RsFeedReaderMsg *item)
+{
+	uint32_t s = 8; /* header */
+	s += 2; /* version */
+	s += GetTlvStringSize(item->msgId);
+	s += sizeof(uint32_t);
+	s += GetTlvStringSize(item->title);
+	s += GetTlvStringSize(item->link);
+	s += GetTlvStringSize(item->author);
+	s += GetTlvStringSize(item->description);
+	s += GetTlvStringSize(item->descriptionTransformed);
+	s += sizeof(uint32_t); /* pubDate */
+	s += sizeof(uint32_t); /* flag */
+	s += GetTlvStringSize(item->attachmentLink);
+	s += GetTlvStringSize(item->attachment);
+	s += GetTlvStringSize(item->attachmentMimeType);
 
 	return s;
 }

--- a/plugins/FeedReader/services/rsFeedReaderItems.cc
+++ b/plugins/FeedReader/services/rsFeedReaderItems.cc
@@ -301,6 +301,49 @@ uint32_t RsFeedReaderSerialiser::sizeMsg(RsFeedReaderMsg *item)
 	s += GetTlvStringSize(item->attachment);
 	s += GetTlvStringSize(item->attachmentMimeType);
 
+	uint32_t sizeLimit = RsSerialiser::MAX_SERIAL_SIZE - 2000;
+	if (s > sizeLimit) {
+		uint32_t baseSize = s - GetTlvStringSize(item->description) - GetTlvStringSize(item->descriptionTransformed);
+		if (baseSize < sizeLimit) {
+			uint32_t allowedTextSize = sizeLimit - baseSize;
+			std::string warning = "<p style='color: #d9534f; font-weight: bold; font-size: 1.1em;'>[Warning: This message has been truncated by RetroShare because its size exceeded the 256 KB safety limit.]</p><br/>";
+			uint32_t neededSpace = warning.size() + 100;
+			if (item->descriptionTransformed.empty()) {
+				if (item->description.size() > allowedTextSize) {
+					if (allowedTextSize > neededSpace) {
+						item->description = warning + item->description.substr(0, allowedTextSize - neededSpace) + "... [TRUNCATED]";
+					} else {
+						item->description = item->description.substr(0, allowedTextSize - 100) + "... [TRUNCATED]";
+					}
+				}
+			} else {
+				item->description.clear();
+				if (item->descriptionTransformed.size() > allowedTextSize) {
+					if (allowedTextSize > neededSpace) {
+						item->descriptionTransformed = warning + item->descriptionTransformed.substr(0, allowedTextSize - neededSpace) + "... [TRUNCATED]";
+					} else {
+						item->descriptionTransformed = item->descriptionTransformed.substr(0, allowedTextSize - 100) + "... [TRUNCATED]";
+					}
+				}
+			}
+			/* Re-calculate the size after modification */
+			s = 8;
+			s += 2;
+			s += GetTlvStringSize(item->msgId);
+			s += sizeof(uint32_t);
+			s += GetTlvStringSize(item->title);
+			s += GetTlvStringSize(item->link);
+			s += GetTlvStringSize(item->author);
+			s += GetTlvStringSize(item->description);
+			s += GetTlvStringSize(item->descriptionTransformed);
+			s += sizeof(uint32_t);
+			s += sizeof(uint32_t);
+			s += GetTlvStringSize(item->attachmentLink);
+			s += GetTlvStringSize(item->attachment);
+			s += GetTlvStringSize(item->attachmentMimeType);
+		}
+	}
+
 	return s;
 }
 
@@ -362,7 +405,9 @@ RsFeedReaderMsg *RsFeedReaderSerialiser::deserialiseMsg(void *data, uint32_t *pk
 	}
 
 	if (*pktsize < rssize)    /* check size */
+	{
 		return NULL; /* not enough data */
+	}
 
 	/* set the packet length */
 	*pktsize = rssize;

--- a/plugins/FeedReader/services/rsFeedReaderItems.h
+++ b/plugins/FeedReader/services/rsFeedReaderItems.h
@@ -146,6 +146,8 @@ public:
 	virtual	bool     serialise(RsItem *item, void *data, uint32_t *size);
 	virtual	RsItem  *deserialise(void *data, uint32_t *size);
 
+	static void correctMsgSize(RsFeedReaderMsg *item);
+
 private:
 	/* For RS_PKT_SUBTYPE_FEEDREADER_FEED */
 	virtual uint32_t         sizeFeed(RsFeedReaderFeed *item);


### PR DESCRIPTION
Fix FeedReader: truncate oversized feed messages to prevent deserialization failure on startup

Issue Summary: Oversized RSS Feed Posts Disappearing on Startup

Bug
In FeedReader plugin subscribe to https://ubuntu.com/blog/feed
Notice this post: https://ubuntu.com//blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon
Notice that after restart this post is missing, and after manual or automatic update it appears again as new

Root Cause
When an RSS feed post is exceptionally large (e.g., > 256 KB due to rich HTML content or embedded base64 images), it is successfully serialized and written to feedreader.cfg at shutdown. However, during startup, the deserializer rejects any item exceeding RsSerialiser::MAX_SERIAL_SIZE (strictly capped at 256 KB for network safety limits), throwing a deserialization failure and discarding the post. Since the post is missing from memory on startup, RetroShare re-downloads it as a brand-new unread post upon the next feed update, creating an endless cycle of disappearing and reappearing unread posts.

Solution
In RsFeedReaderSerialiser::sizeMsg, we now check if the serialized message size exceeds the MAX_SERIAL_SIZE limit. If it does, we cleanly truncate the description (or descriptionTransformed) so that the item fits perfectly under the safety limit, and prepend a stylized warning informing the user:

[Warning: This message has been truncated by RetroShare because its size exceeded the 256 KB safety limit.]

This ensures the post is successfully loaded on startup, preventing it from disappearing and endlessly resetting its read/unread status.