### PR TITLE
gui: Fix forum read status refresh issues by updating all columns and correcting parent loop

### DIFF
--- a/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
@@ -877,10 +877,9 @@ void RsGxsForumModel::setMsgReadStatus(const QModelIndex& i,bool read_status,boo
 
     // also emit dataChanged() for parents since they need to re-draw
 
-    for(QModelIndex j = i.parent(); j.isValid(); j=j.parent())
+    for(QModelIndex j = i.parent(); j.isValid(); j = j.parent())
     {
-        emit dataChanged(j,j);
-        j = j.parent();
+        emit dataChanged(j, j.sibling(j.row(), COLUMN_THREAD_NB_COLUMNS - 1));
     }
 }
 
@@ -917,7 +916,7 @@ void RsGxsForumModel::recursSetMsgReadStatus(ForumModelIndex i,bool read_status,
         convertTabEntryToRefPointer(i,ref);	// we dont use i+1 here because i is not a row, but an index in the mPosts tab
 
         QModelIndex itemIndex = (mTreeMode == TREE_MODE_FLAT)?createIndex(i - 1, 0, ref):createIndex(mPosts[i].prow,0,ref);
-        emit dataChanged(itemIndex, itemIndex);
+        emit dataChanged(itemIndex, itemIndex.sibling(itemIndex.row(), COLUMN_THREAD_NB_COLUMNS - 1));
 	}
 
 	if(!with_children)


### PR DESCRIPTION
gui: Fix forum read status refresh issues by updating all columns and correcting parent loop

Fix the following bug: 
When performing a "mark all as read" operation in a forum, only the Title column is grayed, other columns remain bold 

This PR also fixes a bug in the parent loop that in some cases would cause some parents to stay transiently semi-bold when the last unread children was read. The bug is not easy to reproduce but is obvious in the code.