### PR TITLE
Fix FeedReader text truncation on Windows MSYS2 by forcing UTF-8 and improving XML extraction

### DIFF
--- a/plugins/FeedReader/util/HTMLWrapper.cpp
+++ b/plugins/FeedReader/util/HTMLWrapper.cpp
@@ -32,7 +32,7 @@ bool HTMLWrapper::readHTML(const char *html, const char *url)
 	cleanup();
 
 	handleError(true, mLastErrorString);
-	mDocument = htmlReadMemory(html, strlen(html), url, "", /*HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | */HTML_PARSE_COMPACT | HTML_PARSE_NONET | HTML_PARSE_NOBLANKS);
+	mDocument = htmlReadMemory(html, strlen(html), url, "UTF-8", /*HTML_PARSE_NOERROR | HTML_PARSE_NOWARNING | */HTML_PARSE_COMPACT | HTML_PARSE_NONET | HTML_PARSE_NOBLANKS);
 	handleError(false, mLastErrorString);
 
 	if (mDocument) {

--- a/plugins/FeedReader/util/XMLWrapper.cpp
+++ b/plugins/FeedReader/util/XMLWrapper.cpp
@@ -327,6 +327,10 @@ bool XMLWrapper::getChildText(xmlNodePtr node, const char *childName, std::strin
 		return nodeDump(div, text, true);
 	}
 
+	if (child->children->type != XML_TEXT_NODE) {
+		return false;
+	}
+
 	return getContent(child, text, false);
 }
 

--- a/plugins/FeedReader/util/XMLWrapper.cpp
+++ b/plugins/FeedReader/util/XMLWrapper.cpp
@@ -124,42 +124,24 @@ void XMLWrapper::attach(xmlDocPtr document)
 
 bool XMLWrapper::convertToString(const xmlChar *xmlText, std::string &text)
 {
-	bool result = false;
-
-	xmlBufferPtr in = xmlBufferCreateStatic((void*) xmlText, xmlStrlen(xmlText));
-	xmlBufferPtr out = xmlBufferCreate();
-	int ret = xmlCharEncOutFunc(mCharEncodingHandler, out, in);
-	if (ret >= 0) {
-		result = true;
-		text = (char*) xmlBufferContent(out);
+	if (!xmlText) {
+		text.clear();
+		return false;
 	}
 
-	xmlBufferFree(in);
-	xmlBufferFree(out);
-
-	return result;
+	text = (const char*) xmlText;
+	return true;
 }
 
 bool XMLWrapper::convertFromString(const char *text, xmlChar *&xmlText)
 {
-	bool result = false;
-
-	xmlBufferPtr in = xmlBufferCreateStatic((void*) text, strlen(text));
-	xmlBufferPtr out = xmlBufferCreate();
-	int ret = xmlCharEncInFunc(mCharEncodingHandler, out, in);
-	if (ret >= 0) {
-		result = true;
-#if LIBXML_VERSION >= 20800
-		xmlText = xmlBufferDetach(out);
-#else
-		xmlText = xmlStrdup(xmlBufferContent(out));
-#endif
+	if (!text) {
+		xmlText = NULL;
+		return false;
 	}
 
-	xmlBufferFree(in);
-	xmlBufferFree(out);
-
-	return result;
+	xmlText = xmlStrdup(BAD_CAST text);
+	return xmlText != NULL;
 }
 
 xmlDocPtr XMLWrapper::getDocument() const
@@ -345,15 +327,7 @@ bool XMLWrapper::getChildText(xmlNodePtr node, const char *childName, std::strin
 		return nodeDump(div, text, true);
 	}
 
-	if (child->children->type != XML_TEXT_NODE) {
-		return false;
-	}
-
-	if (child->children->content) {
-		return convertToString(child->children->content, text);
-	}
-
-	return true;
+	return getContent(child, text, false);
 }
 
 std::string XMLWrapper::getAttr(xmlNodePtr node, xmlAttrPtr attr)

--- a/plugins/FeedReader/util/XMLWrapper.cpp
+++ b/plugins/FeedReader/util/XMLWrapper.cpp
@@ -327,10 +327,6 @@ bool XMLWrapper::getChildText(xmlNodePtr node, const char *childName, std::strin
 		return nodeDump(div, text, true);
 	}
 
-	if (child->children->type != XML_TEXT_NODE) {
-		return false;
-	}
-
 	return getContent(child, text, false);
 }
 


### PR DESCRIPTION
Fix FeedReader text truncation on Windows MSYS2 by forcing UTF-8 and improving XML extraction

Description:
This PR fixes a bug where FeedReader messages were being truncated when containing special characters, most notably smart quotes (curly quotes).
The bug exists on all Windows MSYS2 build, including recent builds published by Thunder on his dedicated channel
When a post has a "<anything here>" sequence it is troncated just before the second " and �� are displayed instead
Check feed ubuntu.com/blog/feed at post https://ubuntu.com//blog/rethinking-byod-security-protecting-data-without-trusting-devices
The issue was specifically triggered in Windows MSYS2 builds, where libxml2 failed to correctly detect the encoding when left unspecified. This caused the parser to abort immediately upon encountering non-ASCII UTF-8 bytes, resulting in truncated posts.

Key Changes:
Forced UTF-8 encoding in HTMLWrapper to ensure libxml2 correctly processes special characters regardless of the system's locale/environment.
Improved XML text extraction in XMLWrapper by aggregating all child text nodes instead of just the first one, ensuring full content integrity.
Cleaned up string conversion logic to prevent memory leaks and unnecessary encoding round-trips.



 