### PR TITLE
C make migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,10 @@ if(RS_USE_I2P_SAM3)
     add_subdirectory(supportlibs/libsam3 EXCLUDE_FROM_ALL)
 endif()
 
+if(RS_BROADCAST_DISCOVERY)
+    add_subdirectory(supportlibs/udp-discovery-cpp EXCLUDE_FROM_ALL)
+endif()
+
 if(RS_JSON_API)
     # Disable restbed tests/examples and build as static library
     set(BUILD_TESTS OFF CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,115 @@
+cmake_minimum_required(VERSION 3.18)
+project(RetroShare)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# --- Versioning ---
+find_package(Git REQUIRED)
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE RS_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "RetroShare Version: ${RS_VERSION}")
+
+# --- Options (Ported from retroshare.pri) ---
+option(RS_LIBRETROSHARE_STATIC "Build RetroShare static library" ON)
+option(RS_LIBRETROSHARE_SHARED "Build RetroShare shared library" OFF)
+option(RS_DEVELOPMENT_BUILD "Enable development build (no optimization)" ON)
+option(RS_BITDHT "Enable BitDHT support" ON)
+option(RS_SQLCIPHER "Enable SQLCipher support" ON)
+option(RS_RNPLIB "Use RNP for PGP (recommended)" ON)
+option(RS_JSON_API "Enable JSON API" OFF)
+option(RS_WEBUI "Enable Web UI" OFF)
+option(RS_USE_I2P_SAM3 "Enable I2P SAMv3 support" ON)
+option(RS_GXS "Enable GXS (General eXchange System)" ON)
+option(RS_GXSGUI      "Enable GXS services in GUI" ON)
+option(RS_GXSCHANNELS "Enable GXS channels in GUI" ON)
+option(RS_GXSFORUMS   "Enable GXS forums in GUI"   ON)
+option(RS_GXSPOSTED   "Enable GXS posted in GUI"   ON)
+option(RS_GXSCIRCLES  "Enable GXS circles in GUI"  ON)
+option(RS_GXSWIKIPOS  "Enable GXS wiki"            OFF)
+option(RS_GXSTHEWIRE  "Enable GXS wire"            OFF)
+option(RS_GXSPHOTOSHARE "Enable GXS PhotoShare"    OFF)
+option(RS_GXSIDENTITIES "Enable GXS identities in GUI" ON)
+option(RS_BROADCAST_DISCOVERY "Enable broadcast discovery" ON)
+option(RS_GUI "Build RetroShare GUI" ON)
+option(RS_SERVICE "Build RetroShare Service" ON)
+option(RS_PLUGINS "Enable plugins support" OFF)
+option(RS_WARN_DEPRECATED "Show deprecated warnings" OFF)
+
+option(RS_MESSENGER "Enable Messenger Window" ON)
+option(RS_IDLE      "Enable Idle support"     ON)
+
+if(RS_USE_I2P_SAM3)
+    add_definitions(-DRS_USE_I2P_SAM3)
+endif()
+
+if(RS_GXSWIKIPOS)
+    add_definitions(-DRS_USE_WIKI)
+endif()
+
+if(RS_GXSTHEWIRE)
+    add_definitions(-DRS_USE_WIRE)
+endif()
+
+if(RS_GXSPHOTOSHARE)
+    add_definitions(-DRS_USE_PHOTO)
+endif()
+
+# --- Dependencies ---
+find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
+
+if(RS_GUI)
+    find_package(Qt5 COMPONENTS Core Widgets Gui Network Xml PrintSupport Multimedia REQUIRED)
+    find_package(Qt5 COMPONENTS LinguistTools QUIET)
+    # Note: We can add Qt6 support later as in the .pro files
+endif()
+
+if(RS_SQLCIPHER)
+    # We will need to find sqlcipher properly, for now fallback to standard sqlite if not found
+    find_library(SQLCIPHER_LIBRARY NAMES sqlcipher)
+    if(NOT SQLCIPHER_LIBRARY)
+        message(WARNING "SQLCipher not found, falling back to SQLite3")
+        find_package(SQLite3 REQUIRED)
+    endif()
+else()
+    find_package(SQLite3 REQUIRED)
+endif()
+
+# --- Subdirectories ---
+# 1. Support libs (Librnp, etc.)
+if(RS_RNPLIB)
+    add_subdirectory(supportlibs/librnp EXCLUDE_FROM_ALL)
+endif()
+
+if(RS_JSON_API)
+    # Disable restbed tests/examples and build as static library
+    set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(BUILD_SSL ON CACHE BOOL "" FORCE)
+    set(BUILD_STATIC_LIBRARY ON CACHE BOOL "" FORCE)
+    set(BUILD_SHARED_LIBRARY OFF CACHE BOOL "" FORCE)
+    add_subdirectory(supportlibs/restbed EXCLUDE_FROM_ALL)
+endif()
+
+# 2. Core libs
+add_subdirectory(libbitdht)
+add_subdirectory(openpgpsdk)
+add_subdirectory(libretroshare)
+
+# 3. Executables
+if(RS_SERVICE)
+    add_subdirectory(retroshare-service)
+endif()
+
+if(RS_GUI)
+    add_subdirectory(retroshare-gui)
+endif()
+
+if(RS_PLUGINS)
+    add_subdirectory(plugins)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,8 @@ if(RS_RNPLIB)
 endif()
 
 if(RS_USE_I2P_SAM3)
-    add_subdirectory(supportlibs/libsam3 EXCLUDE_FROM_ALL)
+    add_library(sam3 STATIC supportlibs/libsam3/src/libsam3/libsam3.c)
+    target_include_directories(sam3 PUBLIC supportlibs/libsam3/src/libsam3)
 endif()
 
 if(RS_BROADCAST_DISCOVERY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,13 @@ project(RetroShare)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Global silence for deprecated warnings during migration
+add_compile_options(-Wno-deprecated-declarations -Wno-cpp)
+
 # --- Versioning ---
 find_package(Git REQUIRED)
+
+# 1. Get Root Version
 execute_process(
     COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -13,6 +18,41 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 message(STATUS "RetroShare Version: ${RS_VERSION}")
+
+# Parse Root Version (similar to libretroshare's logic but for root)
+set(V_GIT_DESCRIBE_REGEXP "^v([0-9]+).([0-9]+).([0-9]+)(.*)$")
+if(RS_VERSION MATCHES "${V_GIT_DESCRIBE_REGEXP}")
+    string(REGEX REPLACE "${V_GIT_DESCRIBE_REGEXP}" "\\1;\\2;\\3;\\4" V_GIT_DESCRIBE_LIST ${RS_VERSION})
+    list(GET V_GIT_DESCRIBE_LIST 0 MAJOR_V)
+    list(GET V_GIT_DESCRIBE_LIST 1 MINOR_V)
+    list(GET V_GIT_DESCRIBE_LIST 2 MINI_V)
+    list(GET V_GIT_DESCRIBE_LIST 3 EXTRA_V)
+    
+    set(RS_MAJOR_VERSION "${MAJOR_V}" CACHE STRING "Major version" FORCE)
+    set(RS_MINOR_VERSION "${MINOR_V}" CACHE STRING "Minor version" FORCE)
+    set(RS_MINI_VERSION  "${MINI_V}"  CACHE STRING "Mini version"  FORCE)
+    set(RS_EXTRA_VERSION "${EXTRA_V}" CACHE STRING "Extra version" FORCE)
+else()
+    # Fallback if tag format is different
+    set(RS_MAJOR_VERSION "0" CACHE STRING "Major version" FORCE)
+    set(RS_MINOR_VERSION "6" CACHE STRING "Minor version" FORCE)
+    set(RS_MINI_VERSION  "7" CACHE STRING "Mini version"  FORCE)
+    set(RS_EXTRA_VERSION "a-unknown" CACHE STRING "Extra version" FORCE)
+endif()
+
+# 2. Get LibRetroShare Version (for RS_LIB_VERSION_HASH)
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/libretroshare"
+    OUTPUT_VARIABLE RS_LIB_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT RS_LIB_VERSION)
+    set(RS_LIB_VERSION "[version not available]")
+endif()
+message(STATUS "libretroshare Version: ${RS_LIB_VERSION}")
+
 
 # --- Options (Ported from retroshare.pri) ---
 option(RS_LIBRETROSHARE_STATIC "Build RetroShare static library" ON)
@@ -84,6 +124,10 @@ endif()
 # 1. Support libs (Librnp, etc.)
 if(RS_RNPLIB)
     add_subdirectory(supportlibs/librnp EXCLUDE_FROM_ALL)
+endif()
+
+if(RS_USE_I2P_SAM3)
+    add_subdirectory(supportlibs/libsam3 EXCLUDE_FROM_ALL)
 endif()
 
 if(RS_JSON_API)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(RetroShare)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Global silence for deprecated warnings during migration
 add_compile_options(-Wno-deprecated-declarations -Wno-cpp)
@@ -77,7 +78,8 @@ option(RS_GXSIDENTITIES "Enable GXS identities in GUI" ON)
 option(RS_BROADCAST_DISCOVERY "Enable broadcast discovery" ON)
 option(RS_GUI "Build RetroShare GUI" ON)
 option(RS_SERVICE "Build RetroShare Service" ON)
-option(RS_PLUGINS "Enable plugins support" OFF)
+option(RS_FRIENDSERVER "Build RetroShare FriendServer" OFF)
+option(RS_PLUGINS "Enable plugins support" ON)
 option(RS_WARN_DEPRECATED "Show deprecated warnings" OFF)
 
 option(RS_MESSENGER "Enable Messenger Window" ON)
@@ -160,4 +162,8 @@ endif()
 
 if(RS_PLUGINS)
     add_subdirectory(plugins)
+endif()
+
+if(RS_FRIENDSERVER)
+    add_subdirectory(retroshare-friendserver)
 endif()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,7 @@
+# plugins/CMakeLists.txt
+cmake_minimum_required(VERSION 3.18)
+
+if(RS_GUI)
+    add_subdirectory(FeedReader)
+    add_subdirectory(VOIP)
+endif()

--- a/plugins/FeedReader/CMakeLists.txt
+++ b/plugins/FeedReader/CMakeLists.txt
@@ -1,0 +1,129 @@
+# plugins/FeedReader/CMakeLists.txt
+cmake_minimum_required(VERSION 3.18)
+project(FeedReaderPlugin)
+
+# --- Dependencies ---
+find_package(CURL REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
+pkg_check_modules(LIBXSLT REQUIRED libxslt)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+# --- Sources ---
+set(FEEDREADER_SOURCES
+    FeedReaderPlugin.cpp
+    services/p3FeedReader.cc
+    services/p3FeedReaderThread.cc
+    services/rsFeedReaderItems.cc
+    gui/FeedReaderDialog.cpp
+    gui/FeedReaderMessageWidget.cpp
+    gui/AddFeedDialog.cpp
+    gui/PreviewFeedDialog.cpp
+    gui/FeedReaderNotify.cpp
+    gui/FeedReaderConfig.cpp
+    gui/FeedReaderStringDefs.cpp
+    gui/FeedReaderFeedNotify.cpp
+    gui/FeedReaderUserNotify.cpp
+    gui/FeedReaderFeedItem.cpp
+    gui/FeedTreeWidget.cpp
+    gui/ProxyWidget.cpp
+    util/CURLWrapper.cpp
+    util/XMLWrapper.cpp
+    util/HTMLWrapper.cpp
+    util/XPathWrapper.cpp
+)
+
+set(FEEDREADER_FORMS
+    gui/FeedReaderDialog.ui
+    gui/FeedReaderMessageWidget.ui
+    gui/AddFeedDialog.ui
+    gui/PreviewFeedDialog.ui
+    gui/FeedReaderConfig.ui
+    gui/FeedReaderFeedItem.ui
+    gui/ProxyWidget.ui
+)
+
+set(FEEDREADER_RESOURCES
+    gui/FeedReader_images.qrc
+    lang/FeedReader_lang.qrc
+    qss/FeedReader_qss.qrc
+)
+
+# --- Translations (.ts -> .qm) ---
+file(GLOB TS_FILES "lang/*.ts")
+if(Qt5LinguistTools_FOUND)
+    qt5_add_translation(QM_FILES ${TS_FILES})
+else()
+    find_program(LRELEASE_EXECUTABLE NAMES lrelease-qt5 lrelease)
+    foreach(ts_file ${TS_FILES})
+        get_filename_component(ts_name ${ts_file} NAME_WE)
+        set(qm_src_file "${CMAKE_CURRENT_SOURCE_DIR}/lang/${ts_name}.qm")
+        set(qm_bin_file "${CMAKE_CURRENT_BINARY_DIR}/${ts_name}.qm")
+        
+        if(EXISTS ${qm_src_file})
+            list(APPEND QM_FILES ${qm_src_file})
+        elseif(LRELEASE_EXECUTABLE)
+            add_custom_command(
+                OUTPUT ${qm_bin_file}
+                COMMAND ${LRELEASE_EXECUTABLE} ${ts_file} -qm ${qm_bin_file}
+                DEPENDS ${ts_file}
+                VERBATIM
+            )
+            list(APPEND QM_FILES ${qm_bin_file})
+        endif()
+    endforeach()
+endif()
+
+# --- CTarget ---
+add_library(FeedReader MODULE
+    ${FEEDREADER_SOURCES}
+    ${FEEDREADER_FORMS}
+    ${FEEDREADER_RESOURCES}
+    ${QM_FILES}
+)
+
+set_target_properties(FeedReader PROPERTIES
+    PREFIX "lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins"
+    AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/gui"
+)
+
+# --- Links ---
+if(WIN32)
+    target_link_libraries(FeedReader PRIVATE retroshare)
+endif()
+
+target_link_libraries(FeedReader PRIVATE
+    Qt5::Core
+    Qt5::Widgets
+    Qt5::Xml
+    Qt5::Network
+    CURL::libcurl
+    ${LIBXML2_LIBRARIES}
+    ${LIBXSLT_LIBRARIES}
+)
+
+if(RS_DEVELOPMENT_BUILD)
+    target_compile_options(FeedReader PRIVATE "-g" "-O0")
+endif()
+
+# --- Includes ---
+target_include_directories(FeedReader PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/gui
+    ${CMAKE_CURRENT_SOURCE_DIR}/services
+    ${CMAKE_CURRENT_SOURCE_DIR}/interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/util
+    ${CMAKE_SOURCE_DIR}/libretroshare/src
+    ${CMAKE_SOURCE_DIR}/retroshare-gui/src
+    ${CMAKE_SOURCE_DIR}/retroshare-gui/src/gui
+    ${CMAKE_SOURCE_DIR}/supportlibs/rapidjson/include
+    ${LIBXML2_INCLUDE_DIRS}
+    ${LIBXSLT_INCLUDE_DIRS}
+)
+
+# --- Installation ---
+install(TARGETS FeedReader DESTINATION lib/retroshare/plugins)

--- a/plugins/VOIP/CMakeLists.txt
+++ b/plugins/VOIP/CMakeLists.txt
@@ -1,0 +1,129 @@
+# plugins/VOIP/CMakeLists.txt
+cmake_minimum_required(VERSION 3.18)
+project(VOIPPlugin)
+
+# --- Dependencies ---
+find_package(Qt5 COMPONENTS Multimedia REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(AVCODEC REQUIRED libavcodec)
+pkg_check_modules(AVUTIL REQUIRED libavutil)
+pkg_check_modules(SPEEX REQUIRED speex)
+pkg_check_modules(SPEEXDSP REQUIRED speexdsp)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+# --- Definitions ---
+add_definitions(-D__STDC_CONSTANT_MACROS)
+
+# --- Sources ---
+set(VOIP_SOURCES
+    VOIPPlugin.cpp
+    gui/VOIPConfigPanel.cpp
+    services/p3VOIP.cc
+    services/rsVOIPItems.cc
+    gui/AudioStats.cpp
+    gui/AudioWizard.cpp
+    gui/SpeexProcessor.cpp
+    gui/audiodevicehelper.cpp
+    gui/VideoProcessor.cpp
+    gui/QVideoDevice.cpp
+    gui/VOIPChatWidgetHolder.cpp
+    gui/VOIPGUIHandler.cpp
+    gui/VOIPNotify.cpp
+    gui/VOIPToasterItem.cpp
+    gui/VOIPToasterNotify.cpp
+)
+
+set(VOIP_FORMS
+    gui/AudioStats.ui
+    gui/AudioWizard.ui
+    gui/VOIPConfigPanel.ui
+    gui/VOIPToasterItem.ui
+)
+
+set(VOIP_RESOURCES
+    gui/VOIP_images.qrc
+    lang/VOIP_lang.qrc
+    qss/VOIP_qss.qrc
+)
+
+# --- Translations (.ts -> .qm) ---
+file(GLOB TS_FILES "lang/*.ts")
+if(Qt5LinguistTools_FOUND)
+    qt5_add_translation(QM_FILES ${TS_FILES})
+else()
+    find_program(LRELEASE_EXECUTABLE NAMES lrelease-qt5 lrelease)
+    foreach(ts_file ${TS_FILES})
+        get_filename_component(ts_name ${ts_file} NAME_WE)
+        set(qm_src_file "${CMAKE_CURRENT_SOURCE_DIR}/lang/${ts_name}.qm")
+        set(qm_bin_file "${CMAKE_CURRENT_BINARY_DIR}/${ts_name}.qm")
+        
+        if(EXISTS ${qm_src_file})
+            list(APPEND QM_FILES ${qm_src_file})
+        elseif(LRELEASE_EXECUTABLE)
+            add_custom_command(
+                OUTPUT ${qm_bin_file}
+                COMMAND ${LRELEASE_EXECUTABLE} ${ts_file} -qm ${qm_bin_file}
+                DEPENDS ${ts_file}
+                VERBATIM
+            )
+            list(APPEND QM_FILES ${qm_bin_file})
+        endif()
+    endforeach()
+endif()
+
+# --- Target ---
+add_library(VOIP MODULE
+    ${VOIP_SOURCES}
+    ${VOIP_FORMS}
+    ${VOIP_RESOURCES}
+    ${QM_FILES}
+)
+
+set_target_properties(VOIP PROPERTIES
+    PREFIX "lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins"
+    AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/gui"
+)
+
+# --- Links ---
+if(WIN32)
+    target_link_libraries(VOIP PRIVATE retroshare)
+endif()
+
+target_link_libraries(VOIP PRIVATE
+    Qt5::Core
+    Qt5::Widgets
+    Qt5::Multimedia
+    Qt5::Xml
+    Qt5::Network
+    ${AVCODEC_LIBRARIES}
+    ${AVUTIL_LIBRARIES}
+    ${SPEEX_LIBRARIES}
+    ${SPEEXDSP_LIBRARIES}
+)
+
+if(RS_DEVELOPMENT_BUILD)
+    target_compile_options(VOIP PRIVATE "-g" "-O0")
+endif()
+
+# --- Includes ---
+target_include_directories(VOIP PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/gui
+    ${CMAKE_CURRENT_SOURCE_DIR}/services
+    ${CMAKE_CURRENT_SOURCE_DIR}/interface
+    ${CMAKE_SOURCE_DIR}/libretroshare/src
+    ${CMAKE_SOURCE_DIR}/retroshare-gui/src
+    ${CMAKE_SOURCE_DIR}/retroshare-gui/src/gui
+    ${CMAKE_SOURCE_DIR}/supportlibs/rapidjson/include
+    ${AVCODEC_INCLUDE_DIRS}
+    ${AVUTIL_INCLUDE_DIRS}
+    ${SPEEX_INCLUDE_DIRS}
+    ${SPEEXDSP_INCLUDE_DIRS}
+)
+
+# --- Installation ---
+install(TARGETS VOIP DESTINATION lib/retroshare/plugins)

--- a/retroshare-friendserver/CMakeLists.txt
+++ b/retroshare-friendserver/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# retroshare-friendserver/CMakeLists.txt
+# ##############################################################################
+
+# project() and common options are inherited from the root CMakeLists.txt
+
+# --- Sources ---
+set(RS_FRIENDSERVER_SOURCES
+    src/retroshare-friendserver.cc
+    src/friendserver.cc
+    src/network.cc
+)
+
+# --- Executable ---
+add_executable(retroshare-friendserver ${RS_FRIENDSERVER_SOURCES})
+
+# --- Linkage ---
+# Linked to the retroshare library target defined in libretroshare/
+target_link_libraries(retroshare-friendserver PRIVATE retroshare)
+
+# --- Includes ---
+target_include_directories(retroshare-friendserver PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/libretroshare/src
+)
+
+# --- Development Debug Flags ---
+if(RS_DEVELOPMENT_BUILD)
+    target_compile_options(retroshare-friendserver PRIVATE "-g" "-O0")
+endif()
+
+# --- Installation ---
+install(TARGETS retroshare-friendserver RUNTIME DESTINATION bin)

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -95,8 +95,13 @@ target_include_directories(retroshare-gui PRIVATE
 # --- Compile Definitions ---
 target_compile_definitions(retroshare-gui PRIVATE 
     RS_RELEASE_VERSION="${RS_VERSION}" 
+    RS_MAJOR_VERSION=${RS_MAJOR_VERSION}
+    RS_MINOR_VERSION=${RS_MINOR_VERSION}
+    RS_MINI_VERSION=${RS_MINI_VERSION}
+    RS_EXTRA_VERSION="${RS_EXTRA_VERSION}"
     TARGET="retroshare"
 )
+
 
 if(UNIX AND NOT APPLE)
     find_package(PkgConfig REQUIRED)

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -99,6 +99,7 @@ target_compile_definitions(retroshare-gui PRIVATE
     RS_MINOR_VERSION=${RS_MINOR_VERSION}
     RS_MINI_VERSION=${RS_MINI_VERSION}
     RS_EXTRA_VERSION="${RS_EXTRA_VERSION}"
+    RS_LIB_VERSION_HASH="${RS_LIB_VERSION}"
     TARGET="retroshare"
 )
 

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -1,505 +1,108 @@
 ################################################################################
-# retroshare-gui/CMakeLists.txt                                                #
-# Copyright (C) 2022, Retroshare team <retroshare.team@gmailcom>               #
-#                                                                              #
-# This program is free software: you can redistribute it and/or modify         #
-# it under the terms of the GNU Affero General Public License as               #
-# published by the Free Software Foundation, either version 3 of the           #
-# License, or (at your option) any later version.                              #
-#                                                                              #
-# This program is distributed in the hope that it will be useful,              #
-# but WITHOUT ANY WARRANTY; without even the implied warranty of               #
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                #
-# GNU Affero General Public License for more details.                          #
-#                                                                              #
-# You should have received a copy of the GNU Affero General Public License     #
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.       #
+# retroshare-gui/CMakeLists.txt
 ################################################################################
 
-cmake_minimum_required (VERSION 3.18.0)
-project(retroshare-gui VERSION 0.6.6 LANGUAGES CXX)
-
-include(CMakeDependentOption)
-
-set(
-	RS_BIN_INSTALL_DIR
-	"${CMAKE_INSTALL_PREFIX}/bin"
-	CACHE PATH
-	"Path where to install retroshare-service compiled binary" )
-
-option(
-	RS_DEVELOPMENT_BUILD
-	"Disable optimization to speed up build, enable verbose build log. \
-	 just for development purposes, not suitable for library usage"
-	 ON )
-
-option(
-	RS_JSON_API
-	"Use restbed to expose libretroshare as JSON API via HTTP"
-	OFF )
-
-option(
-	RS_SERVICE_DESKTOP
-	"Install icons and shortcuts for desktop environements"
-	OFF )
-
-option(
-	RS_SERVICE_TERMINAL_LOGIN
-	"Enable RetroShare login via terminal"
-	ON )
-
-option( RS_GXSGUI      "Enable GXS services in GUI" ON )
-option( RS_GXSCHANNELS "Enable GXS channels in GUI" ON )
-option( RS_GXSFORUMS   "Enable GXS forums in GUI"   ON )
-option( RS_GXSPOSTED   "Enable GXS posted in GUI"   ON )
-option( RS_GXSCIRCLES  "Enable GXS circles in GUI"  ON )
-
-cmake_dependent_option(
-	RS_SERVICE_TERMINAL_WEBUI_PASSWORD
-	"Enable settin Web UI password via terminal in retroshare-service"
-	OFF
-	"RS_WEBUI"
-	ON )
-
-cmake_dependent_option(
-	RS_WEBUI
-	"Install RetroShare Web UI"
-	OFF
-	"RS_JSON_API"
-	ON )
-
-################################ QT FILES #######################################
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# project() and common options are inherited from the root CMakeLists.txt
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package( Qt6 COMPONENTS Core         REQUIRED)
-find_package( Qt6 COMPONENTS Widgets      REQUIRED)
-find_package( Qt6 COMPONENTS Xml          REQUIRED)
-find_package( Qt6 COMPONENTS Network      REQUIRED)
-find_package( Qt6 COMPONENTS Multimedia   REQUIRED)
-find_package( Qt6 COMPONENTS PrintSupport REQUIRED)
-
-list( APPEND RS_LINK_LIBRARIES Qt6::Multimedia Qt6::Widgets Qt6::Xml Qt6::Network Qt6::PrintSupport)
-if (NOT Qt6_FOUND)
-	find_package( Qt5 COMPONENTS Core         REQUIRED)
-	find_package( Qt5 COMPONENTS Widgets      REQUIRED)
-	find_package( Qt5 COMPONENTS Xml          REQUIRED)
-	find_package( Qt5 COMPONENTS Network      REQUIRED)
-	find_package( Qt5 COMPONENTS Multimedia   REQUIRED)
-	find_package( Qt5 COMPONENTS PrintSupport REQUIRED)
-
-	list( APPEND RS_LINK_LIBRARIES Qt5::Multimedia Qt5::Widgets Qt5::Xml Qt5::Network Qt5::PrintSupport)
+# --- Qt Dependencies ---
+# Root already found Qt5, we just use it here
+find_package(Qt5 COMPONENTS Core Widgets Xml Network Multimedia PrintSupport REQUIRED)
+if(UNIX AND NOT APPLE)
+    find_package(Qt5 COMPONENTS X11Extras REQUIRED)
+endif()
+find_package(Qt5 COMPONENTS LinguistTools QUIET)
+set(RS_LINK_LIBRARIES Qt5::Core Qt5::Widgets Qt5::Xml Qt5::Network Qt5::Multimedia Qt5::PrintSupport)
+if(UNIX AND NOT APPLE)
+    list(APPEND RS_LINK_LIBRARIES Qt5::X11Extras)
 endif()
 
-################################################################################
-
-set(FETCHCONTENT_QUIET OFF)
-include(FetchContent)
-
-find_package(Git REQUIRED)
-
-################################################################################
-
-if(RS_DEVELOPMENT_BUILD)
-	set(CMAKE_VERBOSE_MAKEFILE ON)
-	set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-endif(RS_DEVELOPMENT_BUILD)
-
-################################################################################
-
+# --- Sources ---
 include(src/CMakeLists.txt)
 
-qt_wrap_ui(RS_UI_HEADERS ${RS_GUI_FORMS})
-if (NOT Qt6_FOUND)
-	qt5_wrap_ui(RS_UI_HEADERS ${RS_GUI_FORMS})
-endif()
-
-add_executable(${PROJECT_NAME} ${RS_GUI_SOURCES} ${RS_UI_HEADERS} ${RS_GUI_QTRESOURCES})
-install(TARGETS ${PROJECT_NAME} DESTINATION ${RS_BIN_INSTALL_DIR})
-
-include_directories( ${CMAKE_BINARY_DIR} )
-
-################################################################################
-
-if(RS_DEVELOPMENT_BUILD)
-	target_compile_options(${PROJECT_NAME} PRIVATE "-O0")
-endif(RS_DEVELOPMENT_BUILD)
-
-################################################################################
-
-set(LIBRETROSHARE_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../libretroshare/")
-if(EXISTS "${LIBRETROSHARE_DEVEL_DIR}/.git" )
-	message(
-		STATUS
-		"libretroshare submodule found at ${LIBRETROSHARE_DEVEL_DIR} using it" )
-	add_subdirectory(
-		"${LIBRETROSHARE_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/libretroshare" )
+# --- Translations (.ts -> .qm) ---
+file(GLOB TS_FILES "src/lang/*.ts")
+if(Qt5LinguistTools_FOUND)
+    qt5_add_translation(QM_FILES ${TS_FILES})
 else()
-	FetchContent_Declare(
-		libretroshare
-		GIT_REPOSITORY "https://gitlab.com/RetroShare/libretroshare.git"
-		GIT_TAG "origin/master"
-		GIT_SHALLOW TRUE
-		GIT_PROGRESS TRUE
-		TIMEOUT 10
-	)
-	FetchContent_MakeAvailable(libretroshare)
+    message(STATUS "Qt5LinguistTools not found, trying to use existing .qm files or lrelease")
+    find_program(LRELEASE_EXECUTABLE NAMES lrelease-qt5 lrelease)
+    foreach(ts_file ${TS_FILES})
+        get_filename_component(ts_name ${ts_file} NAME_WE)
+        set(qm_src_file "${CMAKE_CURRENT_SOURCE_DIR}/src/lang/${ts_name}.qm")
+        set(qm_bin_file "${CMAKE_CURRENT_BINARY_DIR}/${ts_name}.qm")
+        
+        if(EXISTS ${qm_src_file})
+            # Use existing .qm file from source tree
+            list(APPEND QM_FILES ${qm_src_file})
+        elseif(LRELEASE_EXECUTABLE)
+            # Try to generate it, but don't fail if lrelease is broken
+            add_custom_command(
+                OUTPUT ${qm_bin_file}
+                COMMAND ${LRELEASE_EXECUTABLE} ${ts_file} -qm ${qm_bin_file} || ${CMAKE_COMMAND} -E echo "Warning: lrelease failed for ${ts_name}"
+                COMMAND ${CMAKE_COMMAND} -E touch ${qm_bin_file}
+                DEPENDS ${ts_file}
+                VERBATIM
+            )
+            list(APPEND QM_FILES ${qm_bin_file})
+        endif()
+    endforeach()
 endif()
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${LIBRETROSHARE_DEVEL_DIR}/src/)
-
-################################################################################
-
-if(RS_SERVICE_DESKTOP)
-	if(UNIX AND NOT APPLE)
-		install(
-			FILES data/retroshare.svg
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/ )
-
-		install(
-			FILES data/retroshare.xpm
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps/ )
-
-		install(
-			FILES data/24x24/apps/retroshare.png
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/24x24/apps/retroshare.png )
-
-		install(
-			FILES data/48x48/apps/retroshare.png
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/apps/retroshare.png )
-
-		install(
-			FILES data/64x64/apps/retroshare.png
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/64x64/apps/retroshare.png )
-
-		install(
-			FILES data/128x128/apps/retroshare.png
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/128x128/apps/retroshare.png )
-
-		install(
-			FILES data/retroshare.desktop
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/data/retroshare.desktop )
-
-		install(
-			FILES gui/qss/chat/Bubble gui/qss/chat/Bubble_Compact
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/data/stylesheets/ )
-
-		install(
-			FILES src/sounds/ src/qss/
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/ )
-	endif(UNIX AND NOT APPLE)
-endif(RS_SERVICE_DESKTOP)
-
-################################################################################
-
-if(RS_JSON_API)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_JSONAPI)
-endif(RS_JSON_API)
-
-################################# CMark ########################################
-
-if(RS_GUI_CMARK)
-	set(CMARK_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/cmark/")
-	if(EXISTS "${LIBRETROSHARE_DEVEL_DIR}/.git" )
-		message( STATUS "cmark submodule found at ${LIBRETROSHARE_DEVEL_DIR} using it" )
-		add_subdirectory( "${LIBRETROSHARE_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/cmark" )
-	else()
-		FetchContent_Declare(
-			cmark
-			GIT_REPOSITORY "https://github.com/commonmark/cmark.git"
-			GIT_TAG "origin/master"
-			GIT_SHALLOW TRUE
-			GIT_PROGRESS TRUE
-			TIMEOUT 10
-			)
-		FetchContent_MakeAvailable(cmark)
-	endif()
-endif(RS_GUI_CMARK)
-
-################################# LibSam v3 ####################################
-
-set(SAM3_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/libsam3/")
-if(EXISTS "${SAM3_DEVEL_DIR}/.git" )
-	message( STATUS "libsam3 submodule found at ${SAM3_DEVEL_DIR} using it" )
-	add_subdirectory( "${SAM3_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/libsam3" )
-else()
-	FetchContent_Declare(
-		libsam3
-		GIT_REPOSITORY "https://github.com/i2p/libsam3.git"
-		GIT_TAG "origin/master"
-		GIT_SHALLOW TRUE
-		GIT_PROGRESS TRUE
-		TIMEOUT 10
-		)
-	FetchContent_MakeAvailable(libsam3)
+# --- Platform Resources ---
+if(WIN32)
+    set(RS_GUI_RESOURCES ${RS_GUI_RESOURCES} gui/images/retroshare_win.rc)
 endif()
 
-################################################################################
-#                                    TODO                                      #
-################################################################################
+# --- Executable ---
+add_executable(retroshare-gui 
+    ${RS_GUI_SOURCES} 
+    ${RS_GUI_HEADERS}
+    ${RS_GUI_FORMS} 
+    ${RS_GUI_QTRESOURCES}
+    ${QM_FILES}
+    ${RS_GUI_RESOURCES}
+)
 
-#   # Auto detect installed version of cmark
-#   rs_gui_cmark {
-#   	DEFINES *= USE_CMARK
-#   	no_rs_cross_compiling {
-#   		message("Using compiled cmark")
-#   		CMARK_SRC_PATH=$$clean_path($${RS_SRC_PATH}/supportlibs/cmark)
-#   		CMARK_BUILD_PATH=$$clean_path($${RS_BUILD_PATH}/supportlibs/cmark/build)
-#   		INCLUDEPATH *= $$clean_path($${CMARK_SRC_PATH}/src/)
-#   		DEPENDPATH *= $$clean_path($${CMARK_SRC_PATH}/src/)
-#   		QMAKE_LIBDIR *= $$clean_path($${CMARK_BUILD_PATH}/)
-#   		# Using sLibs would fail as libcmark.a is generated at compile-time
-#   		LIBS *= -L$$clean_path($${CMARK_BUILD_PATH}/src/) -lcmark
-#   
-#   		DUMMYCMARKINPUT = FORCE
-#   		CMAKE_GENERATOR_OVERRIDE=""
-#   		win32-g++|win32-clang-g++:CMAKE_GENERATOR_OVERRIDE="-G \"MSYS Makefiles\""
-#   		gencmarklib.name = Generating libcmark.
-#   		gencmarklib.input = DUMMYCMARKINPUT
-#   		gencmarklib.output = $$clean_path($${CMARK_BUILD_PATH}/src/libcmark.a)
-#   		gencmarklib.CONFIG += target_predeps combine
-#   		gencmarklib.variable_out = PRE_TARGETDEPS
-#   		gencmarklib.commands = \
-#   		    cd $${RS_SRC_PATH} && ( \
-#   		    git submodule update --init supportlibs/cmark ; \
-#   		    cd $${CMARK_SRC_PATH} ; \
-#   		    true ) && \
-#   		    mkdir -p $${CMARK_BUILD_PATH} && cd $${CMARK_BUILD_PATH} && \
-#   		    cmake \
-#   		        -DCMAKE_CXX_COMPILER=$$QMAKE_CXX \
-#                           \"-DCMAKE_CXX_FLAGS=$${QMAKE_CXXFLAGS}\" \
-#   		        $${CMAKE_GENERATOR_OVERRIDE} \
-#   		        -DCMAKE_INSTALL_PREFIX=. \
-#   		        -B. \
-#   		        -H$$shell_path($${CMARK_SRC_PATH}) && \
-#   		    $(MAKE)
-#   		QMAKE_EXTRA_COMPILERS += gencmarklib
-#   	} else {
-#   		message("Using systems cmark")
-#   		sLibs *= libcmark
-#   	}
-#   }
+set_target_properties(retroshare-gui PROPERTIES OUTPUT_NAME retroshare)
 
-################################# Linux ##########################################
-# Put lib dir in QMAKE_LFLAGS so it appears before -L/usr/lib
+# --- Linkage ---
+target_link_libraries(retroshare-gui PRIVATE retroshare ${RS_LINK_LIBRARIES})
 
-if(UNIX)
-	find_package(PkgConfig REQUIRED)
+# --- Includes ---
+target_include_directories(retroshare-gui PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/retroshare-gui
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/gxs
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/settings
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/chat
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/connect
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/groups
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/msgs
+    ${CMAKE_SOURCE_DIR}/supportlibs/pegmarkdown
+    ${CMAKE_SOURCE_DIR}/supportlibs/libsam3/src/libsam3
+    ${CMAKE_BINARY_DIR}
+)
 
-	pkg_check_modules(X11 REQUIRED x11)
-	pkg_check_modules(XSCRNSAVER REQUIRED xscrnsaver)
+# --- Compile Definitions ---
+target_compile_definitions(retroshare-gui PRIVATE 
+    RS_RELEASE_VERSION 
+    TARGET="retroshare"
+)
 
-	list( APPEND RS_LINK_LIBRARIES ${X11_LIBRARIES} )
-	list( APPEND RS_LINK_LIBRARIES ${XSCRNSAVER_LIBRARIES} )
+if(UNIX AND NOT APPLE)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(X11 REQUIRED x11)
+    pkg_check_modules(XSCRNSAVER REQUIRED xscrnsaver)
+    
+    target_link_libraries(retroshare-gui PRIVATE ${X11_LIBRARIES} ${XSCRNSAVER_LIBRARIES})
+    target_compile_definitions(retroshare-gui PRIVATE HAVE_XSS)
+endif()
 
-	target_include_directories(${PROJECT_NAME} PRIVATE ${X11_INCLUDE_DIRS})
-	target_compile_options(${PROJECT_NAME} PRIVATE ${X11_CFLAGS_OTHER})
-
-	target_include_directories(retroshare-gui PRIVATE ${XSCRNSAVER_INCLUDE_DIRS})
-	target_compile_options(retroshare-gui PRIVATE ${XSCRNSAVER_CFLAGS_OTHER})
-
-	target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_XSS)
-	target_compile_definitions(${PROJECT_NAME} PRIVATE _FILE_OFFSET_BITS=64)
-	target_link_options(${PROJECT_NAME} PRIVATE LINKER:-rdynamic)
-endif(UNIX)
-
-if(RS_SANITIZE)
-	list( APPEND RS_LINK_LIBRARIES asan )
-	list( APPEND RS_LINK_LIBRARIES ubsan )
-endif(RS_SANITIZE)
-
-#                       #################### Cross compilation for windows under Linux ###################
-#                       
-#                       win32-x-g++ {
-#                       		OBJECTS_DIR = temp/win32-x-g++/obj
-#                       
-#                       		LIBS += ../../../../lib/win32-x-g++-v0.5/libssl.a
-#                       		LIBS += ../../../../lib/win32-x-g++-v0.5/libcrypto.a
-#                       		LIBS += ../../../../lib/win32-x-g++-v0.5/libgpgme.dll.a
-#                       		LIBS += ../../../../lib/win32-x-g++-v0.5/libminiupnpc.a
-#                       		LIBS += ../../../../lib/win32-x-g++-v0.5/libz.a
-#                       		LIBS += -L${HOME}/.wine/drive_c/pthreads/lib -lpthreadGCE2
-#                       		LIBS += -lQtUiTools
-#                       		LIBS += -lws2_32 -luuid -lole32 -liphlpapi -lcrypt32 -gdi32
-#                       		LIBS += -lole32 -lwinmm
-#                       
-#                       		DEFINES *= WINDOWS_SYS WIN32 WIN32_CROSS_UBUNTU
-#                       
-#                       		INCLUDEPATH += ../../../../gpgme-1.1.8/src/
-#                       		INCLUDEPATH += ../../../../libgpg-error-1.7/src/
-#                       
-#                       		RC_FILE = gui/images/retroshare_win.rc
-#                       }
-#                       
-#                       #################################### Windows #####################################
-#                       
-#                       win32-g++|win32-clang-g++ {
-#                       	CONFIG(debug, debug|release) {
-#                       		# show console output
-#                       		CONFIG += console
-#                       	} else {
-#                       		CONFIG -= console
-#                       	}
-#                       
-#                       	CONFIG(debug, debug|release) {
-#                       	} else {
-#                       		# Tell linker to use ASLR protection
-#                       		QMAKE_LFLAGS += -Wl,-dynamicbase
-#                       		# Tell linker to use DEP protection
-#                       		QMAKE_LFLAGS += -Wl,-nxcompat
-#                       	}
-#                       
-#                           # Fix linking error (ld.exe: Error: export ordinal too large) due to too
-#                           # many exported symbols.
-#                           !libretroshare_shared:QMAKE_LFLAGS+=-Wl,--exclude-libs,ALL
-#                       
-#                       	# Switch off optimization for release version
-#                       	QMAKE_CXXFLAGS_RELEASE -= -O2
-#                       	QMAKE_CXXFLAGS_RELEASE += -O0
-#                       	QMAKE_CFLAGS_RELEASE -= -O2
-#                       	QMAKE_CFLAGS_RELEASE += -O0
-#                       
-#                       	# Switch on optimization for debug version
-#                       	#QMAKE_CXXFLAGS_DEBUG += -O2
-#                       	#QMAKE_CFLAGS_DEBUG += -O2
-#                       
-#                       	OBJECTS_DIR = temp/obj
-#                       
-#                           dLib = ws2_32 gdi32 uuid ole32 iphlpapi crypt32 winmm
-#                           LIBS *= $$linkDynamicLibs(dLib)
-#                       
-#                       	RC_FILE = gui/images/retroshare_win.rc
-#                       
-#                       	# export symbols for the plugins
-#                       	LIBS += -Wl,--export-all-symbols,--out-implib,lib/libretroshare-gui.a
-#                       
-#                       	# create lib directory
-#                       	isEmpty(QMAKE_SH) {
-#                       		QMAKE_PRE_LINK = $(CHK_DIR_EXISTS) lib $(MKDIR) lib
-#                       	} else {
-#                       		QMAKE_PRE_LINK = $(CHK_DIR_EXISTS) lib || $(MKDIR) lib
-#                       	}
-#                       
-#                       	greaterThan(QT_MAJOR_VERSION, 4) {
-#                       		# Qt 5
-#                       		RC_INCLUDEPATH += $$_PRO_FILE_PWD_/../../libretroshare/src
-#                       	} else {
-#                       		# Qt 4
-#                       		QMAKE_RC += --include-dir=$$_PRO_FILE_PWD_/../../libretroshare/src
-#                       	}
-#                       }
-#                       
-#                       ##################################### MacOS ######################################
-#                       
-#                       macx {
-#                       	# ENABLE THIS OPTION FOR Univeral Binary BUILD.
-#                       	#CONFIG += ppc x86
-#                       	#QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.4
-#                       	QMAKE_INFO_PLIST = Info.plist
-#                       	mac_icon.files = $$files($$PWD/rsMacIcon.icns)
-#                       	mac_icon.path = Contents/Resources
-#                       	QMAKE_BUNDLE_DATA += mac_icon
-#                       	dplQSS.files = $$PWD/qss
-#                       	dplQSS.path = Contents/Resources
-#                       	QMAKE_BUNDLE_DATA += dplQSS
-#                       	dplChatStyles.files = \
-#                       		$$PWD/gui/qss/chat/Bubble \
-#                       		$$PWD/gui/qss/chat/Bubble_Compact
-#                       	dplChatStyles.path = Contents/Resources/stylesheets
-#                       	QMAKE_BUNDLE_DATA += dplChatStyles 
-#                       #	mac_webui.files = $$files($$PWD/../../libresapi/src/webui)
-#                       #	mac_webui.path = Contents/Resources
-#                       #	QMAKE_BUNDLE_DATA += mac_webui
-#                       
-#                       	OBJECTS_DIR = temp/obj
-#                       
-#                       	CONFIG += version_detail_bash_script
-#                       	LIBS += -lssl -lcrypto -lz 
-#                       	for(lib, LIB_DIR):exists($$lib/libminiupnpc.a){ LIBS += $$lib/libminiupnpc.a}
-#                       	LIBS += -framework CoreFoundation
-#                       	LIBS += -framework Security
-#                       	LIBS += -framework Carbon
-#                       
-#                       	for(lib, LIB_DIR):LIBS += -L"$$lib"
-#                       	for(bin, BIN_DIR):LIBS += -L"$$bin"
-#                       
-#                       	DEPENDPATH += . $$INC_DIR
-#                       	INCLUDEPATH += . $$INC_DIR
-#                       
-#                       	#DEFINES *= MAC_IDLE # for idle feature
-#                       	CONFIG -= uitools
-#                       }
-#                       
-#                       ##################################### FreeBSD ######################################
-#                       
-#                       freebsd-* {
-#                       	INCLUDEPATH *= /usr/local/include/gpgme
-#                       	LIBS *= -lssl
-#                       	LIBS *= -lgpgme
-#                       	LIBS *= -lupnp
-#                       	LIBS *= -lgnome-keyring
-#                       
-#                       	LIBS += -lsqlite3
-#                       }
-#                       
-#                       ##################################### Haiku ######################################
-#                       
-#                       haiku-* {
-#                       	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a
-#                       	PRE_TARGETDEPS *= ../../openpgpsdk/src/lib/libops.a
-#                       
-#                       	LIBS *= ../../libretroshare/src/lib/libretroshare.a
-#                       	LIBS *= ../../openpgpsdk/src/lib/libops.a -lbz2 -lbsd
-#                       	LIBS *= -lssl -lcrypto -lnetwork
-#                       	LIBS *= -lgpgme
-#                       	LIBS *= -lupnp
-#                       	LIBS *= -lz
-#                       	LIBS *= -lixml
-#                       
-#                       	LIBS += ../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
-#                       	LIBS += -lsqlite3
-#                       }
-#                       
-#                       ##################################### OpenBSD ######################################
-#                       
-#                       openbsd-* {
-#                       	INCLUDEPATH *= /usr/local/include
-#                       
-#                       	LIBS *= -lssl -lcrypto
-#                       	LIBS *= -lgpgme
-#                       	LIBS *= -lupnp
-#                       	LIBS *= -lgnome-keyring
-#                       	LIBS += -lsqlite3
-#                       	LIBS *= -rdynamic
-#                       }
-#                       
-#                       ################################### COMMON stuff ##################################
-#                       
-#                       wikipoos {
-#                       	PRE_TARGETDEPS *= $$OUT_PWD/../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
-#                       	LIBS *= $$OUT_PWD/../../supportlibs/pegmarkdown/lib/libpegmarkdown.a
-#                       	LIBS *= -lglib-2.0
-#                       }
-
-################################ GENERAL #######################################
-
-target_link_libraries(${PROJECT_NAME} PRIVATE ${RS_LINK_LIBRARIES})
-
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/)
-
-set( CMAKE_CXX_FLAGS "-Wno-deprecated-declarations" )
-target_compile_definitions(${PROJECT_NAME} PUBLIC  RS_NO_WARN_DEPRECATED )
-target_compile_definitions(${PROJECT_NAME} PRIVATE RS_RELEASE_VERSION )
-target_compile_definitions(${PROJECT_NAME} PRIVATE TARGET=\"retroshare\")
-
-if(RS_GXS_CIRCLES)
-	target_compile_definitions(${PROJECT_NAME} PRIVATE RS_USE_CIRCLES )
-endif(RS_GXS_CIRCLES)
-
-#add_dependencies(${PROJECT_NAME} libretroshare)
-
+# --- Installation ---
+install(TARGETS retroshare-gui RUNTIME DESTINATION bin)

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -92,6 +92,10 @@ target_include_directories(retroshare-gui PRIVATE
     ${CMAKE_BINARY_DIR}
 )
 
+if(RS_JSON_API)
+    target_include_directories(retroshare-gui PRIVATE ${CMAKE_SOURCE_DIR}/supportlibs/restbed/source/)
+endif()
+
 # --- Compile Definitions ---
 target_compile_definitions(retroshare-gui PRIVATE 
     RS_RELEASE_VERSION="${RS_VERSION}" 

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -67,7 +67,10 @@ add_executable(retroshare-gui
     ${RS_GUI_RESOURCES}
 )
 
-set_target_properties(retroshare-gui PROPERTIES OUTPUT_NAME retroshare)
+set_target_properties(retroshare-gui PROPERTIES 
+    OUTPUT_NAME retroshare 
+    AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src/gui/gxs;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/common;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/settings;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/chat;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/msgs"
+)
 
 # --- Linkage ---
 target_link_libraries(retroshare-gui PRIVATE retroshare ${RS_LINK_LIBRARIES})

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -105,6 +105,7 @@ target_compile_definitions(retroshare-gui PRIVATE
     RS_EXTRA_VERSION="${RS_EXTRA_VERSION}"
     RS_LIB_VERSION_HASH="${RS_LIB_VERSION}"
     TARGET="retroshare"
+    RS_DIRECT_CHAT
 )
 
 

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(retroshare-gui
 set_target_properties(retroshare-gui PROPERTIES 
     OUTPUT_NAME retroshare 
     AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src/gui/gxs;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/common;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/settings;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/chat;${CMAKE_CURRENT_SOURCE_DIR}/src/gui/msgs"
+    ENABLE_EXPORTS ON
 )
 
 # --- Linkage ---

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -94,7 +94,7 @@ target_include_directories(retroshare-gui PRIVATE
 
 # --- Compile Definitions ---
 target_compile_definitions(retroshare-gui PRIVATE 
-    RS_RELEASE_VERSION 
+    RS_RELEASE_VERSION="${RS_VERSION}" 
     TARGET="retroshare"
 )
 

--- a/retroshare-gui/src/CMakeLists.txt
+++ b/retroshare-gui/src/CMakeLists.txt
@@ -16,678 +16,859 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.       #
 ################################################################################
 
-list(
-	APPEND RS_GUI_SOURCES
-	src/TorControl/TorControlWindow.cpp
-
-	src/main.cpp 
-	src/rshare.cpp 
-
-	src/gui/notifyqt.cpp 
-	src/gui/AboutDialog.cpp 
-	src/gui/AboutWidget.cpp 
-	src/gui/QuickStartWizard.cpp 
-	src/gui/StartDialog.cpp 
-	src/gui/HomePage.cpp
-	src/gui/ChatLobbyWidget.cpp 
-	src/gui/GetStartedDialog.cpp 
-	src/gui/GenCertDialog.cpp 
-	src/gui/NetworkDialog.cpp 
-	src/gui/mainpagestack.cpp 
-	src/gui/MainWindow.cpp 
-	src/gui/NetworkView.cpp 
-	src/gui/FriendsDialog.cpp 
-	src/gui/ServicePermissionDialog.cpp 
-	src/gui/RemoteDirModel.cpp 
-	src/gui/RsAutoUpdatePage.cpp 
-	src/gui/RetroShareLink.cpp 
-	src/gui/SearchTreeWidget.cpp 
-	src/gui/ShareManager.cpp 
-	#	src/gui/ShareDialog.cpp 
-	src/gui/NewsFeed.cpp 
-	src/gui/MainPage.cpp 
-	src/gui/HelpDialog.cpp 
-	src/gui/LogoBar.cpp 
-	src/gui/SoundManager.cpp 
-
-	src/gui/im_history/ImHistoryBrowser.cpp 
-	src/gui/im_history/IMHistoryItemDelegate.cpp 
-	src/gui/im_history/IMHistoryItemPainter.cpp 
-
-	src/gui/help/browser/helpbrowser.cpp 
-	src/gui/help/browser/helptextbrowser.cpp 
-
-	src/gui/FileTransfer/SearchDialog.cpp 
-	src/gui/FileTransfer/SharedFilesDialog.cpp 
-	src/gui/FileTransfer/TransfersDialog.cpp 
-	src/gui/FileTransfer/FileTransferInfoWidget.cpp 
-	src/gui/FileTransfer/DLListDelegate.cpp 
-	src/gui/FileTransfer/ULListDelegate.cpp 
-	src/gui/FileTransfer/xprogressbar.cpp 
-	src/gui/FileTransfer/DetailsDialog.cpp 
-	src/gui/FileTransfer/TransferUserNotify.cpp 
-	src/gui/FileTransfer/BannedFilesDialog.cpp 
-
-	src/lang/languagesupport.cpp 
-
-	src/util/RsProtectedTimer.cpp 
-	src/util/stringutil.cpp 
-	src/util/RsNetUtil.cpp 
-	src/util/DateTime.cpp 
-	src/util/RetroStyleLabel.cpp 
-	src/util/WidgetBackgroundImage.cpp 
-	src/util/PixmapMerging.cpp 
-	src/util/MouseEventFilter.cpp 
-	src/util/EventFilter.cpp 
-	src/util/Widget.cpp 
-	src/util/RsAction.cpp 
-	src/util/printpreview.cpp 
-	src/util/log.cpp 
-	src/util/misc.cpp 
-	src/util/HandleRichText.cpp 
-	src/util/ObjectPainter.cpp 
-	src/util/RsFile.cpp 
-	src/util/RichTextEdit.cpp 
-	src/util/ClickableLabel.cpp 
-	src/util/AspectRatioPixmapLabel.cpp 
-
-	src/gui/profile/ProfileWidget.cpp 
-	src/gui/profile/StatusMessage.cpp 
-	src/gui/profile/ProfileManager.cpp 
-
-	src/gui/chat/PopupChatWindow.cpp 
-	src/gui/chat/PopupChatDialog.cpp 
-	src/gui/chat/PopupDistantChatDialog.cpp 
-	src/gui/chat/ChatTabWidget.cpp 
-	src/gui/chat/ChatWidget.cpp 
-	src/gui/chat/ChatDialog.cpp 
-	src/gui/chat/ChatLobbyDialog.cpp 
-	src/gui/chat/CreateLobbyDialog.cpp 
-	src/gui/chat/ChatStyle.cpp 
-	src/gui/chat/ChatUserNotify.cpp 
-	src/gui/chat/ChatLobbyUserNotify.cpp 
-
-	src/gui/connect/ConfCertDialog.cpp 
-	src/gui/connect/PGPKeyDialog.cpp 
-	src/gui/connect/ConnectFriendWizard.cpp 
-	src/gui/connect/ConnectProgressDialog.cpp 
-	src/gui/connect/FriendRecommendDialog.cpp 
-
-	src/gui/msgs/MessagesDialog.cpp 
-	src/gui/msgs/MessageComposer.cpp 
-	src/gui/msgs/MessageWidget.cpp 
-	src/gui/msgs/MessageWindow.cpp 
-	src/gui/msgs/MessageModel.cpp 
-	src/gui/msgs/TagsMenu.cpp 
-	src/gui/msgs/MessageUserNotify.cpp 
-
-	src/gui/common/RsButtonOnText.cpp 
-	src/gui/common/RSGraphWidget.cpp 
-	src/gui/common/ElidedLabel.cpp 
-	src/gui/common/vmessagebox.cpp 
-	src/gui/common/RsCollectionDialog.cpp 
-	src/gui/common/RsCollection.cpp 
-	src/gui/common/RsUrlHandler.cpp 
-	src/gui/common/rwindow.cpp 
-	src/gui/common/rshtml.cpp 
-	src/gui/common/AvatarDefs.cpp 
-	src/gui/common/AvatarDialog.cpp 
-	src/gui/common/GroupFlagsWidget.cpp 
-	src/gui/common/GroupSelectionBox.cpp 
-	src/gui/common/GroupChooser.cpp 
-	src/gui/common/StatusDefs.cpp 
-	src/gui/common/TagDefs.cpp 
-	src/gui/common/GroupDefs.cpp 
-	src/gui/common/Emoticons.cpp 
-	src/gui/common/RSComboBox.cpp 
-	src/gui/common/RSListWidgetItem.cpp 
-	src/gui/common/RSTextEdit.cpp 
-	src/gui/common/RSPlainTextEdit.cpp 
-	src/gui/common/RSTreeWidget.cpp 
-	src/gui/common/RSTreeWidgetItem.cpp 
-	src/gui/common/RSFeedWidget.cpp 
-	src/gui/common/RSTabWidget.cpp 
-	src/gui/common/RSElidedItemDelegate.cpp 
-	src/gui/common/RSItemDelegate.cpp 
-	src/gui/common/PeerDefs.cpp 
-	src/gui/common/FilesDefs.cpp 
-	src/gui/common/PopularityDefs.cpp 
-	src/gui/common/RsBanListDefs.cpp 
-	src/gui/common/GroupTreeWidget.cpp 
-	src/gui/common/RSTreeView.cpp 
-	src/gui/common/AvatarWidget.cpp 
-	src/gui/common/FriendListModel.cpp 
-	src/gui/common/NewFriendList.cpp 
-	src/gui/common/FriendSelectionWidget.cpp 
-	src/gui/common/FriendSelectionDialog.cpp 
-	src/gui/common/HashBox.cpp 
-	src/gui/common/LineEditClear.cpp 
-	src/gui/common/DropLineEdit.cpp 
-	src/gui/common/RSTextBrowser.cpp 
-	src/gui/common/RSImageBlockWidget.cpp 
-	src/gui/common/FeedNotify.cpp 
-	src/gui/common/UserNotify.cpp 
-	src/gui/common/HeaderFrame.cpp 
-	src/gui/common/MimeTextEdit.cpp 
-	src/gui/common/UIStateHelper.cpp 
-	src/gui/common/FloatingHelpBrowser.cpp 
-	src/gui/common/SubscribeToolButton.cpp 
-	src/gui/common/RsBanListToolButton.cpp 
-	src/gui/common/FlowLayout.cpp 
-	src/gui/common/PictureFlow.cpp 
-	src/gui/common/ToasterNotify.cpp 
-
-	src/gui/style/RSStyle.cpp 
-	src/gui/style/StyleDialog.cpp 
-
-	src/gui/settings/RSPermissionMatrixWidget.cpp 
-	src/gui/settings/rsharesettings.cpp 
-	src/gui/settings/RsharePeerSettings.cpp 
-	src/gui/settings/rsettings.cpp 
-	src/gui/settings/rsettingswin.cpp 
-	src/gui/settings/GeneralPage.cpp 
-	src/gui/settings/AboutPage.cpp 
-	src/gui/settings/ServerPage.cpp 
-	src/gui/settings/NotifyPage.cpp 
-	src/gui/settings/CryptoPage.cpp 
-	src/gui/settings/PeoplePage.cpp 
-	src/gui/settings/MessagePage.cpp 
-	src/gui/settings/NewTag.cpp 
-	src/gui/settings/ForumPage.cpp 
-	src/gui/settings/PluginsPage.cpp 
-	src/gui/settings/PluginItem.cpp 
-	src/gui/settings/AppearancePage.cpp 
-	src/gui/settings/FileAssociationsPage.cpp 
-	src/gui/settings/SoundPage.cpp 
-	src/gui/settings/TransferPage.cpp 
-	src/gui/settings/ChatPage.cpp 
-	src/gui/settings/ChannelPage.cpp 
-	src/gui/settings/PostedPage.cpp 
-	src/gui/settings/ServicePermissionsPage.cpp 
-	src/gui/settings/AddFileAssociationDialog.cpp 
-	src/gui/settings/GroupFrameSettingsWidget.cpp 
-
-	src/gui/statusbar/peerstatus.cpp 
-	src/gui/statusbar/natstatus.cpp 
-	src/gui/statusbar/dhtstatus.cpp 
-	src/gui/statusbar/torstatus.cpp 
-	src/gui/statusbar/ratesstatus.cpp 
-	src/gui/statusbar/hashingstatus.cpp 
-	src/gui/statusbar/discstatus.cpp 
-	src/gui/statusbar/SoundStatus.cpp 
-	src/gui/statusbar/OpModeStatus.cpp 
-	src/gui/statusbar/ToasterDisable.cpp 
-	src/gui/statusbar/SysTrayStatus.cpp 
-
-	src/gui/toaster/ToasterItem.cpp 
-	src/gui/toaster/MessageToaster.cpp 
-	src/gui/toaster/DownloadToaster.cpp 
-	src/gui/toaster/OnlineToaster.cpp 
-	src/gui/toaster/ChatToaster.cpp 
-	src/gui/toaster/GroupChatToaster.cpp 
-	src/gui/toaster/ChatLobbyToaster.cpp 
-	src/gui/toaster/FriendRequestToaster.cpp 
-
-	src/gui/advsearch/advancedsearchdialog.cpp 
-	src/gui/advsearch/expressionwidget.cpp 
-	src/gui/advsearch/guiexprelement.cpp 
-
-	src/gui/elastic/graphwidget.cpp 
-	src/gui/elastic/edge.cpp 
-	src/gui/elastic/arrow.cpp 
-	src/gui/elastic/elnode.cpp 
-
-	src/gui/feeds/BoardsCommentsItem.cpp 
-	src/gui/feeds/FeedItem.cpp 
-	src/gui/feeds/FeedHolder.cpp 
-	src/gui/feeds/GxsCircleItem.cpp 
-	src/gui/feeds/ChannelsCommentsItem.cpp 
-	src/gui/feeds/PeerItem.cpp 
-	src/gui/feeds/MsgItem.cpp 
-	src/gui/feeds/ChatMsgItem.cpp 
-	src/gui/feeds/SubFileItem.cpp 
-	src/gui/feeds/AttachFileItem.cpp 
-	src/gui/feeds/SecurityItem.cpp 
-	src/gui/feeds/SecurityIpItem.cpp 
-	src/gui/feeds/NewsFeedUserNotify.cpp 
-
-	src/gui/groups/CreateGroup.cpp 
-
-	src/gui/statistics/BandwidthGraphWindow.cpp 
-	src/gui/statistics/BandwidthStatsWidget.cpp 
-	src/gui/statistics/DhtWindow.cpp 
-	src/gui/statistics/Histogram.cpp 
-	src/gui/statistics/TurtleRouterDialog.cpp 
-	src/gui/statistics/TurtleRouterStatistics.cpp 
-	src/gui/statistics/GxsIdStatistics.cpp 
-	src/gui/statistics/GlobalRouterStatistics.cpp 
-	src/gui/statistics/GxsTransportStatistics.cpp 
-	src/gui/statistics/StatisticsWindow.cpp 
-	src/gui/statistics/BwCtrlWindow.cpp 
-	src/gui/statistics/RttStatistics.cpp 
-	src/gui/statistics/BWGraph.cpp 
-
-	src/util/RsSyntaxHighlighter.cpp 
-	src/util/imageutil.cpp 
-	src/util/retroshareWin32.cpp
-
-	src/gui/NetworkDialog/pgpid_item_model.cpp 
-	src/gui/NetworkDialog/pgpid_item_proxy.cpp 
-	)
-
-list(
-	APPEND RS_GUI_FORMS
-	src/TorControl/TorControlWindow.ui
-
-	src/gui/StartDialog.ui 
-	src/gui/HomePage.ui
-	src/gui/GetStartedDialog.ui 
-	src/gui/GenCertDialog.ui 
-	src/gui/AboutDialog.ui 
-	src/gui/AboutWidget.ui 
-	src/gui/QuickStartWizard.ui 
-	src/gui/NetworkDialog.ui 
-	src/gui/common/AvatarDialog.ui 
-	src/gui/MainWindow.ui 
-	src/gui/NetworkView.ui 
-	src/gui/FriendsDialog.ui 
-	src/gui/NewsFeed.ui 
-	src/gui/ShareManager.ui 
-	src/gui/help/browser/helpbrowser.ui 
-	src/gui/HelpDialog.ui 
-	src/gui/ServicePermissionDialog.ui 
-	src/gui/ChatLobbyWidget.ui 
-
-	src/gui/FileTransfer/TransfersDialog.ui 
-	src/gui/FileTransfer/DetailsDialog.ui 
-	src/gui/FileTransfer/SearchDialog.ui 
-	src/gui/FileTransfer/SharedFilesDialog.ui 
-	src/gui/FileTransfer/BannedFilesDialog.ui 
-
-	src/gui/profile/ProfileWidget.ui 
-	src/gui/profile/StatusMessage.ui 
-	src/gui/profile/ProfileManager.ui 
-
-	src/gui/chat/PopupChatWindow.ui 
-	src/gui/chat/PopupChatDialog.ui 
-	src/gui/chat/ChatTabWidget.ui 
-	src/gui/chat/ChatWidget.ui 
-	src/gui/chat/ChatLobbyDialog.ui 
-	src/gui/chat/CreateLobbyDialog.ui 
-
-	src/gui/connect/ConfCertDialog.ui 
-	src/gui/connect/PGPKeyDialog.ui 
-	src/gui/connect/ConnectFriendWizard.ui 
-	src/gui/connect/ConnectProgressDialog.ui 
-	src/gui/connect/FriendRecommendDialog.ui 
-
-	src/gui/msgs/MessagesDialog.ui 
-	src/gui/msgs/MessageComposer.ui 
-	src/gui/msgs/MessageWindow.ui
-	src/gui/msgs/MessageWidget.ui
-
-	src/gui/settings/settingsw.ui 
-	src/gui/settings/GeneralPage.ui 
-	src/gui/settings/ServerPage.ui 
-	src/gui/settings/NotifyPage.ui 
-	src/gui/settings/PeoplePage.ui 
-	src/gui/settings/CryptoPage.ui 
-	src/gui/settings/MessagePage.ui 
-	src/gui/settings/NewTag.ui 
-	src/gui/settings/ForumPage.ui 
-	src/gui/settings/AboutPage.ui 
-	src/gui/settings/PluginsPage.ui 
-	src/gui/settings/AppearancePage.ui 
-	src/gui/settings/TransferPage.ui 
-	src/gui/settings/SoundPage.ui 
-	src/gui/settings/ChatPage.ui 
-	src/gui/settings/ChannelPage.ui 
-	src/gui/settings/PostedPage.ui 
-	src/gui/settings/ServicePermissionsPage.ui 
-	src/gui/settings/PluginItem.ui 
-	src/gui/settings/GroupFrameSettingsWidget.ui 
-
-	src/gui/toaster/MessageToaster.ui 
-	src/gui/toaster/OnlineToaster.ui 
-	src/gui/toaster/DownloadToaster.ui 
-	src/gui/toaster/ChatToaster.ui 
-	src/gui/toaster/GroupChatToaster.ui 
-	src/gui/toaster/ChatLobbyToaster.ui 
-	src/gui/toaster/FriendRequestToaster.ui 
-
-	src/gui/advsearch/AdvancedSearchDialog.ui 
-	src/gui/advsearch/expressionwidget.ui 
-
-	src/gui/feeds/BoardsCommentsItem.ui 
-	src/gui/feeds/GxsCircleItem.ui 
-	src/gui/feeds/ChannelsCommentsItem.ui 
-	src/gui/feeds/PeerItem.ui 
-	src/gui/feeds/MsgItem.ui 
-	src/gui/feeds/ChatMsgItem.ui 
-	src/gui/feeds/SubFileItem.ui 
-	src/gui/feeds/AttachFileItem.ui 
-	src/gui/feeds/SecurityItem.ui 
-	src/gui/feeds/SecurityIpItem.ui 
-
-	src/gui/im_history/ImHistoryBrowser.ui 
-
-	src/gui/groups/CreateGroup.ui 
-
-	src/gui/common/GroupTreeWidget.ui 
-	src/gui/common/AvatarWidget.ui 
-	src/gui/common/NewFriendList.ui 
-	src/gui/common/FriendSelectionWidget.ui 
-	src/gui/common/HashBox.ui 
-	src/gui/common/RSImageBlockWidget.ui 
-	src/gui/common/RsCollectionDialog.ui 
-	src/gui/common/HeaderFrame.ui 
-	src/gui/common/RSFeedWidget.ui 
-
-	src/gui/style/StyleDialog.ui 
-
-	src/gui/statistics/BandwidthGraphWindow.ui 
-	src/gui/statistics/BandwidthStatsWidget.ui 
-	src/gui/statistics/DhtWindow.ui 
-	src/gui/statistics/TurtleRouterDialog.ui 
-	src/gui/statistics/TurtleRouterStatistics.ui 
-	src/gui/statistics/GxsIdStatistics.ui 
-	src/gui/statistics/GlobalRouterStatistics.ui 
-	src/gui/statistics/GxsTransportStatistics.ui 
-	src/gui/statistics/StatisticsWindow.ui 
-	src/gui/statistics/BwCtrlWindow.ui 
-	src/gui/statistics/RttStatistics.ui 
-
-	src/util/RichTextEdit.ui
-	)
-
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
-
-	src/TorControl/TorControlWindow.h
-
-	src/chat/distantchat.h
-	src/chat/distributedchat.h
-	src/chat/p3chatservice.h
-	src/chat/rschatitems.h 
-
-	src/rshare.h 
-	src/retroshare-gui/configpage.h 
-	src/retroshare-gui/RsAutoUpdatePage.h 
-	src/retroshare-gui/mainpage.h 
-
-	src/control/bandwidthevent.h 
-	src/control/eventtype.h 
-
-	src/gui/QuickStartWizard.h 
-	src/gui/notifyqt.h 
-	src/gui/GetStartedDialog.h 
-	src/gui/StartDialog.h 
-	src/gui/HomePage.h
-	src/gui/NetworkDialog.h 
-	src/gui/GenCertDialog.h 
-	src/gui/linetypes.h 
-	src/gui/mainpagestack.h 
-	src/gui/MainWindow.h 
-	src/gui/RSHumanReadableDelegate.h 
-	src/gui/AboutDialog.h 
-	src/gui/AboutWidget.h 
-	src/gui/NetworkView.h 
-	src/gui/FriendsDialog.h 
-	src/gui/ServicePermissionDialog.h 
-	src/gui/RemoteDirModel.h 
-	src/gui/RetroShareLink.h 
-	src/gui/SearchTreeWidget.h 
-	src/gui/ShareManager.h 
-	src/gui/NewsFeed.h 
-	src/gui/ShareDialog.h 
-	src/gui/SFListDelegate.h 
-	src/gui/SoundManager.h 
-	src/gui/HelpDialog.h 
-	src/gui/LogoBar.h 
-
-	src/gui/common/AvatarDialog.h 
-
-	src/gui/NetworkDialog/pgpid_item_model.h 
-	src/gui/NetworkDialog/pgpid_item_proxy.h 
-
-	src/gui/FileTransfer/SearchDialog.h 
-	src/gui/FileTransfer/SharedFilesDialog.h 
-	src/gui/FileTransfer/xprogressbar.h 
-	src/gui/FileTransfer/DetailsDialog.h 
-	src/gui/FileTransfer/FileTransferInfoWidget.h 
-	src/gui/FileTransfer/DLListDelegate.h 
-	src/gui/FileTransfer/ULListDelegate.h 
-	src/gui/FileTransfer/TransfersDialog.h 
-	src/gui/FileTransfer/BannedFilesDialog.h 
-	src/gui/FileTransfer/TransferUserNotify.h 
-
-	src/gui/statistics/TurtleRouterDialog.h 
-	src/gui/statistics/TurtleRouterStatistics.h 
-	src/gui/statistics/GxsIdStatistics.h 
-	src/gui/statistics/dhtgraph.h 
-	src/gui/statistics/Histogram.h 
-	src/gui/statistics/BandwidthGraphWindow.h 
-	src/gui/statistics/turtlegraph.h 
-	src/gui/statistics/BandwidthStatsWidget.h 
-	src/gui/statistics/DhtWindow.h 
-	src/gui/statistics/GlobalRouterStatistics.h 
-	src/gui/statistics/GxsTransportStatistics.h 
-	src/gui/statistics/StatisticsWindow.h 
-	src/gui/statistics/BwCtrlWindow.h 
-	src/gui/statistics/BWGraph.h 
-	src/gui/statistics/RttStatistics.h 
-
-	src/gui/plugins/PluginInterface.h 
-
-	src/gui/im_history/ImHistoryBrowser.h 
-	src/gui/im_history/IMHistoryItemDelegate.h 
-	src/gui/im_history/IMHistoryItemPainter.h 
-
-	src/lang/languagesupport.h 
-
-	src/util/RsSyntaxHighlighter.h 
-	src/util/imageutil.h 
-	src/util/RichTextEdit.h 
-	src/util/retroshareWin32.h
-	src/util/RsProtectedTimer.h 
-	src/util/stringutil.h 
-	src/util/RsNetUtil.h 
-	src/util/DateTime.h 
-	src/util/RetroStyleLabel.h 
-	src/util/dllexport.h 
-	src/util/NonCopyable.h 
-	src/util/rsutildll.h 
-	src/util/dllexport.h 
-	src/util/global.h 
-	src/util/rsqtutildll.h 
-	src/util/Interface.h 
-	src/util/PixmapMerging.h 
-	src/util/MouseEventFilter.h 
-	src/util/EventFilter.h 
-	src/util/Widget.h 
-	src/util/RsAction.h 
-	src/util/RsUserdata.h 
-	src/util/printpreview.h 
-	src/util/log.h 
-	src/util/misc.h 
-	src/util/HandleRichText.h 
-	src/util/ObjectPainter.h 
-	src/util/RsQtVersion.h 
-	src/util/RsFile.h 
-	src/util/qtthreadsutils.h 
-	src/util/ClickableLabel.h 
-	src/util/AspectRatioPixmapLabel.h 
-
-	src/gui/profile/ProfileWidget.h 
-	src/gui/profile/ProfileManager.h 
-	src/gui/profile/StatusMessage.h 
-
-	src/gui/chat/PopupChatWindow.h 
-	src/gui/chat/PopupChatDialog.h 
-	src/gui/chat/PopupDistantChatDialog.h 
-	src/gui/chat/ChatTabWidget.h 
-	src/gui/chat/ChatWidget.h 
-	src/gui/chat/ChatDialog.h 
-	src/gui/ChatLobbyWidget.h 
-	src/gui/chat/ChatLobbyDialog.h 
-	src/gui/chat/CreateLobbyDialog.h 
-	src/gui/chat/ChatStyle.h 
-	src/gui/chat/ChatUserNotify.h 
-	src/gui/chat/ChatLobbyUserNotify.h 
-
-	src/gui/connect/ConfCertDialog.h 
-	src/gui/connect/PGPKeyDialog.h 
-	src/gui/connect/FriendRecommendDialog.h 
-
-	src/gui/msgs/MessagesDialog.h 
-	src/gui/msgs/MessageInterface.h 
-	src/gui/msgs/MessageComposer.h 
-	src/gui/msgs/MessageWindow.h 
-	src/gui/msgs/MessageWidget.h 
-	src/gui/msgs/MessageModel.h 
-	src/gui/msgs/TagsMenu.h 
-	src/gui/msgs/textformat.h 
-	src/gui/msgs/MessageUserNotify.h 
-
-	src/gui/images/retroshare_win.rc.h 
-
-	src/gui/settings/RSPermissionMatrixWidget.h 
-	src/gui/settings/rsharesettings.h 
-	src/gui/settings/RsharePeerSettings.h 
-	src/gui/settings/rsettings.h 
-	src/gui/settings/rsettingswin.h 
-	src/gui/settings/GeneralPage.h 
-	src/gui/settings/PeoplePage.h 
-	src/gui/settings/AboutPage.h 
-	src/gui/settings/ServerPage.h 
-	src/gui/settings/NotifyPage.h 
-	src/gui/settings/CryptoPage.h 
-	src/gui/settings/MessagePage.h 
-	src/gui/settings/NewTag.h 
-	src/gui/settings/ForumPage.h 
-	src/gui/settings/PluginsPage.h 
-	src/gui/settings/PluginItem.h 
-	src/gui/settings/AppearancePage.h 
-	src/gui/settings/FileAssociationsPage.h 
-	src/gui/settings/SoundPage.h 
-	src/gui/settings/TransferPage.h 
-	src/gui/settings/ChatPage.h 
-	src/gui/settings/ChannelPage.h 
-	src/gui/settings/PostedPage.h 
-	src/gui/settings/ServicePermissionsPage.h 
-	src/gui/settings/AddFileAssociationDialog.h 
-	src/gui/settings/GroupFrameSettingsWidget.h 
-
-	src/gui/toaster/ToasterItem.h 
-	src/gui/toaster/MessageToaster.h 
-	src/gui/toaster/OnlineToaster.h 
-	src/gui/toaster/DownloadToaster.h 
-	src/gui/toaster/ChatToaster.h 
-	src/gui/toaster/GroupChatToaster.h 
-	src/gui/toaster/ChatLobbyToaster.h 
-	src/gui/toaster/FriendRequestToaster.h 
-
-	src/gui/common/RsButtonOnText.h 
-	src/gui/common/RsCollection.h 
-	src/gui/common/RSGraphWidget.h 
-	src/gui/common/ElidedLabel.h 
-	src/gui/common/vmessagebox.h 
-	src/gui/common/RsUrlHandler.h 
-	src/gui/common/RsCollectionDialog.h 
-	src/gui/common/rwindow.h 
-	src/gui/common/rshtml.h 
-	src/gui/common/AvatarDefs.h 
-	src/gui/common/GroupFlagsWidget.h 
-	src/gui/common/GroupSelectionBox.h 
-	src/gui/common/GroupChooser.h 
-	src/gui/common/StatusDefs.h 
-	src/gui/common/TagDefs.h 
-	src/gui/common/GroupDefs.h 
-	src/gui/common/Emoticons.h 
-	src/gui/common/RSComboBox.h 
-	src/gui/common/RSListWidgetItem.h 
-	src/gui/common/RSTextEdit.h 
-	src/gui/common/RSPlainTextEdit.h 
-	src/gui/common/RSTreeWidget.h 
-	src/gui/common/RSTreeWidgetItem.h 
-	src/gui/common/RSFeedWidget.h 
-	src/gui/common/RSTabWidget.h 
-	src/gui/common/RSElidedItemDelegate.h 
-	src/gui/common/RSItemDelegate.h 
-	src/gui/common/PeerDefs.h 
-	src/gui/common/FilesDefs.h 
-	src/gui/common/PopularityDefs.h 
-	src/gui/common/RsBanListDefs.h 
-	src/gui/common/GroupTreeWidget.h 
-	src/gui/common/RSTreeView.h 
-	src/gui/common/AvatarWidget.h 
-	src/gui/common/FriendListModel.h 
-	src/gui/common/NewFriendList.h 
-	src/gui/common/FriendSelectionWidget.h 
-	src/gui/common/FriendSelectionDialog.h 
-	src/gui/common/HashBox.h 
-	src/gui/common/LineEditClear.h 
-	src/gui/common/DropLineEdit.h 
-	src/gui/common/RSTextBrowser.h 
-	src/gui/common/RSImageBlockWidget.h 
-	src/gui/common/FeedNotify.h 
-	src/gui/common/UserNotify.h 
-	src/gui/common/HeaderFrame.h 
-	src/gui/common/MimeTextEdit.h 
-	src/gui/common/UIStateHelper.h 
-	src/gui/common/FloatingHelpBrowser.h 
-	src/gui/common/SubscribeToolButton.h 
-	src/gui/common/RsBanListToolButton.h 
-	src/gui/common/FlowLayout.h 
-	src/gui/common/PictureFlow.h 
-	src/gui/common/ToasterNotify.h 
-
-	src/gui/style/RSStyle.h 
-	src/gui/style/StyleDialog.h 
-
-	src/gui/help/browser/helpbrowser.h 
-	src/gui/help/browser/helptextbrowser.h 
-
-	src/gui/statusbar/peerstatus.h 
-	src/gui/statusbar/natstatus.h 
-	src/gui/statusbar/dhtstatus.h 
-	src/gui/statusbar/torstatus.h 
-	src/gui/statusbar/ratesstatus.h 
-	src/gui/statusbar/hashingstatus.h 
-	src/gui/statusbar/discstatus.h 
-	src/gui/statusbar/SoundStatus.h 
-	src/gui/statusbar/OpModeStatus.h 
-	src/gui/statusbar/ToasterDisable.h 
-	src/gui/statusbar/SysTrayStatus.h 
-
-	src/gui/advsearch/advancedsearchdialog.h 
-	src/gui/advsearch/expressionwidget.h 
-	src/gui/advsearch/guiexprelement.h 
-
-	src/gui/elastic/graphwidget.h 
-	src/gui/elastic/edge.h 
-	src/gui/elastic/arrow.h 
-	src/gui/elastic/elnode.h 
-
-	src/gui/feeds/BoardsCommentsItem.h 
-	src/gui/feeds/FeedItem.h 
-	src/gui/feeds/FeedHolder.h 
-	src/gui/feeds/GxsCircleItem.h 
-	src/gui/feeds/ChannelsCommentsItem.h 
-	src/gui/feeds/PeerItem.h 
-	src/gui/feeds/MsgItem.h 
-	src/gui/feeds/ChatMsgItem.h 
-	src/gui/feeds/SubFileItem.h 
-	src/gui/feeds/AttachFileItem.h 
-	src/gui/feeds/SecurityItem.h 
-	src/gui/feeds/SecurityIpItem.h 
-	src/gui/feeds/NewsFeedUserNotify.h 
-
-	src/gui/connect/ConnectFriendWizard.h 
-	src/gui/connect/ConnectProgressDialog.h 
-
-	src/gui/groups/CreateGroup.h 
-	)
+set(RS_GUI_SOURCES 
+    src/TorControl/TorControlWindow.cpp
+    src/gui/AboutDialog.cpp
+    src/gui/AboutWidget.cpp
+    src/gui/ChatLobbyWidget.cpp
+    src/gui/Circles/CirclesDialog.cpp
+    src/gui/Circles/CreateCircleDialog.cpp
+    src/gui/FileTransfer/BannedFilesDialog.cpp
+    src/gui/FileTransfer/DLListDelegate.cpp
+    src/gui/FileTransfer/DetailsDialog.cpp
+    src/gui/FileTransfer/FileTransferInfoWidget.cpp
+    src/gui/FileTransfer/SearchDialog.cpp
+    src/gui/FileTransfer/SharedFilesDialog.cpp
+    src/gui/FileTransfer/TransferUserNotify.cpp
+    src/gui/FileTransfer/TransfersDialog.cpp
+    src/gui/FileTransfer/ULListDelegate.cpp
+    src/gui/FileTransfer/xprogressbar.cpp
+    src/gui/FriendServerControl.cpp
+    src/gui/FriendsDialog.cpp
+    src/gui/GenCertDialog.cpp
+    src/gui/GetStartedDialog.cpp
+    src/gui/HelpDialog.cpp
+    src/gui/HomePage.cpp
+    src/gui/Identity/IdDetailsDialog.cpp
+    src/gui/Identity/IdDialog.cpp
+    src/gui/Identity/IdEditDialog.cpp
+    src/gui/Identity/IdentityListModel.cpp
+    src/gui/LogoBar.cpp
+    src/gui/MainPage.cpp
+    src/gui/MainWindow.cpp
+    src/gui/NetworkDialog.cpp
+    src/gui/NetworkDialog/pgpid_item_model.cpp
+    src/gui/NetworkDialog/pgpid_item_proxy.cpp
+    src/gui/NetworkView.cpp
+    src/gui/NewsFeed.cpp
+    src/gui/People/CircleWidget.cpp
+    src/gui/People/IdentityWidget.cpp
+    src/gui/People/PeopleDialog.cpp
+)
+
+if(RS_GXSPHOTOSHARE)
+    list(APPEND RS_GUI_SOURCES
+        src/gui/PhotoShare/AlbumDialog.cpp
+        src/gui/PhotoShare/AlbumExtra.cpp
+        src/gui/PhotoShare/AlbumGroupDialog.cpp
+        src/gui/PhotoShare/AlbumItem.cpp
+        src/gui/PhotoShare/PhotoDialog.cpp
+        src/gui/PhotoShare/PhotoDrop.cpp
+        src/gui/PhotoShare/PhotoItem.cpp
+        src/gui/PhotoShare/PhotoShare.cpp
+        src/gui/PhotoShare/PhotoShareItemHolder.cpp
+        src/gui/PhotoShare/PhotoSlideShow.cpp
+    )
+endif()
+
+list(APPEND RS_GUI_SOURCES
+    src/gui/PluginManager.cpp
+    src/gui/PluginManagerWidget.cpp
+    src/gui/PluginsPage.cpp
+    src/gui/Posted/BoardPostDisplayWidget.cpp
+    src/gui/Posted/BoardPostImageHelper.cpp
+    src/gui/Posted/PhotoView.cpp
+    src/gui/Posted/PostedCardView.cpp
+    src/gui/Posted/PostedCreatePostDialog.cpp
+    src/gui/Posted/PostedDialog.cpp
+    src/gui/Posted/PostedGroupDialog.cpp
+    src/gui/Posted/PostedItem.cpp
+    src/gui/Posted/PostedListWidgetWithModel.cpp
+    src/gui/Posted/PostedPostsModel.cpp
+    src/gui/Posted/PostedUserNotify.cpp
+    src/gui/QuickStartWizard.cpp
+    src/gui/RemoteDirModel.cpp
+    src/gui/RetroShareLink.cpp
+    src/gui/RsAutoUpdatePage.cpp
+    src/gui/RsGUIEventManager.cpp
+    src/gui/SearchTreeWidget.cpp
+    src/gui/ServicePermissionDialog.cpp
+    src/gui/ShareManager.cpp
+    src/gui/SoundManager.cpp
+    src/gui/StartDialog.cpp
+)
+
+if(RS_GXSTHEWIRE)
+    list(APPEND RS_GUI_SOURCES
+        src/gui/TheWire/CustomFrame.cpp
+        src/gui/TheWire/PulseAddDialog.cpp
+        src/gui/TheWire/PulseMessage.cpp
+        src/gui/TheWire/PulseReply.cpp
+        src/gui/TheWire/PulseReplySeperator.cpp
+        src/gui/TheWire/PulseTopLevel.cpp
+        src/gui/TheWire/PulseViewGroup.cpp
+        src/gui/TheWire/PulseViewItem.cpp
+        src/gui/TheWire/WireDialog.cpp
+        src/gui/TheWire/WireGroupDialog.cpp
+        src/gui/TheWire/WireGroupExtra.cpp
+        src/gui/TheWire/WireGroupItem.cpp
+        src/gui/TheWire/WireUserNotify.cpp
+        src/gui/feeds/WireNotifyGroupItem.cpp
+        src/gui/feeds/WireNotifyPostItem.cpp
+    )
+endif()
+
+if(RS_GXSWIKIPOS)
+    list(APPEND RS_GUI_SOURCES
+        src/gui/WikiPoos/WikiAddDialog.cpp
+        src/gui/WikiPoos/WikiDialog.cpp
+        src/gui/WikiPoos/WikiEditDialog.cpp
+        src/gui/WikiPoos/WikiUserNotify.cpp
+    )
+endif()
+
+list(APPEND RS_GUI_SOURCES
+    src/gui/advsearch/advancedsearchdialog.cpp
+    src/gui/advsearch/expressionwidget.cpp
+    src/gui/advsearch/guiexprelement.cpp
+    src/gui/chat/ChatDialog.cpp
+    src/gui/chat/ChatLobbyDialog.cpp
+    src/gui/chat/ChatLobbyUserNotify.cpp
+    src/gui/chat/ChatStyle.cpp
+    src/gui/chat/ChatTabWidget.cpp
+    src/gui/chat/ChatUserNotify.cpp
+    src/gui/chat/ChatWidget.cpp
+    src/gui/chat/CreateLobbyDialog.cpp
+    src/gui/chat/PopupChatDialog.cpp
+    src/gui/chat/PopupChatWindow.cpp
+    src/gui/chat/PopupDistantChatDialog.cpp
+    src/gui/common/AvatarDefs.cpp
+    src/gui/common/AvatarDialog.cpp
+    src/gui/common/AvatarWidget.cpp
+    src/gui/common/DropLineEdit.cpp
+    src/gui/common/ElidedLabel.cpp
+    src/gui/common/Emoticons.cpp
+    src/gui/common/FeedNotify.cpp
+    src/gui/common/FilesDefs.cpp
+    src/gui/common/FloatingHelpBrowser.cpp
+    src/gui/common/FlowLayout.cpp
+    src/gui/common/FriendListModel.cpp
+    src/gui/common/FriendSelectionDialog.cpp
+    src/gui/common/FriendSelectionWidget.cpp
+    src/gui/common/GroupChooser.cpp
+    src/gui/common/GroupDefs.cpp
+    src/gui/common/GroupFlagsWidget.cpp
+    src/gui/common/GroupSelectionBox.cpp
+    src/gui/common/GroupTreeWidget.cpp
+    src/gui/common/HashBox.cpp
+    src/gui/common/HeaderFrame.cpp
+    src/gui/common/LineEditClear.cpp
+    src/gui/common/MimeTextEdit.cpp
+    src/gui/common/NewFriendList.cpp
+    src/gui/common/PeerDefs.cpp
+    src/gui/common/PictureFlow.cpp
+    src/gui/common/PopularityDefs.cpp
+    src/gui/common/RSComboBox.cpp
+    src/gui/common/RSElidedItemDelegate.cpp
+    src/gui/common/RSFeedWidget.cpp
+    src/gui/common/RSGraphWidget.cpp
+    src/gui/common/RSImageBlockWidget.cpp
+    src/gui/common/RSItemDelegate.cpp
+    src/gui/common/RSListWidgetItem.cpp
+    src/gui/common/RSPlainTextEdit.cpp
+    src/gui/common/RSTabWidget.cpp
+    src/gui/common/RSTextBrowser.cpp
+    src/gui/common/RSTextEdit.cpp
+    src/gui/common/RSTreeView.cpp
+    src/gui/common/RSTreeWidget.cpp
+    src/gui/common/RSTreeWidgetItem.cpp
+    src/gui/common/RsBanListDefs.cpp
+    src/gui/common/RsBanListToolButton.cpp
+    src/gui/common/RsButtonOnText.cpp
+    src/gui/common/RsCollection.cpp
+    src/gui/common/RsCollectionDialog.cpp
+    src/gui/common/RsCollectionModel.cpp
+    src/gui/common/RsUrlHandler.cpp
+    src/gui/common/StatusDefs.cpp
+    src/gui/common/SubscribeToolButton.cpp
+    src/gui/common/TagDefs.cpp
+    src/gui/common/ToasterNotify.cpp
+    src/gui/common/UIStateHelper.cpp
+    src/gui/common/UserNotify.cpp
+    src/gui/common/rshtml.cpp
+    src/gui/common/rwindow.cpp
+    src/gui/common/vmessagebox.cpp
+    src/gui/connect/ConfCertDialog.cpp
+    src/gui/connect/ConnectFriendWizard.cpp
+    src/gui/connect/ConnectProgressDialog.cpp
+    src/gui/connect/FriendRecommendDialog.cpp
+    src/gui/connect/PGPKeyDialog.cpp
+    src/gui/elastic/arrow.cpp
+    src/gui/elastic/edge.cpp
+    src/gui/elastic/elnode.cpp
+    src/gui/elastic/graphwidget.cpp
+    src/gui/feeds/AttachFileItem.cpp
+    src/gui/feeds/BoardsCommentsItem.cpp
+    src/gui/feeds/BoardsPostItem.cpp
+    src/gui/feeds/ChannelsCommentsItem.cpp
+    src/gui/feeds/ChatMsgItem.cpp
+    src/gui/feeds/FeedHolder.cpp
+    src/gui/feeds/FeedItem.cpp
+    src/gui/feeds/GxsChannelGroupItem.cpp
+    src/gui/feeds/GxsChannelPostItem.cpp
+    src/gui/feeds/GxsCircleItem.cpp
+    src/gui/feeds/GxsFeedItem.cpp
+    src/gui/feeds/GxsForumGroupItem.cpp
+    src/gui/feeds/GxsForumMsgItem.cpp
+    src/gui/feeds/GxsGroupFeedItem.cpp
+    src/gui/feeds/MsgItem.cpp
+    src/gui/feeds/NewsFeedUserNotify.cpp
+    src/gui/feeds/PeerItem.cpp
+    src/gui/feeds/PostedGroupItem.cpp
+    src/gui/feeds/SecurityIpItem.cpp
+    src/gui/feeds/SecurityItem.cpp
+    src/gui/feeds/SubFileItem.cpp
+    src/gui/groups/CreateGroup.cpp
+    src/gui/gxs/GxsCircleChooser.cpp
+    src/gui/gxs/GxsCircleLabel.cpp
+    src/gui/gxs/GxsCommentContainer.cpp
+    src/gui/gxs/GxsCommentDialog.cpp
+    src/gui/gxs/GxsCommentTreeWidget.cpp
+    src/gui/gxs/GxsCreateCommentDialog.cpp
+    src/gui/gxs/GxsGroupDialog.cpp
+    src/gui/gxs/GxsGroupFrameDialog.cpp
+    src/gui/gxs/GxsGroupShareKey.cpp
+    src/gui/gxs/GxsIdChooser.cpp
+    src/gui/gxs/GxsIdDetails.cpp
+    src/gui/gxs/GxsIdLabel.cpp
+    src/gui/gxs/GxsIdTreeWidgetItem.cpp
+    src/gui/gxs/GxsMessageFramePostWidget.cpp
+    src/gui/gxs/GxsMessageFrameWidget.cpp
+    src/gui/gxs/GxsStatisticsProvider.cpp
+    src/gui/gxs/GxsUserNotify.cpp
+    src/gui/gxs/RsGxsUpdateBroadcastBase.cpp
+    src/gui/gxs/RsGxsUpdateBroadcastPage.cpp
+    src/gui/gxs/RsGxsUpdateBroadcastWidget.cpp
+)
+
+if(RS_GXSWIKIPOS)
+    list(APPEND RS_GUI_SOURCES src/gui/gxs/WikiGroupDialog.cpp)
+endif()
+
+list(APPEND RS_GUI_SOURCES
+    src/gui/gxschannels/CreateGxsChannelMsg.cpp
+    src/gui/gxschannels/GxsChannelDialog.cpp
+    src/gui/gxschannels/GxsChannelFilesStatusWidget.cpp
+    src/gui/gxschannels/GxsChannelGroupDialog.cpp
+    src/gui/gxschannels/GxsChannelPostFilesModel.cpp
+    src/gui/gxschannels/GxsChannelPostThumbnail.cpp
+    src/gui/gxschannels/GxsChannelPostsModel.cpp
+    src/gui/gxschannels/GxsChannelPostsWidgetWithModel.cpp
+    src/gui/gxschannels/GxsChannelUserNotify.cpp
+    src/gui/gxsforums/CreateGxsForumMsg.cpp
+    src/gui/gxsforums/GxsForumGroupDialog.cpp
+    src/gui/gxsforums/GxsForumModel.cpp
+    src/gui/gxsforums/GxsForumThreadWidget.cpp
+    src/gui/gxsforums/GxsForumUserNotify.cpp
+    src/gui/gxsforums/GxsForumsDialog.cpp
+    src/gui/help/browser/helpbrowser.cpp
+    src/gui/help/browser/helptextbrowser.cpp
+    src/gui/im_history/IMHistoryItemDelegate.cpp
+    src/gui/im_history/IMHistoryItemPainter.cpp
+    src/gui/im_history/ImHistoryBrowser.cpp
+    src/gui/mainpagestack.cpp
+    src/gui/msgs/MessageComposer.cpp
+    src/gui/msgs/MessageModel.cpp
+    src/gui/msgs/MessageUserNotify.cpp
+    src/gui/msgs/MessageWidget.cpp
+    src/gui/msgs/MessageWindow.cpp
+    src/gui/msgs/MessagesDialog.cpp
+    src/gui/msgs/TagsMenu.cpp
+    src/gui/profile/ProfileManager.cpp
+    src/gui/profile/ProfileWidget.cpp
+    src/gui/profile/StatusMessage.cpp
+    src/gui/settings/AboutPage.cpp
+    src/gui/settings/AddFileAssociationDialog.cpp
+    src/gui/settings/AppearancePage.cpp
+    src/gui/settings/ChannelPage.cpp
+    src/gui/settings/ChatPage.cpp
+    src/gui/settings/CryptoPage.cpp
+    src/gui/settings/FileAssociationsPage.cpp
+    src/gui/settings/ForumPage.cpp
+    src/gui/settings/GeneralPage.cpp
+    src/gui/settings/GroupFrameSettingsWidget.cpp
+    src/gui/settings/MessagePage.cpp
+    src/gui/settings/NewTag.cpp
+    src/gui/settings/NotifyPage.cpp
+    src/gui/settings/PeoplePage.cpp
+    src/gui/settings/PluginItem.cpp
+    src/gui/settings/PluginsPage.cpp
+    src/gui/settings/PostedPage.cpp
+    src/gui/settings/RSPermissionMatrixWidget.cpp
+    src/gui/settings/RsharePeerSettings.cpp
+    src/gui/settings/ServerPage.cpp
+    src/gui/settings/ServicePermissionsPage.cpp
+    src/gui/settings/SoundPage.cpp
+    src/gui/settings/TransferPage.cpp
+    src/gui/settings/rsettings.cpp
+    src/gui/settings/rsettingswin.cpp
+    src/gui/settings/rsharesettings.cpp
+    src/gui/statistics/BWGraph.cpp
+    src/gui/statistics/BandwidthGraphWindow.cpp
+    src/gui/statistics/BandwidthStatsWidget.cpp
+    src/gui/statistics/BwCtrlWindow.cpp
+    src/gui/statistics/DhtWindow.cpp
+    src/gui/statistics/GlobalRouterStatistics.cpp
+    src/gui/statistics/GxsIdStatistics.cpp
+    src/gui/statistics/GxsNetTunnelsDialog.cpp
+    src/gui/statistics/GxsTransportStatistics.cpp
+    src/gui/statistics/Histogram.cpp
+    src/gui/statistics/RttStatistics.cpp
+    src/gui/statistics/StatisticsWindow.cpp
+    src/gui/statistics/TunnelStatisticsDialog.cpp
+    src/gui/statistics/TurtleRouterDialog.cpp
+    src/gui/statistics/TurtleRouterStatistics.cpp
+    src/gui/statusbar/OpModeStatus.cpp
+    src/gui/statusbar/SoundStatus.cpp
+    src/gui/statusbar/SysTrayStatus.cpp
+    src/gui/statusbar/ToasterDisable.cpp
+    src/gui/statusbar/dhtstatus.cpp
+    src/gui/statusbar/discstatus.cpp
+    src/gui/statusbar/hashingstatus.cpp
+    src/gui/statusbar/natstatus.cpp
+    src/gui/statusbar/peerstatus.cpp
+    src/gui/statusbar/ratesstatus.cpp
+    src/gui/statusbar/torstatus.cpp
+    src/gui/style/RSStyle.cpp
+    src/gui/style/StyleDialog.cpp
+    src/gui/toaster/ChatLobbyToaster.cpp
+    src/gui/toaster/ChatToaster.cpp
+    src/gui/toaster/DownloadToaster.cpp
+    src/gui/toaster/FriendRequestToaster.cpp
+    src/gui/toaster/GroupChatToaster.cpp
+    src/gui/toaster/MessageToaster.cpp
+    src/gui/toaster/OnlineToaster.cpp
+    src/gui/toaster/ToasterItem.cpp
+    src/idle/idle.cpp
+    src/idle/idle_platform.cpp
+    src/lang/languagesupport.cpp
+    src/main.cpp
+    src/rshare.cpp
+    src/util/AspectRatioPixmapLabel.cpp
+    src/util/ClickableLabel.cpp
+    src/util/DateTime.cpp
+    src/util/EventFilter.cpp
+    src/util/FontSizeHandler.cpp
+    src/util/HandleRichText.cpp
+    src/util/MouseEventFilter.cpp
+    src/util/ObjectPainter.cpp
+    src/util/PixmapMerging.cpp
+    src/util/RetroStyleLabel.cpp
+    src/util/RichTextEdit.cpp
+    src/util/RsAction.cpp
+    src/util/RsFile.cpp
+    src/util/RsGxsUpdateBroadcast.cpp
+    src/util/RsNetUtil.cpp
+    src/util/RsProtectedTimer.cpp
+    src/util/RsQtVersion.cpp
+    src/util/RsSyntaxHighlighter.cpp
+    src/util/TokenQueue.cpp
+    src/util/Widget.cpp
+    src/util/WidgetBackgroundImage.cpp
+    src/util/imageutil.cpp
+    src/util/log.cpp
+    src/util/misc.cpp
+    src/util/printpreview.cpp
+    src/util/retroshareWin32.cpp
+    src/util/stringutil.cpp
+)
+
+set(RS_GUI_FORMS 
+    src/TorControl/TorControlWindow.ui
+    src/gui/AboutDialog.ui
+    src/gui/AboutWidget.ui
+    src/gui/ChatLobbyWidget.ui
+    src/gui/Circles/CirclesDialog.ui
+    src/gui/Circles/CreateCircleDialog.ui
+    src/gui/FileTransfer/BannedFilesDialog.ui
+    src/gui/FileTransfer/DetailsDialog.ui
+    src/gui/FileTransfer/SearchDialog.ui
+    src/gui/FileTransfer/SharedFilesDialog.ui
+    src/gui/FileTransfer/TransfersDialog.ui
+    src/gui/FriendServerControl.ui
+    src/gui/FriendsDialog.ui
+    src/gui/GenCertDialog.ui
+    src/gui/GetStartedDialog.ui
+    src/gui/HelpDialog.ui
+    src/gui/HomePage.ui
+    src/gui/Identity/IdDetailsDialog.ui
+    src/gui/Identity/IdDialog.ui
+    src/gui/Identity/IdEditDialog.ui
+    src/gui/MainWindow.ui
+    src/gui/NetworkDialog.ui
+    src/gui/NetworkView.ui
+    src/gui/NewsFeed.ui
+    src/gui/People/CircleWidget.ui
+    src/gui/People/IdentityWidget.ui
+    src/gui/People/PeopleDialog.ui
+)
+
+list(APPEND RS_GUI_FORMS
+    src/gui/Posted/BoardPostDisplayWidget_card.ui
+    src/gui/Posted/BoardPostDisplayWidget_compact.ui
+    src/gui/Posted/PhotoView.ui
+    src/gui/Posted/PostedCardView.ui
+    src/gui/Posted/PostedCreatePostDialog.ui
+    src/gui/Posted/PostedItem.ui
+    src/gui/Posted/PostedListWidgetWithModel.ui
+    src/gui/QuickStartWizard.ui
+    src/gui/ServicePermissionDialog.ui
+    src/gui/ShareManager.ui
+    src/gui/StartDialog.ui
+)
+
+list(APPEND RS_GUI_FORMS
+    src/gui/advsearch/AdvancedSearchDialog.ui
+    src/gui/advsearch/expressionwidget.ui
+    src/gui/chat/ChatLobbyDialog.ui
+    src/gui/chat/ChatTabWidget.ui
+    src/gui/chat/ChatWidget.ui
+    src/gui/chat/CreateLobbyDialog.ui
+    src/gui/chat/PopupChatDialog.ui
+    src/gui/chat/PopupChatWindow.ui
+    src/gui/common/AvatarDialog.ui
+    src/gui/common/AvatarWidget.ui
+    src/gui/common/FriendSelectionWidget.ui
+    src/gui/common/GroupTreeWidget.ui
+    src/gui/common/HashBox.ui
+    src/gui/common/HeaderFrame.ui
+    src/gui/common/NewFriendList.ui
+    src/gui/common/RSFeedWidget.ui
+    src/gui/common/RSImageBlockWidget.ui
+    src/gui/common/RsCollectionDialog.ui
+    src/gui/connect/ConfCertDialog.ui
+    src/gui/connect/ConnectFriendWizard.ui
+    src/gui/connect/ConnectProgressDialog.ui
+    src/gui/connect/FriendRecommendDialog.ui
+    src/gui/connect/PGPKeyDialog.ui
+    src/gui/feeds/AttachFileItem.ui
+    src/gui/feeds/BoardsCommentsItem.ui
+    src/gui/feeds/BoardsPostItem.ui
+    src/gui/feeds/ChannelsCommentsItem.ui
+    src/gui/feeds/ChatMsgItem.ui
+    src/gui/feeds/GxsChannelGroupItem.ui
+    src/gui/feeds/GxsChannelPostItem.ui
+    src/gui/feeds/GxsCircleItem.ui
+    src/gui/feeds/GxsForumGroupItem.ui
+    src/gui/feeds/GxsForumMsgItem.ui
+    src/gui/feeds/MsgItem.ui
+    src/gui/feeds/PeerItem.ui
+    src/gui/feeds/PostedGroupItem.ui
+    src/gui/feeds/SecurityIpItem.ui
+    src/gui/feeds/SecurityItem.ui
+    src/gui/feeds/SubFileItem.ui
+    src/gui/groups/CreateGroup.ui
+    src/gui/gxs/GxsCommentContainer.ui
+    src/gui/gxs/GxsCommentDialog.ui
+    src/gui/gxs/GxsCreateCommentDialog.ui
+    src/gui/gxs/GxsGroupDialog.ui
+    src/gui/gxs/GxsGroupFrameDialog.ui
+    src/gui/gxs/GxsGroupShareKey.ui
+    src/gui/gxschannels/GxsChannelFilesStatusWidget.ui
+    src/gui/gxschannels/GxsChannelPostsWidgetWithModel.ui
+    src/gui/gxsforums/GxsForumThreadWidget.ui
+    src/gui/msgs/MessageComposer.ui
+    src/gui/msgs/MessageWidget.ui
+    src/gui/msgs/MessageWindow.ui
+    src/gui/msgs/MessagesDialog.ui
+    src/gui/profile/ProfileWidget.ui
+    src/gui/settings/AboutPage.ui
+    src/gui/settings/AppearancePage.ui
+    src/gui/settings/ChannelPage.ui
+    src/gui/settings/ChatPage.ui
+    src/gui/settings/CryptoPage.ui
+    src/gui/settings/ForumPage.ui
+    src/gui/settings/GeneralPage.ui
+    src/gui/settings/GroupFrameSettingsWidget.ui
+    src/gui/settings/MessagePage.ui
+    src/gui/settings/NewTag.ui
+    src/gui/settings/NotifyPage.ui
+    src/gui/settings/PeoplePage.ui
+    src/gui/settings/PluginsPage.ui
+    src/gui/settings/PostedPage.ui
+    src/gui/settings/ServerPage.ui
+    src/gui/settings/ServicePermissionsPage.ui
+    src/gui/settings/SoundPage.ui
+    src/gui/settings/TransferPage.ui
+    src/gui/statistics/BandwidthGraphWindow.ui
+    src/gui/statistics/BandwidthStatsWidget.ui
+    src/gui/statistics/BwCtrlWindow.ui
+    src/gui/statistics/DhtWindow.ui
+    src/gui/statistics/GlobalRouterStatistics.ui
+    src/gui/statistics/GxsIdStatistics.ui
+    src/gui/statistics/GxsNetTunnelsDialog.ui
+    src/gui/statistics/GxsTransportStatistics.ui
+    src/gui/statistics/RttStatistics.ui
+    src/gui/statistics/StatisticsWindow.ui
+    src/gui/statistics/TunnelStatisticsDialog.ui
+    src/gui/statistics/TurtleRouterDialog.ui
+    src/gui/statistics/TurtleRouterStatistics.ui
+    src/gui/style/StyleDialog.ui
+)
+
+set(RS_GUI_HEADERS 
+    src/TorControl/TorControlWindow.h
+    src/control/bandwidthevent.h
+    src/control/eventtype.h
+    src/gui/AboutDialog.h
+    src/gui/AboutWidget.h
+    src/gui/ChatLobbyWidget.h
+    src/gui/Circles/CirclesDialog.h
+    src/gui/Circles/CreateCircleDialog.h
+    src/gui/FileTransfer/BannedFilesDialog.h
+    src/gui/FileTransfer/DLListDelegate.h
+    src/gui/FileTransfer/DetailsDialog.h
+    src/gui/FileTransfer/FileTransferInfoWidget.h
+    src/gui/FileTransfer/SearchDialog.h
+    src/gui/FileTransfer/SharedFilesDialog.h
+    src/gui/FileTransfer/TransferUserNotify.h
+    src/gui/FileTransfer/TransfersDialog.h
+    src/gui/FileTransfer/ULListDelegate.h
+    src/gui/FileTransfer/xprogressbar.h
+    src/gui/FriendServerControl.h
+    src/gui/FriendsDialog.h
+    src/gui/GenCertDialog.h
+    src/gui/GetStartedDialog.h
+    src/gui/HelpDialog.h
+    src/gui/HomePage.h
+    src/gui/Identity/IdDetailsDialog.h
+    src/gui/Identity/IdDialog.h
+    src/gui/Identity/IdEditDialog.h
+    src/gui/Identity/IdentityListModel.h
+    src/gui/LogoBar.h
+    src/gui/MainWindow.h
+    src/gui/NetworkDialog.h
+    src/gui/NetworkDialog/pgpid_item_model.h
+    src/gui/NetworkDialog/pgpid_item_proxy.h
+    src/gui/NetworkView.h
+    src/gui/NewsFeed.h
+    src/gui/People/CircleWidget.h
+    src/gui/People/IdentityWidget.h
+    src/gui/People/PeopleDialog.h
+)
+
+if(RS_GXSPHOTOSHARE)
+    list(APPEND RS_GUI_HEADERS
+        src/gui/PhotoShare/AlbumDialog.h
+        src/gui/PhotoShare/AlbumExtra.h
+        src/gui/PhotoShare/AlbumGroupDialog.h
+        src/gui/PhotoShare/AlbumItem.h
+        src/gui/PhotoShare/PhotoDialog.h
+        src/gui/PhotoShare/PhotoDrop.h
+        src/gui/PhotoShare/PhotoItem.h
+        src/gui/PhotoShare/PhotoShare.h
+        src/gui/PhotoShare/PhotoShareItemHolder.h
+        src/gui/PhotoShare/PhotoSlideShow.h
+    )
+endif()
+
+list(APPEND RS_GUI_HEADERS
+    src/gui/PluginManager.h
+    src/gui/PluginManagerWidget.h
+    src/gui/PluginsPage.h
+    src/gui/Posted/BoardPostDisplayWidget.h
+    src/gui/Posted/BoardPostImageHelper.h
+    src/gui/Posted/PhotoView.h
+    src/gui/Posted/PostedCardView.h
+    src/gui/Posted/PostedCreatePostDialog.h
+    src/gui/Posted/PostedDialog.h
+    src/gui/Posted/PostedGroupDialog.h
+    src/gui/Posted/PostedItem.h
+    src/gui/Posted/PostedListWidgetWithModel.h
+    src/gui/Posted/PostedPostsModel.h
+    src/gui/Posted/PostedUserNotify.h
+    src/gui/QuickStartWizard.h
+    src/gui/RSHumanReadableDelegate.h
+    src/gui/RemoteDirModel.h
+    src/gui/RetroShareLink.h
+    src/gui/RsGUIEventManager.h
+    src/gui/SearchTreeWidget.h
+    src/gui/ServicePermissionDialog.h
+    src/gui/ShareManager.h
+    src/gui/SoundManager.h
+    src/gui/StartDialog.h
+)
+
+list(APPEND RS_GUI_HEADERS
+    src/gui/advsearch/advancedsearchdialog.h
+    src/gui/advsearch/expressionwidget.h
+    src/gui/advsearch/guiexprelement.h
+    src/gui/chat/ChatDialog.h
+    src/gui/chat/ChatLobbyDialog.h
+    src/gui/chat/ChatLobbyUserNotify.h
+    src/gui/chat/ChatStyle.h
+    src/gui/chat/ChatTabWidget.h
+    src/gui/chat/ChatUserNotify.h
+    src/gui/chat/ChatWidget.h
+    src/gui/chat/CreateLobbyDialog.h
+    src/gui/chat/PopupChatDialog.h
+    src/gui/chat/PopupChatWindow.h
+    src/gui/chat/PopupDistantChatDialog.h
+    src/gui/common/AvatarDefs.h
+    src/gui/common/AvatarDialog.h
+    src/gui/common/AvatarWidget.h
+    src/gui/common/DropLineEdit.h
+    src/gui/common/ElidedLabel.h
+    src/gui/common/Emoticons.h
+    src/gui/common/FeedNotify.h
+    src/gui/common/FilesDefs.h
+    src/gui/common/FloatingHelpBrowser.h
+    src/gui/common/FlowLayout.h
+    src/gui/common/FriendListModel.h
+    src/gui/common/FriendSelectionDialog.h
+    src/gui/common/FriendSelectionWidget.h
+    src/gui/common/GroupChooser.h
+    src/gui/common/GroupDefs.h
+    src/gui/common/GroupFlagsWidget.h
+    src/gui/common/GroupSelectionBox.h
+    src/gui/common/GroupTreeWidget.h
+    src/gui/common/HashBox.h
+    src/gui/common/HeaderFrame.h
+    src/gui/common/LineEditClear.h
+    src/gui/common/MacDockIconHandler.h
+    src/gui/common/MimeTextEdit.h
+    src/gui/common/NewFriendList.h
+    src/gui/common/PeerDefs.h
+    src/gui/common/PictureFlow.h
+    src/gui/common/PopularityDefs.h
+    src/gui/common/RSComboBox.h
+    src/gui/common/RSElidedItemDelegate.h
+    src/gui/common/RSFeedWidget.h
+    src/gui/common/RSGraphWidget.h
+    src/gui/common/RSImageBlockWidget.h
+    src/gui/common/RSItemDelegate.h
+    src/gui/common/RSListWidgetItem.h
+    src/gui/common/RSPlainTextEdit.h
+    src/gui/common/RSTabWidget.h
+    src/gui/common/RSTextBrowser.h
+    src/gui/common/RSTextEdit.h
+    src/gui/common/RSTreeView.h
+    src/gui/common/RSTreeWidget.h
+    src/gui/common/RSTreeWidgetItem.h
+    src/gui/common/RsBanListDefs.h
+    src/gui/common/RsBanListToolButton.h
+    src/gui/common/RsButtonOnText.h
+    src/gui/common/RsCollection.h
+    src/gui/common/RsCollectionDialog.h
+    src/gui/common/RsCollectionModel.h
+    src/gui/common/RsUrlHandler.h
+    src/gui/common/StatusDefs.h
+    src/gui/common/SubscribeToolButton.h
+    src/gui/common/TagDefs.h
+    src/gui/common/ToasterNotify.h
+    src/gui/common/UIStateHelper.h
+    src/gui/common/UserNotify.h
+    src/gui/common/rshtml.h
+    src/gui/common/rwindow.h
+    src/gui/common/vmessagebox.h
+    src/gui/connect/ConfCertDialog.h
+    src/gui/connect/ConnectFriendWizard.h
+    src/gui/connect/ConnectProgressDialog.h
+    src/gui/connect/FriendRecommendDialog.h
+    src/gui/connect/PGPKeyDialog.h
+    src/gui/elastic/arrow.h
+    src/gui/elastic/edge.h
+    src/gui/elastic/elnode.h
+    src/gui/elastic/graphwidget.h
+    src/gui/feeds/AttachFileItem.h
+    src/gui/feeds/BoardsCommentsItem.h
+    src/gui/feeds/BoardsPostItem.h
+    src/gui/feeds/ChannelsCommentsItem.h
+    src/gui/feeds/ChatMsgItem.h
+    src/gui/feeds/FeedHolder.h
+    src/gui/feeds/FeedItem.h
+    src/gui/feeds/GxsChannelGroupItem.h
+    src/gui/feeds/GxsChannelPostItem.h
+    src/gui/feeds/GxsCircleItem.h
+    src/gui/feeds/GxsFeedItem.h
+    src/gui/feeds/GxsForumGroupItem.h
+    src/gui/feeds/GxsForumMsgItem.h
+    src/gui/feeds/GxsGroupFeedItem.h
+    src/gui/feeds/MsgItem.h
+    src/gui/feeds/NewsFeedUserNotify.h
+    src/gui/feeds/PeerItem.h
+    src/gui/feeds/PostedGroupItem.h
+    src/gui/feeds/SecurityIpItem.h
+    src/gui/feeds/SecurityItem.h
+    src/gui/feeds/SubFileItem.h
+    src/gui/groups/CreateGroup.h
+    src/gui/gxs/GxsCircleChooser.h
+    src/gui/gxs/GxsCircleLabel.h
+    src/gui/gxs/GxsCommentContainer.h
+    src/gui/gxs/GxsCommentDialog.h
+    src/gui/gxs/GxsCommentTreeWidget.h
+    src/gui/gxs/GxsCreateCommentDialog.h
+    src/gui/gxs/GxsGroupDialog.h
+    src/gui/gxs/GxsGroupFrameDialog.h
+    src/gui/gxs/GxsGroupShareKey.h
+    src/gui/gxs/GxsIdChooser.h
+    src/gui/gxs/GxsIdDetails.h
+    src/gui/gxs/GxsIdLabel.h
+    src/gui/gxs/GxsIdTreeWidgetItem.h
+    src/gui/gxs/GxsMessageFramePostWidget.h
+    src/gui/gxs/GxsMessageFrameWidget.h
+    src/gui/gxs/GxsStatisticsProvider.h
+    src/gui/gxs/GxsUserNotify.h
+    src/gui/gxs/RsGxsUpdateBroadcastBase.h
+    src/gui/gxs/RsGxsUpdateBroadcastPage.h
+    src/gui/gxs/RsGxsUpdateBroadcastWidget.h
+)
+
+if(RS_GXSWIKIPOS)
+    list(APPEND RS_GUI_HEADERS src/gui/gxs/WikiGroupDialog.h)
+endif()
+
+list(APPEND RS_GUI_HEADERS
+    src/gui/gxschannels/CreateGxsChannelMsg.h
+    src/gui/gxschannels/GxsChannelDialog.h
+    src/gui/gxschannels/GxsChannelFilesStatusWidget.h
+    src/gui/gxschannels/GxsChannelGroupDialog.h
+    src/gui/gxschannels/GxsChannelPostFilesModel.h
+    src/gui/gxschannels/GxsChannelPostThumbnail.h
+    src/gui/gxschannels/GxsChannelPostsModel.h
+    src/gui/gxschannels/GxsChannelPostsWidgetWithModel.h
+    src/gui/gxschannels/GxsChannelUserNotify.h
+    src/gui/gxsforums/CreateGxsForumMsg.h
+    src/gui/gxsforums/GxsForumGroupDialog.h
+    src/gui/gxsforums/GxsForumModel.h
+    src/gui/gxsforums/GxsForumThreadWidget.h
+    src/gui/gxsforums/GxsForumUserNotify.h
+    src/gui/gxsforums/GxsForumsDialog.h
+    src/gui/help/browser/helpbrowser.h
+    src/gui/help/browser/helptextbrowser.h
+    src/gui/im_history/IMHistoryItemDelegate.h
+    src/gui/im_history/IMHistoryItemPainter.h
+    src/gui/im_history/ImHistoryBrowser.h
+    src/gui/images/retroshare_win.rc.h
+    src/gui/linetypes.h
+    src/gui/mainpagestack.h
+    src/gui/msgs/MessageComposer.h
+    src/gui/msgs/MessageInterface.h
+    src/gui/msgs/MessageModel.h
+    src/gui/msgs/MessageUserNotify.h
+    src/gui/msgs/MessageWidget.h
+    src/gui/msgs/MessageWindow.h
+    src/gui/msgs/MessagesDialog.h
+    src/gui/msgs/TagsMenu.h
+    src/gui/msgs/textformat.h
+    src/gui/plugins/PluginInterface.h
+    src/gui/profile/ProfileManager.h
+    src/gui/profile/ProfileWidget.h
+    src/gui/profile/StatusMessage.h
+    src/gui/settings/AboutPage.h
+    src/gui/settings/AddFileAssociationDialog.h
+    src/gui/settings/AppearancePage.h
+    src/gui/settings/ChannelPage.h
+    src/gui/settings/ChatPage.h
+    src/gui/settings/CryptoPage.h
+    src/gui/settings/FileAssociationsPage.h
+    src/gui/settings/ForumPage.h
+    src/gui/settings/GeneralPage.h
+    src/gui/settings/GroupFrameSettingsWidget.h
+    src/gui/settings/MessagePage.h
+    src/gui/settings/NewTag.h
+    src/gui/settings/NotifyPage.h
+    src/gui/settings/PeoplePage.h
+    src/gui/settings/PluginItem.h
+    src/gui/settings/PluginsPage.h
+    src/gui/settings/PostedPage.h
+    src/gui/settings/RSPermissionMatrixWidget.h
+    src/gui/settings/RsharePeerSettings.h
+    src/gui/settings/ServerPage.h
+    src/gui/settings/ServicePermissionsPage.h
+    src/gui/settings/SoundPage.h
+    src/gui/settings/TransferPage.h
+    src/gui/settings/rsettings.h
+    src/gui/settings/rsettingswin.h
+    src/gui/settings/rsharesettings.h
+    src/gui/statistics/BWGraph.h
+    src/gui/statistics/BandwidthGraphWindow.h
+    src/gui/statistics/BandwidthStatsWidget.h
+    src/gui/statistics/BwCtrlWindow.h
+    src/gui/statistics/DhtWindow.h
+    src/gui/statistics/GlobalRouterStatistics.h
+    src/gui/statistics/GxsIdStatistics.h
+    src/gui/statistics/GxsNetTunnelsDialog.h
+    src/gui/statistics/GxsTransportStatistics.h
+    src/gui/statistics/Histogram.h
+    src/gui/statistics/RttStatistics.h
+    src/gui/statistics/StatisticsWindow.h
+    src/gui/statistics/TunnelStatisticsDialog.h
+    src/gui/statistics/TurtleRouterDialog.h
+    src/gui/statistics/TurtleRouterStatistics.h
+    src/gui/statistics/dhtgraph.h
+    src/gui/statistics/turtlegraph.h
+    src/gui/statusbar/OpModeStatus.h
+    src/gui/statusbar/SoundStatus.h
+    src/gui/statusbar/SysTrayStatus.h
+    src/gui/statusbar/ToasterDisable.h
+    src/gui/statusbar/dhtstatus.h
+    src/gui/statusbar/discstatus.h
+    src/gui/statusbar/hashingstatus.h
+    src/gui/statusbar/natstatus.h
+    src/gui/statusbar/peerstatus.h
+    src/gui/statusbar/ratesstatus.h
+    src/gui/statusbar/torstatus.h
+    src/gui/style/RSStyle.h
+    src/gui/style/StyleDialog.h
+    src/gui/toaster/ChatLobbyToaster.h
+    src/gui/toaster/ChatToaster.h
+    src/gui/toaster/DownloadToaster.h
+    src/gui/toaster/FriendRequestToaster.h
+    src/gui/toaster/GroupChatToaster.h
+    src/gui/toaster/MessageToaster.h
+    src/gui/toaster/OnlineToaster.h
+    src/gui/toaster/ToasterItem.h
+    src/idle/idle.h
+    src/lang/languagesupport.h
+    src/retroshare-gui/RsAutoUpdatePage.h
+    src/retroshare-gui/configpage.h
+    src/retroshare-gui/mainpage.h
+    src/rshare.h
+    src/util/AspectRatioPixmapLabel.h
+    src/util/ClickableLabel.h
+    src/util/DateTime.h
+    src/util/EventFilter.h
+    src/util/FontSizeHandler.h
+    src/util/HandleRichText.h
+    src/util/MouseEventFilter.h
+    src/util/NonCopyable.h
+    src/util/ObjectPainter.h
+    src/util/PixmapMerging.h
+    src/util/RetroStyleLabel.h
+    src/util/RichTextEdit.h
+    src/util/RsAction.h
+    src/util/RsFile.h
+    src/util/RsGxsUpdateBroadcast.h
+    src/util/RsNetUtil.h
+    src/util/RsProtectedTimer.h
+    src/util/RsQtVersion.h
+    src/util/RsSyntaxHighlighter.h
+    src/util/RsUserdata.h
+    src/util/TokenQueue.h
+    src/util/Widget.h
+    src/util/dllexport.h
+    src/util/global.h
+    src/util/imageutil.h
+    src/util/log.h
+    src/util/misc.h
+    src/util/printpreview.h
+    src/util/qtthreadsutils.h
+    src/util/retroshareWin32.h
+    src/util/rsqtutildll.h
+    src/util/rsutildll.h
+    src/util/stringutil.h
+)
 
 if(RS_JSON_API)
 	list(
@@ -696,7 +877,7 @@ if(RS_JSON_API)
 	)
 
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/settings/JsonApiPage.h
 	)
 
@@ -713,8 +894,7 @@ if(RS_WEBUI)
 	)
 
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		src/jsonapi/p3webui.h 
+		APPEND RS_GUI_HEADERS
 		src/gui/settings/WebuiPage.h 
 	)
 
@@ -770,30 +950,11 @@ if(RS_UNFINISHED_TRANSLATIONS)
 		)
 endif(RS_UNFINISHED_TRANSLATIONS)
 
-if(RS_MESSENGER)
-
-	target_compile_definitions( ${PROJECT_NAME} PUBLIC MESSENGER_WINDOW )
-
-	list(
-		APPEND RS_GUI_SOURCES
-		src/gui/MessengerWindow.cpp 
-		src/gui/common/FriendList.cpp
-		)
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		src/gui/MessengerWindow.h 
-		src/gui/common/FriendList.h 
-		)
-	list(
-		APPEND RS_GUI_FORMS
-		src/gui/MessengerWindow.ui 
-		src/gui/common/FriendList.ui
-		)
-endif(RS_MESSENGER)
+# MessengerWindow and FriendList are now in the main lists
 
 if(RS_IDLE)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/idle/idle.h
 		)
 	list(
@@ -805,7 +966,7 @@ endif(RS_IDLE)
 
 if(RS_FRAMECATCHER)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/util/framecatcher.h
 		)
 	list(
@@ -831,7 +992,7 @@ if(RS_EFS)
 		src/gui/FriendServerControl.cpp
 		)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/FriendServerControl.h
 		)
 	list(
@@ -845,7 +1006,7 @@ endif(RS_EFS)
 if(RS_UNFINISHED)
 
 	list(	
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/unfinished/ApplicationWindow.h 
 
 		#		gui/unfinished/CalDialog.h 
@@ -895,50 +1056,100 @@ if(RS_GXSPHOTOSHARE)
 	target_compile_definitions(
 		${PROJECT_NAME} PUBLIC RS_USE_PHOTO 
 		)
-
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		src/gui/PhotoShare/AlbumGroupDialog.h 
-		src/gui/PhotoShare/AlbumExtra.h 
-		src/gui/PhotoShare/PhotoDrop.h 
-		src/gui/PhotoShare/AlbumItem.h 
-		src/gui/PhotoShare/AlbumDialog.h 
-		src/gui/PhotoShare/PhotoItem.h 
-		src/gui/PhotoShare/PhotoShareItemHolder.h 
-		src/gui/PhotoShare/PhotoShare.h 
-		src/gui/PhotoShare/PhotoSlideShow.h 
-		src/gui/PhotoShare/PhotoDialog.h
-		)
-	list(
-		APPEND RS_GUI_FORMS
-		src/gui/PhotoShare/AlbumExtra.ui 
-		src/gui/PhotoShare/PhotoItem.ui 
-		src/gui/PhotoShare/PhotoDialog.ui 
-		src/gui/PhotoShare/AlbumItem.ui 
-		src/gui/PhotoShare/AlbumDialog.ui 
-		src/gui/PhotoShare/PhotoShare.ui 
-		src/gui/PhotoShare/PhotoSlideShow.ui
-		)
+    list(APPEND RS_GUI_QTRESOURCES src/gui/PhotoShare/Photo_images.qrc)
 
 	list(
 		APPEND RS_GUI_SOURCES
-		src/gui/PhotoShare/AlbumGroupDialog.cpp 
-		src/gui/PhotoShare/AlbumExtra.cpp 
-		src/gui/PhotoShare/PhotoItem.cpp 
-		src/gui/PhotoShare/PhotoDialog.cpp 
-		src/gui/PhotoShare/PhotoDrop.cpp 
-		src/gui/PhotoShare/AlbumItem.cpp 
-		src/gui/PhotoShare/AlbumDialog.cpp 
-		src/gui/PhotoShare/PhotoShareItemHolder.cpp 
-		src/gui/PhotoShare/PhotoShare.cpp 
-		src/gui/PhotoShare/PhotoSlideShow.cpp
-		)
+        src/gui/PhotoShare/AlbumDialog.cpp
+        src/gui/PhotoShare/AlbumExtra.cpp
+        src/gui/PhotoShare/AlbumGroupDialog.cpp
+        src/gui/PhotoShare/AlbumItem.cpp
+        src/gui/PhotoShare/PhotoDialog.cpp
+        src/gui/PhotoShare/PhotoDrop.cpp
+        src/gui/PhotoShare/PhotoItem.cpp
+        src/gui/PhotoShare/PhotoShare.cpp
+        src/gui/PhotoShare/PhotoShareItemHolder.cpp
+        src/gui/PhotoShare/PhotoSlideShow.cpp
+	)
 
 	list(
-		APPEND RS_GUI_QTRESOURCES
-		src/gui/PhotoShare/Photo_images.qrc
-		)
+		APPEND RS_GUI_HEADERS
+        src/gui/PhotoShare/AlbumDialog.h
+        src/gui/PhotoShare/AlbumExtra.h
+        src/gui/PhotoShare/AlbumGroupDialog.h
+        src/gui/PhotoShare/AlbumItem.h
+        src/gui/PhotoShare/PhotoDialog.h
+        src/gui/PhotoShare/PhotoDrop.h
+        src/gui/PhotoShare/PhotoItem.h
+        src/gui/PhotoShare/PhotoShare.h
+        src/gui/PhotoShare/PhotoShareItemHolder.h
+        src/gui/PhotoShare/PhotoSlideShow.h
+	)
+
+	list(
+		APPEND RS_GUI_FORMS
+        src/gui/PhotoShare/AlbumDialog.ui
+        src/gui/PhotoShare/AlbumExtra.ui
+        src/gui/PhotoShare/AlbumItem.ui
+        src/gui/PhotoShare/PhotoDialog.ui
+        src/gui/PhotoShare/PhotoItem.ui
+        src/gui/PhotoShare/PhotoShare.ui
+        src/gui/PhotoShare/PhotoSlideShow.ui
+	)
 endif(RS_GXSPHOTOSHARE)
+
+if(RS_GXSTHEWIRE)
+	target_compile_definitions(
+		${PROJECT_NAME} PUBLIC RS_USE_WIRE 
+		)
+    list(APPEND RS_GUI_SOURCES
+        src/gui/TheWire/CustomFrame.cpp
+        src/gui/TheWire/PulseAddDialog.cpp
+        src/gui/TheWire/PulseMessage.cpp
+        src/gui/TheWire/PulseReply.cpp
+        src/gui/TheWire/PulseReplySeperator.cpp
+        src/gui/TheWire/PulseTopLevel.cpp
+        src/gui/TheWire/PulseViewGroup.cpp
+        src/gui/TheWire/PulseViewItem.cpp
+        src/gui/TheWire/WireDialog.cpp
+        src/gui/TheWire/WireGroupDialog.cpp
+        src/gui/TheWire/WireGroupExtra.cpp
+        src/gui/TheWire/WireGroupItem.cpp
+        src/gui/TheWire/WireUserNotify.cpp
+        src/gui/feeds/WireNotifyGroupItem.cpp
+        src/gui/feeds/WireNotifyPostItem.cpp
+    )
+    list(APPEND RS_GUI_HEADERS
+        src/gui/TheWire/CustomFrame.h
+        src/gui/TheWire/PulseAddDialog.h
+        src/gui/TheWire/PulseMessage.h
+        src/gui/TheWire/PulseReply.h
+        src/gui/TheWire/PulseReplySeperator.h
+        src/gui/TheWire/PulseTopLevel.h
+        src/gui/TheWire/PulseViewGroup.h
+        src/gui/TheWire/PulseViewItem.h
+        src/gui/TheWire/WireDialog.h
+        src/gui/TheWire/WireGroupDialog.h
+        src/gui/TheWire/WireGroupExtra.h
+        src/gui/TheWire/WireGroupItem.h
+        src/gui/TheWire/WireUserNotify.h
+        src/gui/feeds/WireNotifyGroupItem.h
+        src/gui/feeds/WireNotifyPostItem.h
+    )
+    list(APPEND RS_GUI_FORMS
+        src/gui/TheWire/PulseAddDialog.ui
+        src/gui/TheWire/PulseMessage.ui
+        src/gui/TheWire/PulseReply.ui
+        src/gui/TheWire/PulseReplySeperator.ui
+        src/gui/TheWire/PulseTopLevel.ui
+        src/gui/TheWire/PulseViewGroup.ui
+        src/gui/TheWire/WireDialog.ui
+        src/gui/TheWire/WireGroupExtra.ui
+        src/gui/TheWire/WireGroupItem.ui
+        src/gui/feeds/WireNotifyGroupItem.ui
+        src/gui/feeds/WireNotifyPostItem.ui
+    )
+endif(RS_GXSTHEWIRE)
 
 if(RS_GXSWIKIPOS)
 	target_compile_definitions(
@@ -948,105 +1159,34 @@ if(RS_GXSWIKIPOS)
 	target_include_directories(${PROJECT_NAME} PUBLIC ../../supportlibs/pegmarkdown)
 
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		src/gui/WikiPoos/WikiDialog.h 
-		src/gui/WikiPoos/WikiAddDialog.h 
-		src/gui/WikiPoos/WikiEditDialog.h 
-		src/gui/gxs/WikiGroupDialog.h 
-		src/gui/gxs/RsGxsUpdateBroadcastBase.h 
-		src/gui/gxs/RsGxsUpdateBroadcastWidget.h 
-		src/gui/gxs/RsGxsUpdateBroadcastPage.h 
-		)
-
-	list(
-		APPEND RS_GUI_FORMS
-		src/gui/WikiPoos/WikiDialog.ui 
-		src/gui/WikiPoos/WikiAddDialog.ui 
-		src/gui/WikiPoos/WikiEditDialog.ui 
-		)
-
-	list(
-		APPEND RS_GUI_SOURCES
-		src/gui/WikiPoos/WikiDialog.cpp 
-		src/gui/WikiPoos/WikiAddDialog.cpp 
-		src/gui/WikiPoos/WikiEditDialog.cpp 
-		src/gui/gxs/WikiGroupDialog.cpp 
-		src/gui/gxs/RsGxsUpdateBroadcastBase.cpp 
-		src/gui/gxs/RsGxsUpdateBroadcastWidget.cpp 
-		src/gui/gxs/RsGxsUpdateBroadcastPage.cpp 
-		)
-
-	list(
 		APPEND RS_GUI_QTRESOURCES
 		src/gui/WikiPoos/Wiki_images.qrc
 		)
+    
+    list(APPEND RS_GUI_SOURCES
+        src/gui/WikiPoos/WikiAddDialog.cpp
+        src/gui/WikiPoos/WikiDialog.cpp
+        src/gui/WikiPoos/WikiEditDialog.cpp
+        src/gui/WikiPoos/WikiUserNotify.cpp
+    )
+    list(APPEND RS_GUI_HEADERS
+        src/gui/WikiPoos/WikiAddDialog.h
+        src/gui/WikiPoos/WikiDialog.h
+        src/gui/WikiPoos/WikiEditDialog.h
+        src/gui/WikiPoos/WikiUserNotify.h
+    )
+    list(APPEND RS_GUI_FORMS
+        src/gui/WikiPoos/WikiAddDialog.ui
+        src/gui/WikiPoos/WikiDialog.ui
+        src/gui/WikiPoos/WikiEditDialog.ui
+    )
 endif(RS_GXSWIKIPOS)
 	
-if(RS_GXSTHEWIRE)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_USE_WIRE 
-		)
-
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		src/gui/TheWire/WireDialog.h 
-		src/gui/TheWire/WireGroupItem.h 
-		src/gui/TheWire/WireGroupDialog.h 
-		src/gui/TheWire/WireGroupExtra.h 
-		src/gui/TheWire/PulseAddDialog.h 
-		src/gui/TheWire/PulseViewItem.h 
-		src/gui/TheWire/PulseTopLevel.h 
-		src/gui/TheWire/PulseViewGroup.h 
-		src/gui/TheWire/PulseReply.h 
-		src/gui/TheWire/PulseReplySeperator.h 
-		src/gui/TheWire/PulseMessage.h
-		src/gui/TheWire/WireUserNotify.h
-		src/gui/feeds/WireNotifyGroupItem.h 
-		src/gui/feeds/WireNotifyPostItem.h
-		)
-
-	list(
-		APPEND RS_GUI_FORMS
-		src/gui/TheWire/WireDialog.ui 
-		src/gui/TheWire/WireGroupItem.ui 
-		src/gui/TheWire/WireGroupExtra.ui 
-		src/gui/TheWire/PulseAddDialog.ui 
-		src/gui/TheWire/PulseTopLevel.ui 
-		src/gui/TheWire/PulseViewGroup.ui 
-		src/gui/TheWire/PulseReply.ui 
-		src/gui/TheWire/PulseReplySeperator.ui 
-		src/gui/TheWire/PulseMessage.ui
-		src/gui/feeds/WireNotifyGroupItem.ui
-		src/gui/feeds/WireNotifyPostItem.ui
-		)
-
-	list(
-		APPEND RS_GUI_SOURCES
-		src/gui/TheWire/WireDialog.cpp 
-		src/gui/TheWire/WireGroupItem.cpp 
-		src/gui/TheWire/WireGroupDialog.cpp 
-		src/gui/TheWire/WireGroupExtra.cpp 
-		src/gui/TheWire/PulseAddDialog.cpp 
-		src/gui/TheWire/PulseViewItem.cpp 
-		src/gui/TheWire/PulseTopLevel.cpp 
-		src/gui/TheWire/PulseViewGroup.cpp 
-		src/gui/TheWire/PulseReply.cpp 
-		src/gui/TheWire/PulseReplySeperator.cpp 
-		src/gui/TheWire/PulseMessage.cpp 
-		src/gui/TheWire/WireUserNotify.cpp
-		src/gui/feeds/WireNotifyGroupItem.cpp
-		src/gui/feeds/WireNotifyPostItem.cpp
-		)
-
-	list(
-		APPEND RS_GUI_QTRESOURCES
-		RESOURCES += src/gui/TheWire/TheWire_images.qrc
-		)
-endif(RS_GXSTHEWIRE)
+# TheWire handled at top
 
 if(RS_GXSIDENTITIES)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/Identity/IdDialog.h 
 		src/gui/Identity/IdEditDialog.h 
 		src/gui/Identity/IdDetailsDialog.h 
@@ -1069,7 +1209,7 @@ endif(RS_GXSIDENTITIES)
 	
 if(RS_GXSCIRCLES)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/Circles/CirclesDialog.h 
 		src/gui/Circles/CreateCircleDialog.h 
 		src/gui/People/PeopleDialog.h
@@ -1098,7 +1238,7 @@ endif(RS_GXSCIRCLES)
 
 if(RS_GXSGUI)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/gxs/GxsGroupDialog.h 
 		src/gui/gxs/GxsIdDetails.h 
 		src/gui/gxs/GxsIdChooser.h
@@ -1113,8 +1253,8 @@ if(RS_GXSGUI)
 		src/gui/gxs/GxsGroupFrameDialog.h 
 		src/gui/gxs/GxsMessageFrameWidget.h 
 		src/gui/gxs/GxsMessageFramePostWidget.h 
-		src/gui/gxs/GxsGroupFeedItem.h 
-		src/gui/gxs/GxsFeedItem.h 
+		src/gui/feeds/GxsGroupFeedItem.h 
+		src/gui/feeds/GxsFeedItem.h 
 		src/gui/gxs/GxsGroupShareKey.h 
 		src/gui/gxs/GxsUserNotify.h 
 		src/gui/gxs/GxsFeedWidget.h 
@@ -1150,8 +1290,8 @@ if(RS_GXSGUI)
 		src/gui/gxs/GxsGroupFrameDialog.cpp 
 		src/gui/gxs/GxsMessageFrameWidget.cpp 
 		src/gui/gxs/GxsMessageFramePostWidget.cpp 
-		src/gui/gxs/GxsGroupFeedItem.cpp 
-		src/gui/gxs/GxsFeedItem.cpp 
+		src/gui/feeds/GxsGroupFeedItem.cpp 
+		src/gui/feeds/GxsFeedItem.cpp 
 		src/gui/gxs/GxsUserNotify.cpp 
 		src/gui/gxs/GxsFeedWidget.cpp 
 		src/util/TokenQueue.cpp 
@@ -1162,7 +1302,7 @@ endif(RS_GXSGUI)
 	
 if(RS_GXSFORUMS) 
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS 
+		APPEND RS_GUI_HEADERS 
 		src/gui/gxsforums/GxsForumsDialog.h 
 		src/gui/gxsforums/GxsForumGroupDialog.h 
 		src/gui/gxsforums/CreateGxsForumMsg.h 
@@ -1197,7 +1337,7 @@ endif(RS_GXSFORUMS)
 	
 if(RS_GXSCHANNELS)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/gxschannels/GxsChannelDialog.h 
 		src/gui/gxschannels/GxsChannelGroupDialog.h 
 		src/gui/gxschannels/CreateGxsChannelMsg.h 
@@ -1238,7 +1378,7 @@ endif(RS_GXSCHANNELS)
 	
 if(RS_GXSPOSTED)
 	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+		APPEND RS_GUI_HEADERS
 		src/gui/Posted/PostedDialog.h 
 		src/gui/Posted/PostedListWidgetWithModel.h 
 		src/gui/Posted/PostedPostsModel.h 
@@ -1284,6 +1424,12 @@ if(RS_GXSPOSTED)
 		src/gui/Posted/Posted_images.qrc
 		)
 endif(RS_GXSPOSTED)
+
+# Cleanup lists to avoid duplicates from conditional blocks
+list(REMOVE_DUPLICATES RS_GUI_SOURCES)
+list(REMOVE_DUPLICATES RS_GUI_HEADERS)
+list(REMOVE_DUPLICATES RS_GUI_FORMS)
+
 
 
 

--- a/retroshare-gui/src/gui/PhotoShare/PhotoDialog.cpp
+++ b/retroshare-gui/src/gui/PhotoShare/PhotoDialog.cpp
@@ -101,7 +101,7 @@ void PhotoDialog::toggleComments()
 			RsGxsId current_author;
 			// create CommentDialog.
 			RsGxsCommentService *commentService = dynamic_cast<RsGxsCommentService *>(mRsPhoto);
-			GxsCommentDialog *commentDialog = new GxsCommentDialog(this,current_author, mRsPhoto->getTokenService(), commentService);
+			GxsCommentDialog *commentDialog = new GxsCommentDialog(this,current_author, commentService);
 
 			// TODO: Need to fetch all msg versions, otherwise - won't get all the comments.
 			// For the moment - use current msgid.

--- a/retroshare-gui/src/gui/PluginManager.cpp
+++ b/retroshare-gui/src/gui/PluginManager.cpp
@@ -217,7 +217,8 @@ PluginManager::pluginWidget(QString pluginName)
         QString em = tr("Error: no plugin with name '%1' found")
                         .arg(pluginName);
         emit errorAppeared( em );
-    }      
+    }
+    return 0;
 }
 
 //=============================================================================

--- a/retroshare-gui/src/gui/PluginManagerWidget.cpp
+++ b/retroshare-gui/src/gui/PluginManagerWidget.cpp
@@ -20,6 +20,8 @@
 
 #include "PluginManagerWidget.h"
 #include "gui/settings/rsharesettings.h"
+#include "util/misc.h"
+
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -160,9 +162,8 @@ PluginManagerWidget::registerNewPlugin(QString pluginName)
 void
 PluginManagerWidget::installPluginButtonClicked()
 {
-    QString fileName = misc::getOpenFileName(this, RshareSettings::LASTDIR_PLUGIN, tr("Open Plugin to install"), "./", tr("Plugins (*.so *.dll)"));
-
-    if (!fileName.isNull())
+    QString fileName;
+    if (misc::getOpenFileName(this, RshareSettings::LASTDIR_PLUGIN, tr("Open Plugin to install"), tr("Plugins (*.so *.dll)"), fileName))
        emit installPluginRequested(fileName);
 }
 

--- a/retroshare-gui/src/gui/PluginsPage.cpp
+++ b/retroshare-gui/src/gui/PluginsPage.cpp
@@ -42,6 +42,8 @@
 #include "PluginsPage.h"
 #include "PluginManager.h"
 
+namespace gui {
+
 //============================================================================== 
 
 PluginsPage::PluginsPage(QWidget *parent )
@@ -95,5 +97,6 @@ PluginsPage::pluginRegistered(QString pluginName)
 
     pluginTabs->addTab( pw , pluginName );
 }
+} // namespace gui
 
 //==============================================================================

--- a/retroshare-gui/src/gui/common/RsCollectionModel.h
+++ b/retroshare-gui/src/gui/common/RsCollectionModel.h
@@ -1,4 +1,6 @@
+#pragma once
 #include <QAbstractItemModel>
+
 
 #include "RsCollection.h"
 

--- a/retroshare-gui/src/gui/gxs/GxsFeedWidget.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsFeedWidget.cpp
@@ -19,7 +19,7 @@
  *******************************************************************************/
 
 #include "GxsFeedWidget.h"
-#include "gui/gxs/GxsFeedItem.h"
+#include "gui/feeds/GxsFeedItem.h"
 
 #define PAIR(groupId,messageId) QPair<RsGxsGroupId, RsGxsMessageId>(groupId, messageId)
 

--- a/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupDialog.cpp
@@ -359,8 +359,7 @@ void GxsGroupDialog::setupDefaults()
         
 #ifndef RS_USE_CIRCLES
     ui.typeGroup->setEnabled(false);
-    ui.typeGroup_3->setEnabled(false);
-    ui.typeLocal_3->setEnabled(false);
+    ui.typeLocal->setEnabled(false);
 #endif
 }
 

--- a/retroshare-service/CMakeLists.txt
+++ b/retroshare-service/CMakeLists.txt
@@ -9,6 +9,7 @@ set(RS_SERVICE_SOURCES src/retroshare-service.cc)
 
 # --- Executable ---
 add_executable(retroshare-service ${RS_SERVICE_SOURCES})
+target_compile_definitions(retroshare-service PRIVATE RS_RELEASE_VERSION="${RS_VERSION}")
 
 # --- Linkage ---
 # Linked to the retroshare library target defined in libretroshare/

--- a/retroshare-service/CMakeLists.txt
+++ b/retroshare-service/CMakeLists.txt
@@ -1,229 +1,31 @@
-# RetroShare decentralized communication platform
-#
-# Copyright (C) 2021-2022  Gioacchino Mazzurco <gio@retroshare.cc>
-# Copyright (C) 2021-2022  Asociación Civil Altermundi <info@altermundi.net>
-#
-# SPDX-License-Identifier: CC0-1.0
-
-cmake_minimum_required (VERSION 3.18.0)
-project(retroshare-service)
-
-include(CMakeDependentOption)
-
-if(APPLE)
-  include_directories("/usr/local/include") 
-  LINK_DIRECTORIES("/usr/local/lib")
-endif()
-
-set(
-	RS_BIN_INSTALL_DIR
-	"${CMAKE_INSTALL_PREFIX}/bin"
-	CACHE PATH
-	"Path where to install retroshare-service compiled binary" )
-
-option(
-	RS_DEVELOPMENT_BUILD
-	"Disable optimization to speed up build, enable verbose build log. \
-	 just for development purposes, not suitable for library usage"
-	OFF )
-
-option(
-	RS_RNPLIB
-	"Enable use RNP lib for PGP"
-	OFF )
-
-option(
-	RS_JSON_API
-	"Use restbed to expose libretroshare as JSON API via HTTP"
-	ON )
-
-option(
-	RS_SERVICE_DESKTOP
-	"Install icons and shortcuts for desktop environements"
-	OFF )
-
-option(
-	RS_SERVICE_TERMINAL_LOGIN
-	"Enable RetroShare login via terminal"
-	ON )
-
-cmake_dependent_option(
-	RS_SERVICE_TERMINAL_WEBUI_PASSWORD
-	"Enable settin Web UI password via terminal in retroshare-service"
-	OFF
-	"RS_WEBUI"
-	ON )
-
-cmake_dependent_option(
-	RS_WEBUI
-	"Install RetroShare Web UI"
-	OFF
-	"RS_JSON_API"
-	ON )
-
+################################################################################
+# retroshare-service/CMakeLists.txt
 ################################################################################
 
-set(FETCHCONTENT_QUIET OFF)
-include(FetchContent)
+# project() and common options are inherited from the root CMakeLists.txt
 
-# Find required dependencies
-# find_package for Botan and json-c failed to populate variables, remove them.
-# find_package(Botan 3 REQUIRED)
-# message(STATUS "Botan_FOUND=${Botan_FOUND}")
-# message(STATUS "BOTAN_LIBRARIES=${BOTAN_LIBRARIES}")
-# message(STATUS "BOTAN_INCLUDE_DIRS=${BOTAN_INCLUDE_DIRS}")
-# 
-# find_package(json-c REQUIRED)
-# message(STATUS "json-c_FOUND=${json-c_FOUND}")
-# message(STATUS "JSON-C_LIBRARIES=${JSON-C_LIBRARIES}")
-# message(STATUS "JSON-C_INCLUDE_DIRS=${JSON-C_INCLUDE_DIRS}")
+# --- Sources ---
+set(RS_SERVICE_SOURCES src/retroshare-service.cc)
 
-find_package(ZLIB REQUIRED)
-find_package(BZip2 REQUIRED)
+# --- Executable ---
+add_executable(retroshare-service ${RS_SERVICE_SOURCES})
 
-find_package(Git REQUIRED)
+# --- Linkage ---
+# Linked to the retroshare library target defined in libretroshare/
+target_link_libraries(retroshare-service PRIVATE retroshare)
 
-################################################################################
-
-if(RS_DEVELOPMENT_BUILD)
-	set(CMAKE_VERBOSE_MAKEFILE ON)
-	set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-endif(RS_DEVELOPMENT_BUILD)
-
-################################################################################
-
-list(
-	APPEND RS_SERVICE_SOURCES
-	src/retroshare-service.cc )
-
-add_executable(${PROJECT_NAME} ${RS_SERVICE_SOURCES})
-
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
-
-install(TARGETS ${PROJECT_NAME} DESTINATION ${RS_BIN_INSTALL_DIR})
-
-################################################################################
-
-if(RS_DEVELOPMENT_BUILD)
-	target_compile_options(${PROJECT_NAME} PRIVATE "-O0")
-endif(RS_DEVELOPMENT_BUILD)
-
-################################################################################
-
-set(LIBRETROSHARE_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../libretroshare/")
-if(EXISTS "${LIBRETROSHARE_DEVEL_DIR}/CMakeLists.txt" )
-	message(
-		STATUS
-		"libretroshare source found at ${LIBRETROSHARE_DEVEL_DIR} using it" )
-	add_subdirectory(
-		"${LIBRETROSHARE_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/libretroshare" )
-else()
-	FetchContent_Declare(
-		libretroshare
-		GIT_REPOSITORY "https://github.com/RetroShare/libretroshare.git"
-		GIT_TAG "origin/master"
-		GIT_SHALLOW TRUE
-		GIT_PROGRESS TRUE
-		TIMEOUT 10
-	)
-	FetchContent_MakeAvailable(libretroshare)
-endif()
-
-target_link_libraries(${PROJECT_NAME} PRIVATE retroshare)
-
-################################################################################
-
-if(RS_RNPLIB)
-	# Add RNP build directories to linker search path
-	target_link_directories(${PROJECT_NAME} PRIVATE
-		${CMAKE_CURRENT_BINARY_DIR}/supportlibs/librnp/Build/src/lib
-		${CMAKE_CURRENT_BINARY_DIR}/supportlibs/librnp/Build/src/libsexpp
-	)
-
-	# Link libraries by name, including RNP libs and dependencies first
-	target_link_libraries(${PROJECT_NAME} PRIVATE
-		rnp             # Link by name
-		sexpp
-		botan-3
-		json-c
-		bz2
-		z
-		retroshare
-	)
-endif(RS_RNPLIB)
-
-################################################################################
-
-# Add include directories from found packages
-# target_include_directories(${PROJECT_NAME} PRIVATE
-#     ${Botan_INCLUDE_DIRS}
-#     ${JSONC_INCLUDE_DIRS}
-# )
-
-# Link only libretroshare, it should handle its own dependencies now
-target_link_libraries(${PROJECT_NAME} PRIVATE retroshare)
-
-################################################################################
-
-if(RS_SERVICE_DESKTOP)
-	if(UNIX AND NOT APPLE)
-		install(
-			FILES data/retroshare-service.svg
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/ )
-
-		install(
-			FILES data/retroshare-service_48x48.png
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/apps/
-			RENAME retroshare-service.png)
-
-		install(
-			FILES data/retroshare-service_128x128.png
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/128x128/apps/
-			RENAME retroshare-service.png )
-
-		install(
-			FILES data/retroshare-service.desktop
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/data/ )
-	endif(UNIX AND NOT APPLE)
-endif(RS_SERVICE_DESKTOP)
-
-################################################################################
-
+# --- Compile Definitions ---
 if(RS_JSON_API)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_JSONAPI)
-endif(RS_JSON_API)
+    target_compile_definitions(retroshare-service PUBLIC RS_JSONAPI)
+endif()
 
 if(RS_SERVICE_TERMINAL_LOGIN)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_SERVICE_TERMINAL_LOGIN)
-endif(RS_SERVICE_TERMINAL_LOGIN)
+    target_compile_definitions(retroshare-service PUBLIC RS_SERVICE_TERMINAL_LOGIN)
+endif()
 
 if(RS_WEBUI)
-	set(RS_WEBUI_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../retroshare-webui/")
-	if(EXISTS "${RS_WEBUI_DEVEL_DIR}/CMakeLists.txt" )
-		message(
-			STATUS
-			"RetroShare WebUI source found at ${RS_WEBUI_DEVEL_DIR} using it" )
-		add_subdirectory(
-			"${RS_WEBUI_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/webui" )
-	else()
-		FetchContent_Declare(
-			webui
-			GIT_REPOSITORY "https://github.com/RetroShare/RSNewWebUI.git"
-			GIT_TAG "origin/master"
-			GIT_SHALLOW TRUE
-			GIT_PROGRESS TRUE
-			TIMEOUT 10
-		)
-		FetchContent_MakeAvailable(webui)
-	endif()
+    target_compile_definitions(retroshare-service PUBLIC RS_WEBUI)
+endif()
 
-	add_dependencies(${PROJECT_NAME} retroshare-webui)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_WEBUI)
-endif(RS_WEBUI)
-
-if(RS_SERVICE_TERMINAL_WEBUI_PASSWORD)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_SERVICE_TERMINAL_WEBUI_PASSWORD )
-endif(RS_SERVICE_TERMINAL_WEBUI_PASSWORD)
-
-################################################################################
+# --- Installation ---
+install(TARGETS retroshare-service RUNTIME DESTINATION bin)

--- a/retroshare-service/CMakeLists.txt
+++ b/retroshare-service/CMakeLists.txt
@@ -9,7 +9,14 @@ set(RS_SERVICE_SOURCES src/retroshare-service.cc)
 
 # --- Executable ---
 add_executable(retroshare-service ${RS_SERVICE_SOURCES})
-target_compile_definitions(retroshare-service PRIVATE RS_RELEASE_VERSION="${RS_VERSION}")
+target_compile_definitions(retroshare-service PRIVATE 
+    RS_RELEASE_VERSION="${RS_VERSION}"
+    RS_MAJOR_VERSION=${RS_MAJOR_VERSION}
+    RS_MINOR_VERSION=${RS_MINOR_VERSION}
+    RS_MINI_VERSION=${RS_MINI_VERSION}
+    RS_EXTRA_VERSION="${RS_EXTRA_VERSION}"
+)
+
 
 # --- Linkage ---
 # Linked to the retroshare library target defined in libretroshare/


### PR DESCRIPTION
Works together with libretroshare pr/297

**Update: whole project now migrated to CMake**

**This PR works out of the box on Ubuntu**

**CMake Build System Migration**
This branch introduces a comprehensive migration of the RetroShare build system from QMake to CMake. The goal is to provide a more modern, maintainable, and standard build process for the entire project.

**Accomplishments:**
- Core Components Support: Implemented full CMake support for libretroshare, retroshare-gui, and retroshare-service.
- Dynamic Versioning: Restored and improved the automatic versioning system. The build now dynamically extracts version components (Major, Minor, Mini, Extra) from Git tags for the root project and correctly handles the Git hash for the libretroshare submodule.
- AutoUic Fixes: Resolved complex build issues related to cross-module UI inclusions (notably in GXS components) by implementing robust AUTOUIC_SEARCH_PATHS.
- Standardized Configuration: Centralized project options and dependencies in the root CMakeLists.txt, making it easier to manage build-time features (GXS, BitDHT, etc.).
- Cross-Platform Readiness: Structure prepared for improved cross-platform support and faster build times using Ninja and modern CMake practices.

**Current Status & Caveats:**
- Plugins: Migration of the plugin system to CMake is not yet implemented. Plugins are currently excluded from this build system.
- Validation: The build has been fully tested and validated on Ubuntu with default options (no additional flags). Not tested on macOS. 