### PR TITLE
Add board post pinning to Posted GUI

### DIFF
--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
@@ -75,6 +75,7 @@ static const int POSTED_TABS_POSTS  = 1;
 #define IMAGE_COPYLINK     ":/images/copyrslink.png"
 #define IMAGE_AUTHOR       ":/images/user/personal64.png"
 #define IMAGE_COPYHTTP     ":/images/emblem-web.png"
+#define IMAGE_PIN          ":/images/pin32.png"
 
 Q_DECLARE_METATYPE(RsPostedPost);
 
@@ -357,6 +358,18 @@ void PostedListWidgetWithModel::postContextMenu(const QPoint& point)
 
     menu.addAction(FilesDefs::getIconFromQtResourcePath(IMAGE_AUTHOR), tr("Show author in People tab"), this, SLOT(showAuthorInPeople()))->setData(index);
 
+    if(IS_GROUP_PUBLISHER(mGroup.mMeta.mSubscribeFlags))
+    {
+        QAction *pinAction = nullptr;
+
+        if(post.mPinned)
+            pinAction = menu.addAction(FilesDefs::getIconFromQtResourcePath(IMAGE_PIN), tr("Unpin post"), this, SLOT(unpinPost()));
+        else
+            pinAction = menu.addAction(FilesDefs::getIconFromQtResourcePath(IMAGE_PIN), tr("Pin post"), this, SLOT(pinPost()));
+
+        pinAction->setData(index);
+    }
+
 #ifdef TODO
     // This feature is not implemented yet in libretroshare.
 
@@ -526,6 +539,69 @@ void PostedListWidgetWithModel::copyMessageLink()
     {
         QMessageBox::critical(NULL,tr("Link creation error"),tr("Link could not be created: ")+e.what());
     }
+}
+
+void PostedListWidgetWithModel::pinPost()
+{
+	setPostPinnedFromSender(true);
+}
+
+void PostedListWidgetWithModel::unpinPost()
+{
+	setPostPinnedFromSender(false);
+}
+
+void PostedListWidgetWithModel::setPostPinnedFromSender(bool pinned)
+{
+	try
+	{
+		if(groupId().isNull())
+			throw std::runtime_error("No board currently selected!");
+
+		QAction *action = qobject_cast<QAction*>(QObject::sender());
+
+		if(!action)
+			throw std::runtime_error("No action sender for selected post!");
+
+		QModelIndex index = action->data().toModelIndex();
+
+		if(!index.isValid())
+			throw std::runtime_error("No post under mouse!");
+
+		RsPostedPost post = index.data(Qt::UserRole).value<RsPostedPost>();
+
+		if(post.mMeta.mMsgId.isNull())
+			throw std::runtime_error("Post has empty MsgId!");
+
+		RsGxsGroupId boardId = groupId();
+		RsGxsMessageId postId = post.mMeta.mMsgId;
+
+		RsThread::async([this, boardId, postId, pinned]()
+		{
+			std::string errorMessage;
+			bool ok = rsPosted->setPostPinned(boardId, postId, pinned, errorMessage);
+
+			RsQThreadUtils::postToObject([this, ok, errorMessage]()
+			{
+				if(!ok)
+				{
+					QMessageBox::critical(
+					            this, tr("Could not update pinned post"),
+					            tr("Error occurred while updating pinned post: ")
+					            + QString::fromStdString(errorMessage));
+					return;
+				}
+
+				updateDisplay(true);
+			}, this);
+		});
+	}
+	catch(std::exception& e)
+	{
+		QMessageBox::critical(
+		            this, tr("Could not update pinned post"),
+		            tr("Error occurred while updating pinned post: ") + e.what());
+	}
 }
 
 #ifdef TODO

--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.h
@@ -148,6 +148,8 @@ private slots:
 	void postPostLoad();
 	void copyMessageLink();
     void copyHttpLink();
+	void pinPost();
+	void unpinPost();
     void nextPosts();
     void prevPosts();
 	void filterItems(QString s);
@@ -164,6 +166,7 @@ private:
 
 	void insertBoardDetails(const RsPostedGroup &group);
 	void handleEvent_main_thread(std::shared_ptr<const RsEvent> event);
+	void setPostPinnedFromSender(bool pinned);
 
 private:
     RsPostedGroup mGroup;

--- a/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
@@ -459,6 +459,9 @@ public:
 
 	bool operator()(const RsPostedPost& p1,const RsPostedPost& p2) const
 	{
+		if(p1.mPinned != p2.mPinned)
+			return p1.mPinned;
+
         switch(mSortingStrategy)
         {
         default:
@@ -719,14 +722,16 @@ void RsPostedPostsModel::createPostsArray(std::vector<RsPostedPost>& posts)
 
     mPosts.clear();
 
-    for (std::vector<RsPostedPost>::const_reverse_iterator it = posts.rbegin(); it != posts.rend(); ++it)
+	for (std::vector<RsPostedPost>::const_reverse_iterator it = posts.rbegin(); it != posts.rend(); ++it)
     {
         if(!(*it).mMeta.mMsgId.isNull())
 		{
 #ifdef DEBUG_CHANNEL_MODEL
             std::cerr << " adding post \"" << (*it).mMeta.mMsgName << "\"" << std::endl;
 #endif
-			mPosts.push_back(*it);
+			RsPostedPost post(*it);
+			post.mPinned = mPostedGroup.mPinnedPosts.ids.find(post.mMeta.mMsgId) != mPostedGroup.mPinnedPosts.ids.end();
+			mPosts.push_back(post);
 		}
 #ifdef DEBUG_CHANNEL_MODEL
         else


### PR DESCRIPTION
## Summary
- add Pin post / Unpin post context menu actions for board publishers
- sort pinned board posts above normal posts for all sorting modes
- update the libretroshare submodule to include board pinned-post API support

Depends on RetroShare/libretroshare#299.

## Validation
- git diff --check
- local compile not run: qmake, make, g++, and cl are not installed in this workspace