### PR TITLE
fix(macos): add camera & microphone usage descriptions to Info.plist

### DIFF
--- a/retroshare-gui/src/Info.plist
+++ b/retroshare-gui/src/Info.plist
@@ -18,6 +18,10 @@
 	<string>com.retroshare</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>RetroShare needs access to your camera for video calls.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>RetroShare needs access to your microphone for voice and video calls.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
macOS 10.14+ terminates the app with SIGABRT when it accesses the camera or microphone without the matching usage-description keys in the bundle's Info.plist. Any VOIP audio/video call therefore crashes on macOS as soon as the capture device is opened (AVCaptureDeviceInput via QVideoInputDevice::start()).

Add NSCameraUsageDescription and NSMicrophoneUsageDescription so the system shows the standard permission prompt instead of aborting the process.