### PR TITLE
Fix missing Q_DECLARE_METATYPE include in Posted board widgets

### DIFF
--- a/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedListWidgetWithModel.cpp
@@ -53,6 +53,7 @@
 #include "PostedListWidgetWithModel.h"
 #include "PostedPostsModel.h"
 #include "BoardPostDisplayWidget.h"
+#include "PostedItem.h" // for Q_DECLARE_METATYPE(RsPostedPost)
 
 #include <algorithm>
 

--- a/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
+++ b/retroshare-gui/src/gui/Posted/PostedPostsModel.cpp
@@ -32,6 +32,7 @@
 #include "util/DateTime.h"
 
 #include "PostedPostsModel.h"
+#include "PostedItem.h" // for Q_DECLARE_METATYPE(RsPostedPost)
 
 //#define DEBUG_CHANNEL_MODEL
 


### PR DESCRIPTION
Commit 724db9ae6 ("Fix duplicated MOC declaration") consolidated Q_DECLARE_METATYPE(RsPostedPost) into PostedItem.h and removed the in-file declarations that PostedListWidgetWithModel.cpp and PostedPostsModel.cpp previously carried. But both translation units use QVariant with RsPostedPost (value<>() / fromValue()) and neither includes PostedItem.h, directly or transitively, so the build broke with:

  error: static assertion failed: Type is not registered, please use
  the Q_DECLARE_METATYPE macro to make it known to Qt's meta-object
  system

Add the missing #include "PostedItem.h" to both files so the metatype declaration is visible in those TUs.