### PR TITLE
GUI CMake: reliably select Qt6 (with Qt5 fallback)

### DIFF
--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -100,7 +100,22 @@ set(CMAKE_AUTOUIC OFF)
 
 # Detect Qt6 first, fall back to Qt5. All Qt usage below is version-agnostic via
 # the ${QT_VERSION_MAJOR} variable so the same tree builds against both.
-find_package( QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+#
+# Do NOT use find_package(QT NAMES Qt6 Qt5 ...) here: on distros that ship Qt5
+# and Qt6 side by side in the same prefix (Debian/Ubuntu multiarch,
+# /usr/lib/<arch>/cmake), the NAMES order is NOT honoured. CMake globs the
+# sibling Qt5*/Qt6* config dirs and stops at whichever <name>Config.cmake it
+# reaches first; that order is filesystem-dependent and routinely picks Qt5 even
+# though Qt6 is listed first. We therefore probe Qt6 explicitly and fall back to
+# Qt5. Bonus: this makes -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON work as a reliable
+# way to force a Qt5 build (it didn't, with the versionless QT package name).
+find_package( Qt6 QUIET COMPONENTS Core )
+if( Qt6_FOUND )
+	set( QT_VERSION_MAJOR 6 )
+else()
+	find_package( Qt5 COMPONENTS Core REQUIRED )
+	set( QT_VERSION_MAJOR 5 )
+endif()
 find_package( Qt${QT_VERSION_MAJOR} COMPONENTS
 	Core Widgets Xml Network Multimedia PrintSupport REQUIRED)
 if(QT_VERSION_MAJOR EQUAL 6)


### PR DESCRIPTION
## What
`retroshare-gui/CMakeLists.txt` now selects Qt6 reliably (falling back to Qt5),
and a new `BUILD-cmake.md` documents the CMake build on Linux / macOS / Windows
for both Qt5 and Qt6.

## Why
`find_package(QT NAMES Qt6 Qt5 ...)` does **not** reliably honour the `NAMES`
order on distros that ship Qt5 and Qt6 side by side in the same prefix
(Debian/Ubuntu multiarch, `/usr/lib/<arch>/cmake`): CMake globs the sibling
`Qt5*`/`Qt6*` config dirs and stops at whichever `…Config.cmake` it reaches
first, which is filesystem-order dependent and routinely lands on Qt5 even though
Qt6 is listed first. As a side effect, `-DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON` had
no effect (the package name in that call is `QT`, not `Qt6`).

## How
Probe Qt6 explicitly and fall back to Qt5:
```cmake
find_package(Qt6 QUIET COMPONENTS Core)
if(Qt6_FOUND)
    set(QT_VERSION_MAJOR 6)
else()
    find_package(Qt5 COMPONENTS Core REQUIRED)
    set(QT_VERSION_MAJOR 5)
endif()
```
This makes the Qt6 preference deterministic and makes
`-DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON` work as a reliable way to force a Qt5 build.

## Notes
- Builds against **both** Qt5 and Qt6 (version-agnostic via `${QT_VERSION_MAJOR}`).
- `BUILD-cmake.md`: per-platform build commands (Linux/macOS/Windows, Qt5 & Qt6).
