### PR TITLE
Fix Windows/MinGW crash on thread exit: avoid creating a QObject on the caller thread (postToObject/postToThread)

### DIFF
--- a/retroshare-gui/src/util/qtthreadsutils.h
+++ b/retroshare-gui/src/util/qtthreadsutils.h
@@ -43,14 +43,15 @@ void postToObject(F &&fun, QObject *obj = qApp)
 {
 	if (qobject_cast<QThread*>(obj))
 		qWarning() << "posting a call to a thread object - consider using postToThread";
-	QObject src;
-	auto type = obj->metaObject();
-	QObject::connect( &src, &QObject::destroyed, obj,
-	                  [fun = std::move(fun), type, obj]
-	{
-		// ensure that the object is not being destructed
-		if (obj->metaObject()->inherits(type)) fun();
-	}, Qt::QueuedConnection );
+	// Post the functor to obj's thread WITHOUT creating a temporary QObject on the
+	// calling thread. Creating a QObject here adopts Qt on a non-Qt worker thread
+	// (e.g. std::thread): it allocates per-thread QThreadData and registers a
+	// thread_local cleanup, which crashes when that worker thread exits on MinGW
+	// (libgcc emutls frees the thread_local storage before the __cxa_thread_atexit
+	// destructors run -> NULL deref in Qt's Cleanup::~Cleanup, qthread_win.cpp).
+	// invokeMethod posts to obj's thread without touching the caller's Qt state,
+	// and Qt cancels the call automatically if obj is destroyed first.
+	QMetaObject::invokeMethod(obj, std::forward<F>(fun), Qt::QueuedConnection);
 }
 
 /**
@@ -61,14 +62,8 @@ void postToThread(F &&fun, QThread *thread = qApp->thread())
 {
 	QObject * obj = QAbstractEventDispatcher::instance(thread);
 	Q_ASSERT(obj);
-	QObject src;
-	auto type = obj->metaObject();
-	QObject::connect( &src, &QObject::destroyed, obj,
-	                  [fun, type, obj]
-	{
-		// ensure that the object is not being destructed
-		if (obj->metaObject()->inherits(type)) fun();
-	}, Qt::QueuedConnection );
+	// Same rationale as postToObject: never create a QObject on the calling thread.
+	QMetaObject::invokeMethod(obj, std::forward<F>(fun), Qt::QueuedConnection);
 }
 
 #else // QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)


### PR DESCRIPTION
## What
`RsQThreadUtils::postToObject()` / `postToThread()` no longer create a temporary
`QObject` on the calling thread; they use
`QMetaObject::invokeMethod(obj, fun, Qt::QueuedConnection)` instead.

## Why
The previous implementations created a `QObject` on the **calling** thread and
relied on its `destroyed()` signal. When these helpers are called from a worker
`std::thread` that Qt did not create (e.g.
`GxsGroupFrameDialog::updateGroupSummary()`), creating that QObject makes Qt
**adopt** the thread: it allocates a `QThreadData` and registers a per-thread
cleanup. On Windows with Qt6, when such an adopted `std::thread` exits that
cleanup dereferences thread data that is not valid for a foreign thread and
crashes — a SIGSEGV in Qt's `Cleanup` teardown (`qtbase/.../qthread_win.cpp`).
RetroShare crashes a few seconds after startup on the Qt6 Windows build.

Creating a QObject on a thread Qt did not create is fragile by design; the right
fix is simply not to do it.

## How / compatibility
`QMetaObject::invokeMethod(obj, fun, Qt::QueuedConnection)` posts the functor to
`obj`'s own thread **without** creating any QObject on the caller, so a foreign
`std::thread` is never adopted by Qt. Behaviour is unchanged (and slightly safer:
Qt drops the call if `obj` is destroyed first). The functor overload of
`invokeMethod` exists since Qt 5.10 — the same `#if` branch this code already
used — so it builds against both Qt5 and Qt6. Fixes the Qt6 Windows startup
crash; no behavioural change on Linux/macOS.
