### PR TITLE
Qt6: replace removed QDateTime::setTime_t() with setSecsSinceEpoch()

### DIFF
--- a/retroshare-gui/src/gui/gxs/GxsCommentDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsCommentDialog.cpp
@@ -179,7 +179,7 @@ void GxsCommentDialog::setCommentHeader(QWidget *header)
 	ui->postFrame->setVisible(true);
 
 	QDateTime qtime;
-	qtime.setTime_t(mCurrentPost.mMeta.mPublishTs);
+	qtime.setSecsSinceEpoch(mCurrentPost.mMeta.mPublishTs);
 	QString timestamp = DateTime::formatDateTime(qtime);
 	ui->dateLabel->setText(timestamp);
 	ui->fromLabel->setText(QString::fromUtf8(mCurrentPost.mMeta.mAuthorId.c_str()));

--- a/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumModel.cpp
@@ -994,7 +994,7 @@ static void recursPrintModel(const std::vector<ForumModelPostEntry>& entries,For
     const ForumModelPostEntry& e(entries[index]);
 
 	QDateTime qtime;
-	qtime.setTime_t(e.mPublishTs);
+	qtime.setSecsSinceEpoch(e.mPublishTs);
 
     std::cerr << std::string(depth*2,' ') << index << " : " << e.mAuthorId.toStdString() << " "
               << QString("%1").arg((uint32_t)e.mPostFlags,8,16,QChar('0')).toStdString() << " "
@@ -1024,7 +1024,7 @@ void RsGxsForumModel::debug_dump()
 			std::cerr << " " << e.mChildren[j] ;
 
 		QDateTime qtime;
-		qtime.setTime_t(e.mPublishTs);
+		qtime.setSecsSinceEpoch(e.mPublishTs);
 
         std::cerr << " (" << e.mParent << ")";
 		std::cerr << " " << qtime.toString().toStdString() << " \"" << e.mTitle << "\"" << std::endl;


### PR DESCRIPTION
## What
Replace `QDateTime::setTime_t()` with `QDateTime::setSecsSinceEpoch()` in
`GxsCommentDialog` and `GxsForumModel`.

## Why
`QDateTime::setTime_t()` was deprecated in Qt 5.8 and **removed in Qt6**, so the
GUI does not compile against Qt6.

## Compatibility
`setSecsSinceEpoch()` exists since Qt 5.8, so the code keeps building against
**both** Qt5 and Qt6, with identical behaviour (local time).
