### PR TITLE
filter joined/left system messages in chat rooms

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyDialog.cpp
@@ -891,12 +891,14 @@ void ChatLobbyDialog::handleLobbyEvent(RsChatLobbyEventCode event_type, const Rs
     {
     case RsChatLobbyEventCode::CHAT_LOBBY_EVENT_PEER_LEFT:
         qsParticipant=gxs_id;
-        ui.chatWidget->addChatMsg(true, tr("Chat room management"), QDateTime::currentDateTime(), QDateTime::currentDateTime(), tr("%1 has left the room.").arg(RsHtml::plainText(name)), ChatWidget::MSGTYPE_SYSTEM);
+        if (!(Settings->getChatLobbyFlags() & RS_CHATLOBBY_HIDE_JOIN_LEAVE))
+            ui.chatWidget->addChatMsg(true, tr("Chat room management"), QDateTime::currentDateTime(), QDateTime::currentDateTime(), tr("%1 has left the room.").arg(RsHtml::plainText(name)), ChatWidget::MSGTYPE_SYSTEM);
         emit peerLeft(id()) ;
         break;
     case RsChatLobbyEventCode::CHAT_LOBBY_EVENT_PEER_JOINED:
         qsParticipant=gxs_id;
-        ui.chatWidget->addChatMsg(true, tr("Chat room management"), QDateTime::currentDateTime(), QDateTime::currentDateTime(), tr("%1 joined the room.").arg(RsHtml::plainText(name)), ChatWidget::MSGTYPE_SYSTEM);
+        if (!(Settings->getChatLobbyFlags() & RS_CHATLOBBY_HIDE_JOIN_LEAVE))
+            ui.chatWidget->addChatMsg(true, tr("Chat room management"), QDateTime::currentDateTime(), QDateTime::currentDateTime(), tr("%1 joined the room.").arg(RsHtml::plainText(name)), ChatWidget::MSGTYPE_SYSTEM);
         emit peerJoined(id()) ;
         break;
     case RsChatLobbyEventCode::CHAT_LOBBY_EVENT_PEER_STATUS:

--- a/retroshare-gui/src/gui/settings/ChatPage.cpp
+++ b/retroshare-gui/src/gui/settings/ChatPage.cpp
@@ -293,6 +293,7 @@ ChatPage::ChatPage(QWidget * parent, Qt::WindowFlags flags)
 	connect(ui.chat_Blink,                 SIGNAL(toggled(bool)),            this, SLOT(updateChatFlags()));
 
 	connect(ui.chatLobby_Blink,            SIGNAL(toggled(bool)),            this, SLOT(updateChatLobbyFlags()));
+	connect(ui.chatLobby_HideJoinLeave,    SIGNAL(toggled(bool)),            this, SLOT(updateChatLobbyFlags()));
 
 	connect(ui.publicStyle,                SIGNAL(currentIndexChanged(int)), this,SLOT(on_publicList_currentRowChanged(int)));
 	connect(ui.privateStyle,               SIGNAL(currentIndexChanged(int)), this,SLOT(on_privateList_currentRowChanged(int)));
@@ -376,6 +377,9 @@ void ChatPage::updateChatLobbyFlags()
 
 	if (ui.chatLobby_Blink->isChecked())
 		chatLobbyFlags |= RS_CHATLOBBY_BLINK;
+
+	if (ui.chatLobby_HideJoinLeave->isChecked())
+		chatLobbyFlags |= RS_CHATLOBBY_HIDE_JOIN_LEAVE;
 
 	Settings->setChatLobbyFlags(chatLobbyFlags);
 }
@@ -486,6 +490,7 @@ ChatPage::load()
     uint chatLobbyFlags = Settings->getChatLobbyFlags();
 
     whileBlocking(ui.chatLobby_Blink)->setChecked(chatLobbyFlags & RS_CHATLOBBY_BLINK);
+    whileBlocking(ui.chatLobby_HideJoinLeave)->setChecked(chatLobbyFlags & RS_CHATLOBBY_HIDE_JOIN_LEAVE);
 
 	 // load personal invites
 	 //

--- a/retroshare-gui/src/gui/settings/ChatPage.ui
+++ b/retroshare-gui/src/gui/settings/ChatPage.ui
@@ -564,6 +564,13 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="chatLobby_HideJoinLeave">
+           <property name="text">
+            <string>Hide join/leave messages</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/retroshare-gui/src/gui/settings/rsharesettings.h
+++ b/retroshare-gui/src/gui/settings/rsharesettings.h
@@ -33,6 +33,7 @@
 #include "rsettings.h"
 
 #define RS_CHATLOBBY_BLINK              0x00000001
+#define RS_CHATLOBBY_HIDE_JOIN_LEAVE    0x00000002
 
 #define STATUSBAR_DISC  0x00000001
 


### PR DESCRIPTION
## What

Adds an optional **"Hide join/leave messages"** checkbox under
*Settings → Chat*. When enabled, the *"X joined the room"* / *"X has left
the room"* system messages are no longer printed in chat rooms (lobbies).

## Why

In busy or large chat rooms these join/leave notices can flood the
conversation and bury actual messages. This lets users who don't care
about presence churn keep their chat history clean, while leaving the
behaviour untouched for everyone else.

## How

- New GUI flag `RS_CHATLOBBY_HIDE_JOIN_LEAVE` (0x00000002) in
  `rsharesettings.h`.
- New checkbox `chatLobby_HideJoinLeave` in `ChatPage.ui`, wired up to
  load/save through `updateChatLobbyFlags()` / `load()` in `ChatPage.cpp`.
- `ChatLobbyDialog::handleLobbyEvent()` skips the `addChatMsg(...)` call
  for `PEER_JOINED` / `PEER_LEFT` when the flag is set. The
  `peerJoined` / `peerLeft` signals are still emitted, so the participant
  list and counters stay correct — only the chat text is suppressed.

## Notes

- **Off by default** — existing users see no change.
- GUI-only; no changes to libretroshare or the wire protocol.
- Scope is intentionally limited to join/leave notices; other system
  messages (topic change, etc.) are untouched.
