### PR TITLE
build(cmake): enable the WikiPoos and The Wire GUI features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,14 @@ option(RS_FRIENDSERVER "Build RetroShare Friendserver" ON)
 option(RS_PLUGINS "Build RetroShare Plugins" OFF)
 option(RS_USE_I2P_SAM3 "Enable I2P SAMv3 support" ON)
 
+# Experimental, off-by-default GXS features. These are declared here at the top
+# level so the option propagates to both libretroshare (which compiles the
+# p3wiki/p3wire services and defines RS_USE_WIKI/RS_USE_WIRE) and retroshare-gui
+# (which builds the WikiPoos/TheWire dialogs). Enable both halves together, e.g.
+# cmake -DRS_GXSTHEWIRE=ON -DRS_GXSWIKIPOS=ON ...
+option(RS_GXSWIKIPOS "Build the experimental GXS Wiki (WikiPoos) feature" OFF)
+option(RS_GXSTHEWIRE "Build the experimental GXS 'The Wire' feature" OFF)
+
 # The "sam3" target is defined once here, at the top level, because it is linked
 # by more than one subproject: libretroshare AND retroshare-gui (which uses libsam3
 # directly in gui/settings/ServerPage.cpp). Defining it once avoids a duplicate

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -352,6 +352,27 @@ if(RS_GUI_CMARK)
 	target_include_directories(${PROJECT_NAME} PRIVATE "${CMARK_INCLUDE_DIR}")
 endif(RS_GUI_CMARK)
 
+############################# pegmarkdown (WikiPoos) ###########################
+
+# The WikiPoos GUI (gui/WikiPoos/*) renders markdown via the bundled
+# peg-markdown library. Build and link it only when the Wiki feature is on.
+if(RS_GXSWIKIPOS)
+	set(PEGMARKDOWN_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/pegmarkdown/")
+	if(EXISTS "${PEGMARKDOWN_DEVEL_DIR}/CMakeLists.txt")
+		message(STATUS "pegmarkdown source found at ${PEGMARKDOWN_DEVEL_DIR} using it")
+		if(NOT TARGET pegmarkdown)
+			add_subdirectory("${PEGMARKDOWN_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/pegmarkdown")
+		endif()
+		# PUBLIC include dir of the pegmarkdown target makes markdown_lib.h and
+		# the dummy <glib.h> reachable from the GUI's Wiki sources.
+		target_link_libraries(${PROJECT_NAME} PRIVATE pegmarkdown)
+	else()
+		message(FATAL_ERROR
+			"RS_GXSWIKIPOS is ON but pegmarkdown was not found at "
+			"${PEGMARKDOWN_DEVEL_DIR}")
+	endif()
+endif(RS_GXSWIKIPOS)
+
 ################################# LibSam v3 ####################################
 
 # sam3 is used directly by the GUI (gui/settings/ServerPage.cpp includes

--- a/retroshare-gui/src/CMakeLists.txt
+++ b/retroshare-gui/src/CMakeLists.txt
@@ -945,19 +945,23 @@ if(RS_GXSPHOTOSHARE)
 endif(RS_GXSPHOTOSHARE)
 
 if(RS_GXSWIKIPOS)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_USE_WIKI 
-		)
-
-	target_include_directories(${PROJECT_NAME} PUBLIC ../../supportlibs/pegmarkdown)
+	# NOTE: the retroshare-gui target is created by the parent CMakeLists.txt
+	# (add_executable) only AFTER this file is include()d, so target_* commands
+	# do not work here. add_definitions() is directory-scoped and applies to the
+	# target created later in this same scope. RS_USE_WIKI is also provided
+	# PUBLIC by libretroshare, but we set it explicitly for clarity. The
+	# pegmarkdown include path comes from linking the pegmarkdown target in the
+	# parent CMakeLists.txt.
+	add_definitions(-DRS_USE_WIKI)
 
 	list(
 		APPEND RS_IMPLEMENTATION_HEADERS
 		src/gui/WikiPoos/WikiDialog.h 
 		src/gui/WikiPoos/WikiAddDialog.h 
-		src/gui/WikiPoos/WikiEditDialog.h 
-		src/gui/gxs/WikiGroupDialog.h 
-		src/gui/gxs/RsGxsUpdateBroadcastBase.h 
+		src/gui/WikiPoos/WikiEditDialog.h
+		src/gui/WikiPoos/WikiUserNotify.h
+		src/gui/gxs/WikiGroupDialog.h
+		src/gui/gxs/RsGxsUpdateBroadcastBase.h
 		src/gui/gxs/RsGxsUpdateBroadcastWidget.h 
 		src/gui/gxs/RsGxsUpdateBroadcastPage.h 
 		)
@@ -973,9 +977,10 @@ if(RS_GXSWIKIPOS)
 		APPEND RS_GUI_SOURCES
 		src/gui/WikiPoos/WikiDialog.cpp 
 		src/gui/WikiPoos/WikiAddDialog.cpp 
-		src/gui/WikiPoos/WikiEditDialog.cpp 
-		src/gui/gxs/WikiGroupDialog.cpp 
-		src/gui/gxs/RsGxsUpdateBroadcastBase.cpp 
+		src/gui/WikiPoos/WikiEditDialog.cpp
+		src/gui/WikiPoos/WikiUserNotify.cpp
+		src/gui/gxs/WikiGroupDialog.cpp
+		src/gui/gxs/RsGxsUpdateBroadcastBase.cpp
 		src/gui/gxs/RsGxsUpdateBroadcastWidget.cpp 
 		src/gui/gxs/RsGxsUpdateBroadcastPage.cpp 
 		)
@@ -987,9 +992,9 @@ if(RS_GXSWIKIPOS)
 endif(RS_GXSWIKIPOS)
 	
 if(RS_GXSTHEWIRE)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_USE_WIRE 
-		)
+	# See the RS_GXSWIKIPOS note above: the target does not exist yet here, so
+	# use a directory-scoped definition (also provided PUBLIC by libretroshare).
+	add_definitions(-DRS_USE_WIRE)
 
 	list(
 		APPEND RS_IMPLEMENTATION_HEADERS
@@ -1004,8 +1009,9 @@ if(RS_GXSTHEWIRE)
 		src/gui/TheWire/PulseReply.h 
 		src/gui/TheWire/PulseReplySeperator.h 
 		src/gui/TheWire/PulseMessage.h
+		src/gui/TheWire/CustomFrame.h
 		src/gui/TheWire/WireUserNotify.h
-		src/gui/feeds/WireNotifyGroupItem.h 
+		src/gui/feeds/WireNotifyGroupItem.h
 		src/gui/feeds/WireNotifyPostItem.h
 		)
 
@@ -1036,7 +1042,8 @@ if(RS_GXSTHEWIRE)
 		src/gui/TheWire/PulseViewGroup.cpp 
 		src/gui/TheWire/PulseReply.cpp 
 		src/gui/TheWire/PulseReplySeperator.cpp 
-		src/gui/TheWire/PulseMessage.cpp 
+		src/gui/TheWire/PulseMessage.cpp
+		src/gui/TheWire/CustomFrame.cpp
 		src/gui/TheWire/WireUserNotify.cpp
 		src/gui/feeds/WireNotifyGroupItem.cpp
 		src/gui/feeds/WireNotifyPostItem.cpp
@@ -1044,7 +1051,7 @@ if(RS_GXSTHEWIRE)
 
 	list(
 		APPEND RS_GUI_QTRESOURCES
-		RESOURCES += src/gui/TheWire/TheWire_images.qrc
+		src/gui/TheWire/TheWire_images.qrc
 		)
 endif(RS_GXSTHEWIRE)
 

--- a/supportlibs/pegmarkdown/CMakeLists.txt
+++ b/supportlibs/pegmarkdown/CMakeLists.txt
@@ -1,0 +1,37 @@
+# RetroShare decentralized communication platform
+#
+# SPDX-License-Identifier: CC0-1.0
+#
+# Minimal CMake build for the bundled peg-markdown static library, used by the
+# WikiPoos GUI (retroshare-gui, guarded by RS_GXSWIKIPOS). The historical qmake
+# build (pegmarkdown.pro) linked a pre-built libpegmarkdown.a; this reproduces
+# it as a normal CMake target.
+#
+# We use the bundled "dummy glib" (GLibFacade + the local glib.h) on every
+# platform, exactly like the Windows/macOS qmake builds did, so there is no
+# dependency on system glib-2.0.
+
+cmake_minimum_required(VERSION 3.5)
+project(pegmarkdown C)
+
+add_library(pegmarkdown STATIC
+	markdown_lib.c
+	markdown_parser.c
+	parsing_functions.c
+	markdown_output.c
+	odf.c
+	utility_functions.c
+	GLibFacade.c )
+
+# Some of the (old) sources rely on GNU/POSIX libc extensions (e.g. strdup).
+target_compile_definitions(pegmarkdown PRIVATE _GNU_SOURCE)
+
+# Consumers include "markdown_lib.h" and, transitively, the bundled dummy
+# <glib.h> from this same directory.
+target_include_directories(pegmarkdown PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Third-party legacy C: silence its warnings so they neither clutter the build
+# nor break it under a strict toolchain.
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+	target_compile_options(pegmarkdown PRIVATE -w)
+endif()


### PR DESCRIPTION
Add the CMake plumbing to actually build the (experimental, off-by-default) GXS Wiki (WikiPoos) and The Wire features. Until now the retroshare-gui CMakeLists carried RS_GXSWIKIPOS / RS_GXSTHEWIRE blocks, but the options were never declared and the blocks contained bugs that only surfaced once enabled, so there was no working way to build these features with CMake.

- Declare RS_GXSWIKIPOS / RS_GXSTHEWIRE options at the super-project level (default OFF), so they propagate to libretroshare (which compiles the p3wiki/p3wire services and defines RS_USE_WIKI/RS_USE_WIRE) and to the GUI.
- retroshare-gui/src/CMakeLists.txt: the wiki/wire blocks called target_*() on the retroshare-gui target, which does not exist yet where src is include()d (add_executable runs later). Switch to directory-scoped add_definitions(). Also drop a stray qmake-ism ("RESOURCES +=") in the TheWire qrc list, and re-add two sources lost in the qmake->CMake port: WikiUserNotify (wiki) and CustomFrame (wire).
- Build the bundled peg-markdown used by WikiPoos: add supportlibs/pegmarkdown/CMakeLists.txt (static lib with the bundled dummy glib, no system glib-2.0 dependency) and link it into the GUI when RS_GXSWIKIPOS is on, mirroring the existing cmark integration.

The libretroshare backend change lives in its own repository/branch; the submodule gitlink is intentionally left untouched here so maintainers can advance it when merging. Both features remain OFF by default.