### PR TITLE
fix(voip): keep aspect ratio in camera preview

### DIFF
--- a/plugins/VOIP/gui/QVideoDevice.cpp
+++ b/plugins/VOIP/gui/QVideoDevice.cpp
@@ -232,6 +232,6 @@ void QVideoOutputDevice::showFrame(const QImage& img)
 #ifdef DEBUG_QVIDEODEVICE
     std::cerr << "img.size = " << img.width() << " x " << img.height() << std::endl;
 #endif
-    setPixmap(QPixmap::fromImage(img).scaled( QSize(height()*4/3,height()),Qt::IgnoreAspectRatio,Qt::SmoothTransformation)) ;
+    setPixmap(QPixmap::fromImage(img).scaled( QSize(height()*4/3,height()),Qt::KeepAspectRatio,Qt::SmoothTransformation)) ;
 }
 


### PR DESCRIPTION
The self-view preview in Preferences/VOIP scaled camera frames into the display widget with Qt::IgnoreAspectRatio, forcing them into a 4:3 box. Non-4:3 cameras (e.g. 16:9) were therefore stretched vertically.

Use Qt::KeepAspectRatio, matching the sibling showFrameOff() which already scales the placeholder icon correctly.