### PR TITLE
fix(gui): give RetroShare GUI its own version, independent from libretroshare

### DIFF
--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -622,6 +622,27 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE RS_RELEASE_VERSION )
 target_compile_definitions(${PROJECT_NAME} PRIVATE TARGET=\"retroshare\")
 target_compile_definitions(${PROJECT_NAME} PRIVATE RS_DIRECT_CHAT)
 
+# RetroShare GUI own version (RS_GUI_VERSION), independent from libretroshare.
+# retroshare-gui is a directory of the RetroShare super-project (not a submodule),
+# so `git describe` here resolves to the super-project version, which is exactly
+# what the GUI should report as its own version. Drop the leading 'v' to match the
+# usual version style. rsguiversion.h provides a default, so a build without git
+# metadata (or the qmake/Android build path) still compiles.
+execute_process(
+	COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	OUTPUT_VARIABLE RS_GUI_VERSION
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	RESULT_VARIABLE RS_GUI_GIT_RESULT ) # Avoid CMake failure if git fails
+if(RS_GUI_GIT_RESULT EQUAL 0 AND NOT RS_GUI_VERSION STREQUAL "")
+	string(REGEX REPLACE "^v" "" RS_GUI_VERSION "${RS_GUI_VERSION}")
+	message(STATUS "RetroShare GUI version ${RS_GUI_VERSION}")
+	target_compile_definitions(
+		${PROJECT_NAME} PRIVATE RS_GUI_VERSION="${RS_GUI_VERSION}" )
+else()
+	message(WARNING "Determining RetroShare GUI version via git failed")
+endif()
+
 # Match the actual option name RS_GXSCIRCLES (defined above). It was previously
 # tested as RS_GXS_CIRCLES (extra underscore), so RS_USE_CIRCLES was never defined.
 if(RS_GXSCIRCLES)

--- a/retroshare-gui/src/CMakeLists.txt
+++ b/retroshare-gui/src/CMakeLists.txt
@@ -413,7 +413,8 @@ list(
 
 	src/TorControl/TorControlWindow.h
 
-	src/rshare.h 
+	src/rshare.h
+	src/rsguiversion.h
 	src/retroshare-gui/configpage.h 
 	src/retroshare-gui/RsAutoUpdatePage.h 
 	src/retroshare-gui/mainpage.h 

--- a/retroshare-gui/src/gui/HelpDialog.cpp
+++ b/retroshare-gui/src/gui/HelpDialog.cpp
@@ -80,12 +80,10 @@ HelpDialog::HelpDialog(QWidget *parent) :
 		ui->thanks->setHtml(in.readAll());
 	}
 
-    /* [Modified] Display both RetroShare and libretroshare versions clearly */
-    QString versionText = QString("RetroShare: %1\nlibretroshare: %2")
-                          .arg(RsApplication::retroshareVersion(true))
-                          .arg(QString::fromUtf8(RsInit::libRetroShareVersion()));
-
-	ui->version->setText(versionText);
+	/* Display RetroShare GUI's own version. libretroshare is one of the
+	 * libraries the GUI links against, so its version is shown among the other
+	 * libraries below (see push_front just after getLibraries), not here. */
+	ui->version->setText(RsApplication::retroshareVersion(true));
 
 	/* Add version numbers of libretroshare */
 	std::list<RsLibraryInfo> libraries;

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -368,6 +368,7 @@ wikipoos {
 
 # Input
 HEADERS +=  rshare.h \
+            rsguiversion.h \
             retroshare-gui/configpage.h \
             retroshare-gui/RsAutoUpdatePage.h \
             retroshare-gui/mainpage.h \

--- a/retroshare-gui/src/rsguiversion.h
+++ b/retroshare-gui/src/rsguiversion.h
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * retroshare-gui/src/: rsguiversion.h                                         *
+ *                                                                             *
+ * RetroShare GUI                                                              *
+ *                                                                             *
+ * Copyright (C) 2026  Retroshare Team <contact@retroshare.cc>                 *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Affero General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Affero General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Affero General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+#pragma once
+
+/**
+ * @file rsguiversion.h
+ *
+ * RetroShare GUI own version, independent from libretroshare.
+ *
+ * @def RS_GUI_VERSION
+ * Human readable version string of the RetroShare GUI, injected at compile time
+ * by the build system (both qmake and CMake) from `git describe` of the
+ * RetroShare super-project, i.e. the repository that hosts retroshare-gui.
+ *
+ * This is the GUI application's OWN version, distinct from the core engine
+ * version exposed by libretroshare (RS_HUMAN_READABLE_VERSION in
+ * retroshare/rsversion.h, reported to the GUI through RsInit::libRetroShareVersion()).
+ * The GUI displays its own version as "the RetroShare version" and lists
+ * libretroshare's version among the other libraries, like any dependency.
+ *
+ * A default is provided so builds without version injection (e.g. a source
+ * tarball without git metadata, or a reduced build) still compile.
+ */
+#ifndef RS_GUI_VERSION
+#	define RS_GUI_VERSION "version not available"
+#endif
+
+/** Human readable string describing the RetroShare GUI version */
+constexpr auto RS_GUI_HUMAN_READABLE_VERSION = RS_GUI_VERSION;

--- a/retroshare-gui/src/rshare.cpp
+++ b/retroshare-gui/src/rshare.cpp
@@ -53,7 +53,7 @@
 
 #include <util/argstream.h>
 #include <retroshare/rsinit.h>
-#include <retroshare/rsversion.h>
+#include "rsguiversion.h"
 #include <retroshare/rsplugin.h>
 
 #include "rshare.h"
@@ -241,7 +241,10 @@ void RsApplication::slotConnectionEstablished()
     }
 }
 
-QString RsApplication::retroshareVersion(bool) { return RS_HUMAN_READABLE_VERSION; }
+/* The GUI reports its OWN version here (RS_GUI_VERSION, injected from the
+ * super-project git describe), independent from libretroshare. libretroshare's
+ * version is obtained separately through RsInit::libRetroShareVersion(). */
+QString RsApplication::retroshareVersion(bool) { return RS_GUI_HUMAN_READABLE_VERSION; }
 
 /** Enters the main event loop and waits until exit() is called. The signal
  * running() will be emitted when the event loop has started. */

--- a/retroshare.pri
+++ b/retroshare.pri
@@ -525,6 +525,15 @@ trough qmake command line arguments!")
     }
 }
 
+# RetroShare GUI own version (RS_GUI_VERSION), independent from libretroshare.
+# The block above resolves the RetroShare super-project version; the GUI reports
+# it as its own version (see retroshare-gui/src/rsguiversion.h). Only the GUI
+# consumes this define; harmless for the other sub-projects. When the version
+# could not be determined, rsguiversion.h falls back to its built-in default.
+!isEmpty(RS_MAJOR_VERSION) {
+    DEFINES += RS_GUI_VERSION=\\\"$${RS_MAJOR_VERSION}.$${RS_MINOR_VERSION}.$${RS_MINI_VERSION}$${RS_EXTRA_VERSION}\\\"
+}
+
 # Some supportlibs compilation won't start if the intstalled CMAKE verison is >=3.5.
 # Force compilation in that case
 CMAKE_FORCE_MINVERSION=""


### PR DESCRIPTION
fix(gui): give RetroShare GUI its own version, independent from libretroshare

following Gio's comments, new attempt at displaying RS GUI version without interfering with libretroshare

The GUI reported RS_HUMAN_READABLE_VERSION (a libretroshare macro) as "the RetroShare version". In the CMake build libretroshare exports RS_MAJOR_VERSION as a PUBLIC define, so the GUI inherited the engine's version and displayed it as its own: About showed the same number for both.

Give the GUI its own version, as discussed:

- Add retroshare-gui/src/rsguiversion.h defining RS_GUI_VERSION with a built-in default, so every build path (including qmake/Android) compiles even without version injection.
- Inject RS_GUI_VERSION from 'git describe' of the super-project in both CMake (retroshare-gui/CMakeLists.txt) and qmake (retroshare.pri).
- RsApplication::retroshareVersion() now returns the GUI's own version instead of libretroshare's.
- About (HelpDialog) shows the GUI version at the top; libretroshare's version is listed among the other libraries, like any dependency. AboutWidget already displayed both lines and is now correct automatically.

libretroshare needs no change: it already exposes its own version through RsInit::libRetroShareVersion() in both build systems.