### PR TITLE
build(appimage): linuxdeploy-based AppImage packaging (local + portable glibc 2.31)

### DIFF
--- a/build_scripts/AppImage/BUILD.md
+++ b/build_scripts/AppImage/BUILD.md
@@ -44,6 +44,12 @@ It downloads `linuxdeploy` + `linuxdeploy-plugin-qt` into
 `build_scripts/AppImage/tools/` (once), lays out a clean `AppDir`, and bundles
 Qt + libs.
 
+**Qt5 or Qt6:** the script reads the Qt major from the compiled binary and picks
+the matching `qmake` automatically (`qmake6` for a Qt6 build, `qmake`/`qmake-qt5`
+for Qt5), and aborts early on a qmake/binary Qt mismatch. So to ship a Qt6
+AppImage, just compile the GUI against Qt6 — no script change. Override the
+choice with `QMAKE=/path/to/qmake` if needed.
+
 ---
 
 ## 2. Portable build — `build-appimage-docker.sh`

--- a/build_scripts/AppImage/BUILD.md
+++ b/build_scripts/AppImage/BUILD.md
@@ -1,0 +1,227 @@
+# Building RetroShare AppImages (Linux)
+
+Two ways to produce a RetroShare GUI AppImage. Both **package the CMake build**
+(never qmake) with `linuxdeploy` — they differ only in *where* the binary is
+compiled, which fixes the glibc floor of the result.
+
+| Script | Compiles? | Needs a local CMake build first? | Result runs on |
+|---|---|---|---|
+| `build-appimage-local.sh` | no — packages `Build-cmake/retroshare-gui/retroshare-gui` | **yes** | only distros with glibc ≥ the build host (≈2.39 on Ubuntu 24.04) |
+| `build-appimage-docker.sh` | yes — inside a Debian 11 container | **no** | any distro with **glibc ≥ 2.31** (MX 21, Slackware 15, Debian 11+, Ubuntu 20.04+, Fedora 34+…) |
+
+**Rule of thumb:** use `docker` for anything you hand to testers/users; use
+`local` only for a quick check on a recent machine.
+
+> Whatever you run, **the source tree must already contain the code you want to
+> ship.** These scripts don't change code: `local` repackages whatever is in
+> `Build-cmake/`, `docker` recompiles the mounted source. After switching
+> branches (e.g. to `combo` for the GXS signature-verification fixes) you must
+> rebuild.
+
+---
+
+## 1. Local build — `build-appimage-local.sh`
+
+Fast, but the AppImage inherits **this machine's glibc**, so it only runs on
+equally-recent or newer distros.
+
+```bash
+# 1. compile with CMake first (see ../../BUILD-cmake.md) — Qt5, GUI:
+cmake -G Ninja -B Build-cmake -S . \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON \
+  -DRS_GUI=ON -DRS_SERVICE=OFF -DRS_FRIENDSERVER=OFF -DRS_PLUGINS=OFF \
+  -DRS_JSON_API=ON -DRS_WEBUI=ON -DRS_FORUM_DEEP_INDEX=OFF
+cmake --build Build-cmake -j$(nproc)
+
+# 2. package it:
+build_scripts/AppImage/build-appimage-local.sh
+```
+
+Output: `Build-appimage/RetroShare-<version>-x86_64.AppImage`.
+
+It downloads `linuxdeploy` + `linuxdeploy-plugin-qt` into
+`build_scripts/AppImage/tools/` (once), lays out a clean `AppDir`, and bundles
+Qt + libs.
+
+---
+
+## 2. Portable build — `build-appimage-docker.sh`
+
+Compiles inside a **Debian 11 (glibc 2.31)** container, so the AppImage runs
+almost everywhere. No prior local build needed — it recompiles the mounted
+source itself into `Build-cmake-bullseye/` (separate from your `Build-cmake/`).
+
+> **Prerequisite (glibc 2.31 build only):** the libretroshare you compile must
+> carry the `RS_NO_LTO` opt-out, i.e. **libretroshare PR #316 must be merged**
+> (or its branch checked out in the `libretroshare` submodule). Debian 11's
+> GCC 10 crashes while linking otherwise — see [**LTO**](#lto) below. The
+> `local` build does not need it.
+
+```bash
+build_scripts/AppImage/build-appimage-docker.sh
+```
+
+Prerequisite: **Docker** (or Podman). One-time setup on Ubuntu:
+
+```bash
+sudo apt install -y docker.io
+sudo usermod -aG docker $USER
+```
+
+Then **log out and back in once** (every new terminal then has Docker + your
+normal group). `newgrp docker` is only a "activate it in this terminal without
+logging out" shortcut; its side effect is that files you create in that shell
+get group `docker` — harmless, but avoid it by just re-logging.
+
+### From scratch vs incremental
+
+Incremental by default (reuses `Build-cmake-bullseye/`, fast). To recompile
+everything from zero:
+
+```bash
+CLEAN=1 build_scripts/AppImage/build-appimage-docker.sh
+```
+
+The output `AppDir` and `.AppImage` are rebuilt every run regardless. The Docker
+**image** is never touched by `CLEAN` — rebuild it from scratch only when you
+change dependencies, with `docker build --no-cache -f Dockerfile.bullseye .`.
+
+---
+
+## Files in this directory
+
+| File | Role |
+|---|---|
+| `build-appimage-local.sh` | package the local `Build-cmake` binary (host glibc) |
+| `build-appimage-docker.sh` | host-side driver: build image, run the container build (glibc 2.31) |
+| `Dockerfile.bullseye` | Debian 11 toolchain + deps + AppImage tools |
+| `_appimage-inside.sh` | runs **inside** the container: cmake → AppDir → linuxdeploy |
+| `tools/` | cached `linuxdeploy` + `linuxdeploy-plugin-qt` |
+| `TESTERS.txt` | ship this **with** the AppImage — how testers run it |
+| `Recipe`, `retroshare.yml`, `makeAppImage*.sh` | **obsolete** (old probonopd Qt4/trusty recipe) — ignore |
+
+---
+
+## How the packaging works
+
+Both scripts build the same clean FHS `AppDir` by hand (the project's own
+`install()` rules aren't AppImage-friendly — `RS_SERVICE_DESKTOP` is OFF by
+default and would put the `.desktop` under `prefix/data/`):
+
+```
+AppDir/usr/bin/retroshare-gui                    <- the CMake binary
+AppDir/usr/share/applications/retroshare.desktop <- Icon=retroshare, Exec=retroshare-gui
+AppDir/usr/share/icons/hicolor/{24,48,64,128,scalable}/apps/retroshare.*
+```
+
+then `linuxdeploy --plugin qt --output appimage` bundles Qt + all non-system libs.
+
+**We use `linuxdeploy`, not `linuxdeployqt`.** The probonopd `linuxdeployqt`
+"continuous" build 107 fails silently right after the icon stage on this
+toolchain. `linuxdeploy` + `linuxdeploy-plugin-qt` work and give clear errors.
+`APPIMAGE_EXTRACT_AND_RUN=1` is set because containers/Ubuntu 24.04 lack libfuse2.
+
+---
+
+## Adding a missing build dependency
+
+If the container build fails on a missing header / `pkg_check_modules … not
+found`, add the Debian package to **`Dockerfile.bullseye`** — in the **small
+trailing `RUN apt-get install` layer**, *not* the big apt line. That keeps the
+big toolchain layer a cache hit so only the new package installs (editing the
+big line reinstalls the whole toolchain).
+
+Known one already applied: `libxss-dev` (provides `xscrnsaver.pc`, needed by the
+GUI's idle detection at `retroshare-gui/CMakeLists.txt`).
+
+---
+
+## LTO
+
+The container build passes `-DRS_NO_LTO=ON`. Debian 11's GCC 10 has an LTO
+plugin that segfaults (`lto1: internal compiler error: Segmentation fault`, IPA
+`icf` pass) when linking libretroshare, so LTO **must** be off for the glibc
+2.31 build to link at all.
+
+`RS_NO_LTO` is an opt-out in `libretroshare/CMakeLists.txt` (default builds keep
+LTO on). It is **not in libretroshare master yet** — it comes from libretroshare
+**PR #316** (`CMakeLtoOptOut`). The glibc 2.31 build therefore only works once
+that option is present in the libretroshare you compile:
+
+- **ideally:** PR #316 is merged into libretroshare master — a plain
+  `git submodule update --init` then picks it up, nothing else to do;
+- **until then:** check out the #316 branch inside the `libretroshare` submodule
+  before running the Docker build.
+
+Without it, CMake silently ignores `-DRS_NO_LTO=ON` (`unused variable` warning),
+LTO stays on, and the container link dies with the `lto1` ICE.
+
+The local build (recent host GCC) is unaffected — LTO links fine there, so the
+flag is a harmless no-op. `_appimage-inside.sh` passes it automatically.
+
+---
+
+## Versioning / filename gotcha
+
+The version in the filename comes from `git describe` of the **super-project**
+(retroshare-gui), **not** libretroshare. So a build with a fixed/different
+libretroshare (e.g. `combo`) can carry the **same filename** as an older buggy
+one. Rename the output to mark the real variant, e.g.:
+
+```bash
+mv Build-appimage/RetroShare-v0.6.7.3-1081-g8943c7306-x86_64.AppImage \
+   Build-appimage/RetroShare-combo-gxsfix-x86_64-glibc_2.31.AppImage
+```
+
+---
+
+## glibc portability (why the Docker build exists)
+
+A binary requires the **highest `GLIBC_x.y` symbol** it was linked against, and
+an AppImage **never bundles glibc**. Built on Ubuntu 24.04 the binary needs
+`GLIBC_2.38` → fails on Debian 12 (2.36), Slackware 15 (2.33), MX 21 (2.31).
+Built on Debian 11 it needs only 2.31 → runs on ~everything since 2020.
+
+| Distro | glibc | local (2.39) | docker (2.31) |
+|---|---|---|---|
+| Ubuntu 24.04 | 2.39 | ✅ | ✅ |
+| Debian 13 / Fedora 40 | 2.41 / 2.39 | ✅ | ✅ |
+| Debian 12 | 2.36 | ❌ | ✅ |
+| Slackware 15 | 2.33 | ❌ | ✅ |
+| MX 21 / Debian 11 / Ubuntu 20.04 | 2.31 | ❌ | ✅ |
+| Ubuntu 18.04 / Debian 10 / RHEL 8 | ≤2.28 | ❌ | ❌ |
+
+Check any machine with `ldd --version`.
+
+---
+
+## Troubleshooting
+
+**Docker build "finishes in ~1 second" / exit code 141** — a diagnostic line
+`ldd --version | head -1` was aborting the script via SIGPIPE under
+`set -o pipefail` before cmake ran. Fixed (`_appimage-inside.sh` now folds the
+toolchain banner into a single `echo`). If a build ever exits fast again, check
+the very last command before it stopped.
+
+**Build didn't actually recompile** — check timestamps:
+`ls -la Build-cmake-bullseye/retroshare-gui/retroshare-gui`. If it's old, the
+compile was skipped/aborted. `CLEAN=1` forces a full rebuild.
+
+**"Text file busy" when launching** — the AppImage sits inside a folder a
+running RetroShare is *sharing*; RS holds the file open. Run it from a normal
+folder (see TESTERS.txt).
+
+**"libfuse.so.2" missing on the target** — `sudo apt install libfuse2`, or run
+with `APPIMAGE_EXTRACT_AND_RUN=1 ./RetroShare-*.AppImage`.
+
+**"GLIBC_2.xx not found" on the target** — the target's glibc is older than the
+build host's. Use the Docker (2.31) build, or an even older base if needed.
+
+---
+
+## For testers
+
+Ship `TESTERS.txt` alongside the `.AppImage`. It covers: glibc requirement, how
+to run, the FUSE fallback, `~/.retroshare` behavior (existing profile is reused;
+`HOME=/tmp/rs-test ./…` to isolate), and the shared-folder caveat.

--- a/build_scripts/AppImage/Dockerfile.bullseye
+++ b/build_scripts/AppImage/Dockerfile.bullseye
@@ -1,0 +1,47 @@
+# Debian 11 (bullseye) = glibc 2.31 — "build on old, run everywhere".
+# An AppImage produced here runs on any distro with glibc >= 2.31
+# (MX 21, Slackware 15, Debian 11/12, Ubuntu 20.04+, Fedora 34+, ...).
+#
+# This image only carries the TOOLCHAIN + deps + the AppImage tools.
+# The actual RetroShare source is bind-mounted at /src at run time and built
+# by build_scripts/AppImage/_appimage-inside.sh.
+FROM debian:11
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build toolchain + RetroShare deps (Qt5), mirrors BUILD-cmake.md's Qt5 list,
+# plus what linuxdeploy needs (file, patchelf, desktop-file-utils, wget).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential g++ ninja-build pkg-config git ca-certificates \
+      wget file patchelf desktop-file-utils python3 python3-pip \
+      qtbase5-dev qtbase5-dev-tools qt5-qmake qtmultimedia5-dev libqt5svg5-dev \
+      libqt5x11extras5-dev qttools5-dev qttools5-dev-tools \
+      libssl-dev zlib1g-dev libbz2-dev libbotan-2-dev libjson-c-dev \
+      libasio-dev libsqlcipher-dev \
+      libspeex-dev libspeexdsp-dev libminiupnpc-dev \
+      libavcodec-dev libavutil-dev \
+      libxml2-dev libxslt1-dev libcurl4-openssl-dev \
+      doxygen \
+  && rm -rf /var/lib/apt/lists/*
+
+# Modern CMake (bullseye ships 3.18, some subprojects want newer) — pin via pip
+# so it lands in /usr/local/bin ahead of the distro one.
+RUN pip3 install --no-cache-dir "cmake>=3.27"
+
+# Bake the AppImage bundling tools into the image (no re-download per run).
+RUN mkdir -p /opt/linuxdeploy && cd /opt/linuxdeploy && \
+    wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage && \
+    wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage && \
+    chmod +x /opt/linuxdeploy/*.AppImage
+
+# AppImage tools can't FUSE-mount inside a container — extract instead.
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ENV PATH=/opt/linuxdeploy:/usr/local/bin:$PATH
+
+# Extra deps discovered after the first image build. Kept in a SEPARATE layer on
+# purpose: the big apt layer above stays a cache hit, so adding a package here
+# only installs that package instead of reinstalling the whole toolchain.
+#   libxss-dev  -> xscrnsaver.pc (GUI idle detection, retroshare-gui CMakeLists:408)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libx11-dev libxss-dev libsqlite3-dev \
+  && rm -rf /var/lib/apt/lists/*

--- a/build_scripts/AppImage/TESTERS.txt
+++ b/build_scripts/AppImage/TESTERS.txt
@@ -1,0 +1,32 @@
+RetroShare AppImage — notes for testers
+========================================
+
+WHAT YOU NEED
+  - 64-bit x86 Linux (x86_64). Not ARM / Raspberry Pi.
+  - glibc >= 2.31  (the "portable" build). Check with:  ldd --version
+      2.31 covers everything from ~2020 on: Debian 11+, Ubuntu 20.04+,
+      MX 21+, Slackware 15, Fedora 34+, Mint 20+, openSUSE Leap 15.3+ ...
+  - A graphical session (X11, or Wayland with XWayland — the default).
+
+HOW TO RUN
+  chmod +x RetroShare-*.AppImage
+  ./RetroShare-*.AppImage
+
+IF IT WON'T START WITH A "libfuse.so.2" ERROR
+  Newer distros don't ship FUSE 2 by default. Either:
+      sudo apt install libfuse2            (Debian/Ubuntu/MX)
+  or run it without FUSE:
+      APPIMAGE_EXTRACT_AND_RUN=1 ./RetroShare-*.AppImage
+
+YOUR PROFILE (~/.retroshare)
+  - The AppImage bundles NO profile. It uses ~/.retroshare, exactly like a
+    normal RetroShare install. An existing profile is picked up automatically;
+    the AppImage and a system install share the same ~/.retroshare.
+  - To test in isolation, without touching your real profile:
+      HOME=/tmp/rs-test ./RetroShare-*.AppImage
+    (creates a fresh ~/.retroshare under /tmp/rs-test)
+
+DON'T RUN IT FROM INSIDE A RETROSHARE SHARED FOLDER
+  If a running RetroShare is sharing the folder the AppImage sits in, you'll
+  get "Text file busy" (RS holds the file open). Put the AppImage in a normal
+  folder (Downloads, home) and run it from there.

--- a/build_scripts/AppImage/_appimage-inside.sh
+++ b/build_scripts/AppImage/_appimage-inside.sh
@@ -3,9 +3,11 @@
 # Runs INSIDE the Debian 11 container (see Dockerfile.bullseye), invoked by
 # build-appimage-docker.sh. Bind-mounts: the repo at /src.
 #
-# Builds RetroShare (Qt5, GUI) fresh with CMake into a bullseye-specific build
-# dir (so it never clobbers the host's Build-cmake), assembles the AppDir and
-# emits a glibc-2.31 AppImage into /src/Build-appimage.
+# Builds RetroShare (Qt5, full feature set — same flags as the current-glibc
+# builds) fresh with CMake into a bullseye-specific build dir (so it never
+# clobbers the host's Build-cmake), assembles the AppDir and emits a glibc-2.31
+# AppImage into /src/Build-appimage. This is meant for old Linux installs, so it
+# is NOT stripped down: it follows the same rules as the other builds.
 #
 set -euo pipefail
 
@@ -25,17 +27,23 @@ export PATH=/opt/linuxdeploy:/usr/local/bin:$PATH
 # `set -e`, so the toolchain banner can't kill the build.
 echo ">>> toolchain: $(cmake --version | head -1) | gcc $(gcc -dumpversion) | glibc $(ldd --version 2>&1 | head -1)"
 
-# --- 1. configure + build (Qt5, GUI only) -------------------------------------
+# --- 1. configure + build (Qt5, same feature flags as the current-glibc builds)-
 # Incremental by default: reuse objects from a previous run (set CLEAN=1 to wipe).
 # RS_NO_LTO=ON: GCC 10's LTO plugin segfaults (lto1 ICE) linking libretroshare on
 # bullseye; LTO is only an optimization, so we turn it off for this build.
+# Feature flags mirror build-all-appimages.sh's current-glibc Qt5 build: Qt5 =>
+# plugins ON, service + friendserver ON (wanted in every build). FORUM_DEEP_INDEX
+# stays OFF here and is flipped to ON for combo by build-all-appimages.sh (via a
+# throwaway sed on this file) — so leave that exact flag token untouched below.
 [ -n "${CLEAN:-}" ] && rm -rf "$BUILD"
 cmake -G Ninja -B "$BUILD" -S "$SRC" \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON \
     -DRS_NO_LTO=ON \
-    -DRS_GUI=ON -DRS_SERVICE=OFF -DRS_FRIENDSERVER=OFF -DRS_PLUGINS=OFF \
-    -DRS_JSON_API=ON -DRS_WEBUI=ON -DRS_FORUM_DEEP_INDEX=OFF
+    -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=ON -DRS_SERVICE_TERMINAL_WEBUI_PASSWORD=ON \
+    -DRS_GUI=ON -DRS_SERVICE=ON -DRS_FRIENDSERVER=ON -DRS_PLUGINS=ON -DRS_FORUM_DEEP_INDEX=OFF \
+    -DRS_USE_I2P_SAM3=ON -DRS_BITDHT=ON -DRS_MINIUPNPC=ON \
+    -DRS_BRODCAST_DISCOVERY=ON -DRS_SQLCIPHER=ON
 cmake --build "$BUILD" -j"$(nproc)"
 
 BIN="$BUILD/retroshare-gui/retroshare-gui"

--- a/build_scripts/AppImage/_appimage-inside.sh
+++ b/build_scripts/AppImage/_appimage-inside.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Runs INSIDE the Debian 11 container (see Dockerfile.bullseye), invoked by
+# build-appimage-docker.sh. Bind-mounts: the repo at /src.
+#
+# Builds RetroShare (Qt5, GUI) fresh with CMake into a bullseye-specific build
+# dir (so it never clobbers the host's Build-cmake), assembles the AppDir and
+# emits a glibc-2.31 AppImage into /src/Build-appimage.
+#
+set -euo pipefail
+
+SRC=/src
+BUILD="$SRC/Build-cmake-bullseye"          # separate from host Build-cmake
+OUT="$SRC/Build-appimage"
+APPDIR="$OUT/AppDir-bullseye"
+
+export APPIMAGE_EXTRACT_AND_RUN=1          # no FUSE in containers
+export QMAKE=/usr/bin/qmake                # bullseye qmake = Qt5
+export PATH=/opt/linuxdeploy:/usr/local/bin:$PATH
+
+# Everything in ONE echo on purpose: a standalone `ldd --version | head -1`
+# under `set -o pipefail` returns 141 (SIGPIPE: head closes the pipe, ldd dies
+# writing to it) and `set -e` would abort the whole build right here, before
+# cmake even runs. Inside a command substitution the failure doesn't reach
+# `set -e`, so the toolchain banner can't kill the build.
+echo ">>> toolchain: $(cmake --version | head -1) | gcc $(gcc -dumpversion) | glibc $(ldd --version 2>&1 | head -1)"
+
+# --- 1. configure + build (Qt5, GUI only) -------------------------------------
+# Incremental by default: reuse objects from a previous run (set CLEAN=1 to wipe).
+# RS_NO_LTO=ON: GCC 10's LTO plugin segfaults (lto1 ICE) linking libretroshare on
+# bullseye; LTO is only an optimization, so we turn it off for this build.
+[ -n "${CLEAN:-}" ] && rm -rf "$BUILD"
+cmake -G Ninja -B "$BUILD" -S "$SRC" \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON \
+    -DRS_NO_LTO=ON \
+    -DRS_GUI=ON -DRS_SERVICE=OFF -DRS_FRIENDSERVER=OFF -DRS_PLUGINS=OFF \
+    -DRS_JSON_API=ON -DRS_WEBUI=ON -DRS_FORUM_DEEP_INDEX=OFF
+cmake --build "$BUILD" -j"$(nproc)"
+
+BIN="$BUILD/retroshare-gui/retroshare-gui"
+[ -x "$BIN" ] || { echo "ERROR: build produced no binary at $BIN" >&2; exit 1; }
+
+# --- 2. assemble a clean FHS AppDir -------------------------------------------
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" \
+         "$APPDIR/usr/share/applications" \
+         "$APPDIR/usr/share/icons/hicolor/scalable/apps"
+
+install -m 0755 "$BIN" "$APPDIR/usr/bin/retroshare-gui"
+
+for sz in 24x24 48x48 64x64 128x128; do
+    mkdir -p "$APPDIR/usr/share/icons/hicolor/$sz/apps"
+    cp "$SRC/data/$sz/apps/retroshare.png" \
+       "$APPDIR/usr/share/icons/hicolor/$sz/apps/retroshare.png"
+done
+cp "$SRC/data/retroshare.svg" "$APPDIR/usr/share/icons/hicolor/scalable/apps/retroshare.svg"
+
+DESKTOP="$APPDIR/usr/share/applications/retroshare.desktop"
+cp "$SRC/data/retroshare.desktop" "$DESKTOP"
+sed -i 's/^Icon=.*/Icon=retroshare/' "$DESKTOP"
+sed -i 's|^Exec=/usr/bin/retroshare|Exec=retroshare-gui|' "$DESKTOP"
+
+# --- 3. bundle Qt + libs, emit the AppImage -----------------------------------
+# VERSION is passed in from the host for the output filename.
+cd "$OUT"
+linuxdeploy-x86_64.AppImage --appdir "$APPDIR" \
+    --executable "$APPDIR/usr/bin/retroshare-gui" \
+    --desktop-file "$DESKTOP" \
+    --icon-file "$SRC/data/128x128/apps/retroshare.png" --icon-filename retroshare \
+    --plugin qt \
+    --output appimage
+
+echo
+echo ">>> AppImage(s) in Build-appimage:"
+ls -1 "$OUT"/*.AppImage 2>/dev/null || echo "    (none — check the log above)"

--- a/build_scripts/AppImage/_appimage-inside.sh
+++ b/build_scripts/AppImage/_appimage-inside.sh
@@ -69,13 +69,38 @@ cp "$SRC/data/retroshare.desktop" "$DESKTOP"
 sed -i 's/^Icon=.*/Icon=retroshare/' "$DESKTOP"
 sed -i 's|^Exec=/usr/bin/retroshare|Exec=retroshare-gui|' "$DESKTOP"
 
+# plugins (VOIP, FeedReader): RetroShare searches
+# <exedir>/../lib/retroshare/extensions6/, i.e. usr/lib/retroshare/extensions6
+# from usr/bin/retroshare-gui — the only search path that resolves inside an
+# AppImage (PLUGIN_DIR is absolute and would point at the host, and
+# ~/.retroshare/extensions6 is the user's, not ours). Their own dependencies are
+# deployed in step 3 below.
+PLUGINDIR="$APPDIR/usr/lib/retroshare/extensions6"
+shopt -s nullglob
+RS_PLUGINS=( "$BUILD"/plugins/*.so )
+shopt -u nullglob
+if [ ${#RS_PLUGINS[@]} -gt 0 ]; then
+    mkdir -p "$PLUGINDIR"
+    install -m 0644 "${RS_PLUGINS[@]}" "$PLUGINDIR/"
+    echo ">>> ${#RS_PLUGINS[@]} plugin(s) bundled: $(basename -a "${RS_PLUGINS[@]}" | tr '\n' ' ')"
+else
+    echo ">>> WARNING: no plugin in $BUILD/plugins — the AppImage will ship none."
+fi
+
 # --- 3. bundle Qt + libs, emit the AppImage -----------------------------------
 # VERSION is passed in from the host for the output filename.
+# --deploy-deps-only: the plugins must STAY in extensions6 (RetroShare looks them
+# up by path), but linuxdeploy still has to bundle what they link and patch their
+# rpath. --library would move them into usr/lib, where RS never looks.
+DEPS_ONLY=()
+[ -d "$PLUGINDIR" ] && DEPS_ONLY=( --deploy-deps-only "$PLUGINDIR" )
+
 cd "$OUT"
 linuxdeploy-x86_64.AppImage --appdir "$APPDIR" \
     --executable "$APPDIR/usr/bin/retroshare-gui" \
     --desktop-file "$DESKTOP" \
     --icon-file "$SRC/data/128x128/apps/retroshare.png" --icon-filename retroshare \
+    ${DEPS_ONLY[@]+"${DEPS_ONLY[@]}"} \
     --plugin qt \
     --output appimage
 

--- a/build_scripts/AppImage/build-appimage-docker.sh
+++ b/build_scripts/AppImage/build-appimage-docker.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Portable RetroShare AppImage — built inside a Debian 11 (glibc 2.31) container.
+#
+# Produces an AppImage that runs on any distro with glibc >= 2.31 (MX 21,
+# Slackware 15, Debian 11/12, Ubuntu 20.04+, Fedora 34+, ...), unlike
+# build-appimage-local.sh which bakes in the host's (too-new) glibc.
+#
+# Prerequisite: Docker (or Podman). Install on Ubuntu with:
+#     sudo apt install -y docker.io
+#
+# Usage:
+#     build_scripts/AppImage/build-appimage-docker.sh
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+IMAGE=retroshare-appimage-bullseye
+
+# --- pick a working container engine ------------------------------------------
+if command -v podman >/dev/null 2>&1; then
+    ENGINE="podman"
+elif docker info >/dev/null 2>&1; then
+    ENGINE="docker"
+elif sudo -n docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1; then
+    ENGINE="sudo docker"
+else
+    cat >&2 <<EOF
+ERROR: no usable container engine.
+
+Install Docker and retry:
+    sudo apt install -y docker.io
+    sudo usermod -aG docker \$USER      (then log out/in, or use: newgrp docker)
+
+Or install Podman (rootless, no daemon):
+    sudo apt install -y podman
+EOF
+    exit 1
+fi
+echo ">>> using container engine: $ENGINE"
+
+# --- 1. build the toolchain image (Debian 11 + deps + AppImage tools) ---------
+echo ">>> building image $IMAGE (Debian 11 / glibc 2.31) ..."
+$ENGINE build -t "$IMAGE" -f "$HERE/Dockerfile.bullseye" "$HERE"
+
+# --- 2. compile RS + package the AppImage inside the container ----------------
+VERSION="$(git -C "$ROOT" describe --tags --always 2>/dev/null || echo dev)"
+echo ">>> building + packaging RetroShare $VERSION ..."
+
+# --user + HOME=/tmp so build artifacts land owned by us, not root.
+$ENGINE run --rm \
+    -v "$ROOT":/src \
+    -e VERSION="$VERSION" \
+    -e HOME=/tmp \
+    -e CLEAN="${CLEAN:-}" \
+    --user "$(id -u):$(id -g)" \
+    "$IMAGE" bash /src/build_scripts/AppImage/_appimage-inside.sh
+
+echo
+echo ">>> done. Portable AppImage(s):"
+ls -1 "$ROOT/Build-appimage"/*.AppImage 2>/dev/null || echo "    (none — check the log above)"

--- a/build_scripts/AppImage/build-appimage-docker.sh
+++ b/build_scripts/AppImage/build-appimage-docker.sh
@@ -57,6 +57,33 @@ $ENGINE run --rm \
     --user "$(id -u):$(id -g)" \
     "$IMAGE" bash /src/build_scripts/AppImage/_appimage-inside.sh
 
+# --- 3. rename to the descriptive scheme (host side) --------------------------
+#   RetroShare-v<ver>-<YYYYMMDD>-<count>-g<hash>-Qt-<qtver>-glibc-<min>-x86_64.AppImage
+# The container leaves its AppDir (AppDir-bullseye) and the AppImage in
+# Build-appimage/, so we compute everything here: git describe (version + count +
+# hash), the build date, the exact Qt version read from the bundled libQt5Core
+# (the legacy build is Qt5-only; its qmake lives only inside the container), and
+# the highest GLIBC_2.x symbol across all bundled ELFs (the minimum glibc to run).
+OUT="$ROOT/Build-appimage"
+APPDIR="$OUT/AppDir-bullseye"
+produced="$(ls -1t "$OUT"/*.AppImage 2>/dev/null | head -1 || true)"
+if [ -n "$produced" ]; then
+    desc="$(git -C "$ROOT" describe --tags --always 2>/dev/null | sed 's/^v//' || echo dev)"
+    ver="${desc%%-*}"                                            # 0.6.7.3
+    suffix="${desc#*-}"; [ "$suffix" = "$desc" ] && suffix=""    # 1121-ga87999bd2 (empty on a tag)
+    date="$(date +%Y%m%d)"
+    qtver="$(strings "$APPDIR/usr/lib/libQt5Core.so.5" 2>/dev/null \
+             | grep -oE 'Qt 5\.[0-9]+\.[0-9]+' | grep -oE '5\.[0-9]+\.[0-9]+' | head -1 || true)"
+    [ -n "$qtver" ] || qtver="unknown"
+    glibc="$(find "$APPDIR" -type f \( -name '*.so*' -o -path '*/bin/*' -o -path '*/plugins/*' \) 2>/dev/null \
+             | while read -r f; do objdump -T "$f" 2>/dev/null | grep -oE 'GLIBC_2\.[0-9]+(\.[0-9]+)?'; done \
+             | sort -uV | tail -1 | sed 's/^GLIBC_//')"
+    [ -n "$glibc" ] || glibc="unknown"
+    name="RetroShare-v${ver}-${date}${suffix:+-${suffix}}-Qt-${qtver}-glibc-${glibc}-x86_64.AppImage"
+    mv -f "$produced" "$OUT/$name"
+    echo ">>> renamed -> $name"
+fi
+
 echo
 echo ">>> done. Portable AppImage(s):"
 ls -1 "$ROOT/Build-appimage"/*.AppImage 2>/dev/null || echo "    (none — check the log above)"

--- a/build_scripts/AppImage/build-appimage-local.sh
+++ b/build_scripts/AppImage/build-appimage-local.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Local AppImage packager for the RetroShare GUI — CMake build, no qmake.
+#
+# It does NOT build anything: it packages the binary already produced by the
+# CMake build documented in BUILD-cmake.md (Build-cmake/retroshare-gui/retroshare-gui).
+# Build first with CMake, then run this to wrap the result into an .AppImage.
+#
+# Bundling tool: linuxdeploy + linuxdeploy-plugin-qt (actively maintained).
+# (probonopd/linuxdeployqt "continuous" build 107 fails silently right after the
+#  icon stage on this toolchain, so we do not use it.)
+#
+set -euo pipefail
+
+# --- paths --------------------------------------------------------------------
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"          # repo root (RetroShare.clean)
+BUILDDIR="$ROOT/Build-cmake"               # CMake build dir (see BUILD-cmake.md)
+BIN="$BUILDDIR/retroshare-gui/retroshare-gui"
+OUTDIR="$ROOT/Build-appimage"
+APPDIR="$OUTDIR/AppDir"
+TOOLS="$HERE/tools"
+LD="$TOOLS/linuxdeploy-x86_64.AppImage"
+LD_QT="$TOOLS/linuxdeploy-plugin-qt-x86_64.AppImage"
+
+# Type-2 AppImages need libfuse2, which Ubuntu 24.04 doesn't ship by default.
+# Extracting instead of FUSE-mounting sidesteps that dependency.
+export APPIMAGE_EXTRACT_AND_RUN=1
+
+# linuxdeploy-plugin-qt locates Qt through qmake. It must be the qmake of the
+# SAME Qt major the binary links (Qt5 here — see the Qt5 build in BUILD-cmake.md).
+export QMAKE="${QMAKE:-$(command -v qmake-qt5 || command -v qmake || true)}"
+
+# --- 0. require the CMake build -----------------------------------------------
+if [ ! -x "$BIN" ]; then
+    cat >&2 <<EOF
+ERROR: CMake build not found at:
+    $BIN
+
+Build it first (Qt5, GUI) from the repo root — see BUILD-cmake.md:
+
+    rm -rf Build-cmake
+    cmake -G Ninja -B Build-cmake -S . \\
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \\
+      -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON \\
+      -DRS_GUI=ON -DRS_SERVICE=OFF -DRS_FRIENDSERVER=OFF -DRS_PLUGINS=OFF \\
+      -DRS_JSON_API=ON -DRS_WEBUI=ON -DRS_FORUM_DEEP_INDEX=OFF
+    cmake --build Build-cmake -j\$(nproc)
+
+then re-run this script.
+EOF
+    exit 1
+fi
+
+# --- 1. fetch linuxdeploy + qt plugin -----------------------------------------
+mkdir -p "$TOOLS"
+[ -x "$LD" ] || { echo ">>> downloading linuxdeploy ..."; \
+    wget -q --show-progress -O "$LD" \
+      https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage; \
+    chmod +x "$LD"; }
+[ -x "$LD_QT" ] || { echo ">>> downloading linuxdeploy-plugin-qt ..."; \
+    wget -q --show-progress -O "$LD_QT" \
+      https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage; \
+    chmod +x "$LD_QT"; }
+
+# --- 2. assemble a clean FHS AppDir from the CMake build ----------------------
+# (The project's own install() rules are not FHS-clean for AppImage — desktop
+#  lands in prefix/data/ and RS_SERVICE_DESKTOP is OFF by default — so we lay
+#  the tree out by hand instead of relying on `cmake --install`.)
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" \
+         "$APPDIR/usr/share/applications" \
+         "$APPDIR/usr/share/icons/hicolor/scalable/apps"
+
+install -m 0755 "$BIN" "$APPDIR/usr/bin/retroshare-gui"
+
+# icons: hicolor png set + scalable svg
+for sz in 24x24 48x48 64x64 128x128; do
+    mkdir -p "$APPDIR/usr/share/icons/hicolor/$sz/apps"
+    cp "$ROOT/data/$sz/apps/retroshare.png" \
+       "$APPDIR/usr/share/icons/hicolor/$sz/apps/retroshare.png"
+done
+cp "$ROOT/data/retroshare.svg" "$APPDIR/usr/share/icons/hicolor/scalable/apps/retroshare.svg"
+
+# .desktop: take the shipped one, fix Icon (bare name) and Exec (CMake binary name)
+DESKTOP="$APPDIR/usr/share/applications/retroshare.desktop"
+cp "$ROOT/data/retroshare.desktop" "$DESKTOP"
+sed -i 's/^Icon=.*/Icon=retroshare/' "$DESKTOP"
+sed -i 's|^Exec=/usr/bin/retroshare|Exec=retroshare-gui|' "$DESKTOP"
+
+# --- 3. bundle Qt + libs and emit the .AppImage -------------------------------
+export VERSION="$(git -C "$ROOT" describe --tags --always 2>/dev/null || echo dev)"
+
+cd "$OUTDIR"
+"$LD" --appdir "$APPDIR" \
+    --executable "$APPDIR/usr/bin/retroshare-gui" \
+    --desktop-file "$DESKTOP" \
+    --icon-file "$ROOT/data/128x128/apps/retroshare.png" --icon-filename retroshare \
+    --plugin qt \
+    --output appimage
+
+echo
+echo ">>> done. AppImage(s):"
+ls -1 "$OUTDIR"/*.AppImage 2>/dev/null || echo "    (none produced — check the log above)"

--- a/build_scripts/AppImage/build-appimage-local.sh
+++ b/build_scripts/AppImage/build-appimage-local.sh
@@ -130,6 +130,8 @@ sed -i 's/^Icon=.*/Icon=retroshare/' "$DESKTOP"
 sed -i 's|^Exec=/usr/bin/retroshare|Exec=retroshare-gui|' "$DESKTOP"
 
 # --- 3. bundle Qt + libs and emit the .AppImage -------------------------------
+# linuxdeploy names the output from $VERSION; we rename it afterwards (step 4)
+# because the glibc floor can only be read once every library is bundled.
 export VERSION="$(git -C "$ROOT" describe --tags --always 2>/dev/null || echo dev)"
 
 cd "$OUTDIR"
@@ -139,6 +141,28 @@ cd "$OUTDIR"
     --icon-file "$ROOT/data/128x128/apps/retroshare.png" --icon-filename retroshare \
     --plugin qt \
     --output appimage
+
+# --- 4. rename to the descriptive scheme --------------------------------------
+#   RetroShare-v<ver>-<YYYYMMDD>-<count>-g<hash>-Qt-<qtver>-glibc-<min>-x86_64.AppImage
+# Every field is self-computed here (no orchestrator needed): git describe gives
+# the version + commit count + hash, `date` the build day, qmake the exact Qt
+# version, and the highest GLIBC_2.x symbol required by any bundled ELF gives the
+# minimum glibc to run (an AppImage bundles no libc, so the host must provide it).
+produced="$(ls -1t "$OUTDIR"/*.AppImage 2>/dev/null | head -1 || true)"
+if [ -n "$produced" ]; then
+    desc="$(git -C "$ROOT" describe --tags --always 2>/dev/null | sed 's/^v//' || echo dev)"
+    ver="${desc%%-*}"                                            # 0.6.7.3
+    suffix="${desc#*-}"; [ "$suffix" = "$desc" ] && suffix=""    # 1057-g28175f481 (empty on a tag)
+    date="$(date +%Y%m%d)"
+    qtver="$("$QMAKE" -query QT_VERSION 2>/dev/null || echo "${BIN_QT_MAJOR:-0}.0.0")"
+    glibc="$(find "$APPDIR" -type f \( -name '*.so*' -o -path '*/bin/*' -o -path '*/plugins/*' \) 2>/dev/null \
+             | while read -r f; do objdump -T "$f" 2>/dev/null | grep -oE 'GLIBC_2\.[0-9]+(\.[0-9]+)?'; done \
+             | sort -uV | tail -1 | sed 's/^GLIBC_//')"
+    [ -n "$glibc" ] || glibc="unknown"
+    name="RetroShare-v${ver}-${date}${suffix:+-${suffix}}-Qt-${qtver}-glibc-${glibc}-x86_64.AppImage"
+    mv -f "$produced" "$OUTDIR/$name"
+    echo ">>> renamed -> $name"
+fi
 
 echo
 echo ">>> done. AppImage(s):"

--- a/build_scripts/AppImage/build-appimage-local.sh
+++ b/build_scripts/AppImage/build-appimage-local.sh
@@ -27,9 +27,8 @@ LD_QT="$TOOLS/linuxdeploy-plugin-qt-x86_64.AppImage"
 # Extracting instead of FUSE-mounting sidesteps that dependency.
 export APPIMAGE_EXTRACT_AND_RUN=1
 
-# linuxdeploy-plugin-qt locates Qt through qmake. It must be the qmake of the
-# SAME Qt major the binary links (Qt5 here — see the Qt5 build in BUILD-cmake.md).
-export QMAKE="${QMAKE:-$(command -v qmake-qt5 || command -v qmake || true)}"
+# QMAKE for linuxdeploy-plugin-qt is chosen AFTER the build check below, once we
+# can read the binary's Qt major from it (see the "pick the qmake" section).
 
 # --- 0. require the CMake build -----------------------------------------------
 if [ ! -x "$BIN" ]; then
@@ -51,6 +50,48 @@ then re-run this script.
 EOF
     exit 1
 fi
+
+# --- 0b. pick the qmake matching the binary's Qt major ------------------------
+# linuxdeploy-plugin-qt locates Qt through qmake, and it MUST be the qmake of the
+# SAME Qt major the binary links. Feed it a Qt5 qmake for a Qt6 binary (or vice
+# versa) and it bundles the wrong Qt — the AppImage then dies at launch with
+# "could not load the Qt platform plugin xcb".
+#
+# So we read the major straight from the binary's DT_NEEDED (objdump; no need for
+# the libs to be resolvable, unlike ldd) and pick qmake accordingly. Override the
+# whole thing anytime by exporting QMAKE before running this script.
+BIN_QT_MAJOR="$( { objdump -p "$BIN" 2>/dev/null || readelf -d "$BIN" 2>/dev/null; } \
+                 | grep -oE 'libQt[56]Core' | grep -oE '[56]' | head -1 || true)"
+
+if [ -z "${QMAKE:-}" ]; then
+    case "$BIN_QT_MAJOR" in
+        6) QMAKE="$(command -v qmake6 || command -v qmake-qt6 || true)" ;;
+        5) QMAKE="$(command -v qmake-qt5 || command -v qmake5 || command -v qmake || true)" ;;
+        *) QMAKE="$(command -v qmake-qt5 || command -v qmake || true)" ;;   # unknown: legacy default
+    esac
+fi
+export QMAKE
+
+if [ -z "${QMAKE:-}" ]; then
+    echo "ERROR: no qmake found for Qt${BIN_QT_MAJOR:-?}. Install it or set QMAKE=/path/to/qmake." >&2
+    exit 1
+fi
+
+# Fail early on the qmake/binary Qt-major mismatch that silently yields a
+# non-starting AppImage (also catches a wrong hand-set QMAKE).
+QMAKE_QT_MAJOR="$("$QMAKE" -query QT_VERSION 2>/dev/null | cut -d. -f1 || true)"
+if [ -n "$BIN_QT_MAJOR" ] && [ -n "$QMAKE_QT_MAJOR" ] && [ "$BIN_QT_MAJOR" != "$QMAKE_QT_MAJOR" ]; then
+    cat >&2 <<EOF
+ERROR: Qt major mismatch — linuxdeploy would bundle the wrong Qt and the
+       AppImage would not start.
+    binary links Qt$BIN_QT_MAJOR   ($BIN)
+    QMAKE is      Qt$QMAKE_QT_MAJOR   ($QMAKE)
+Point QMAKE at the matching qmake, e.g.:
+    QMAKE=\$(command -v qmake$BIN_QT_MAJOR) $0
+EOF
+    exit 1
+fi
+echo ">>> Qt major: ${BIN_QT_MAJOR:-unknown} | QMAKE: $QMAKE (Qt${QMAKE_QT_MAJOR:-?})"
 
 # --- 1. fetch linuxdeploy + qt plugin -----------------------------------------
 mkdir -p "$TOOLS"

--- a/build_scripts/AppImage/build-appimage-local.sh
+++ b/build_scripts/AppImage/build-appimage-local.sh
@@ -42,7 +42,7 @@ Build it first (Qt5, GUI) from the repo root — see BUILD-cmake.md:
     cmake -G Ninja -B Build-cmake -S . \\
       -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \\
       -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON \\
-      -DRS_GUI=ON -DRS_SERVICE=OFF -DRS_FRIENDSERVER=OFF -DRS_PLUGINS=OFF \\
+      -DRS_GUI=ON -DRS_SERVICE=ON -DRS_FRIENDSERVER=ON -DRS_PLUGINS=ON \\
       -DRS_JSON_API=ON -DRS_WEBUI=ON -DRS_FORUM_DEEP_INDEX=OFF
     cmake --build Build-cmake -j\$(nproc)
 
@@ -129,16 +129,43 @@ cp "$ROOT/data/retroshare.desktop" "$DESKTOP"
 sed -i 's/^Icon=.*/Icon=retroshare/' "$DESKTOP"
 sed -i 's|^Exec=/usr/bin/retroshare|Exec=retroshare-gui|' "$DESKTOP"
 
+# plugins (VOIP, FeedReader): built into Build-cmake/plugins when RS_PLUGINS=ON.
+# RetroShare searches <exedir>/../lib/retroshare/extensions6/ for them, which from
+# usr/bin/retroshare-gui is exactly usr/lib/retroshare/extensions6 — the only
+# search path that resolves inside an AppImage (PLUGIN_DIR is absolute and would
+# point at the host, and ~/.retroshare/extensions6 is the user's, not ours).
+# Their own dependencies (ffmpeg & co) are deployed in step 3 below.
+PLUGINDIR="$APPDIR/usr/lib/retroshare/extensions6"
+shopt -s nullglob
+RS_PLUGINS=( "$BUILDDIR"/plugins/*.so )
+shopt -u nullglob
+if [ ${#RS_PLUGINS[@]} -gt 0 ]; then
+    mkdir -p "$PLUGINDIR"
+    install -m 0644 "${RS_PLUGINS[@]}" "$PLUGINDIR/"
+    echo ">>> ${#RS_PLUGINS[@]} plugin(s) bundled: $(basename -a "${RS_PLUGINS[@]}" | tr '\n' ' ')"
+else
+    echo ">>> WARNING: no plugin in $BUILDDIR/plugins — the AppImage will ship none."
+    echo "    Configure the build with -DRS_PLUGINS=ON to get VOIP and FeedReader."
+fi
+
 # --- 3. bundle Qt + libs and emit the .AppImage -------------------------------
 # linuxdeploy names the output from $VERSION; we rename it afterwards (step 4)
 # because the glibc floor can only be read once every library is bundled.
 export VERSION="$(git -C "$ROOT" describe --tags --always 2>/dev/null || echo dev)"
+
+# --deploy-deps-only: the plugins are already in the AppDir and must STAY where
+# they are (RetroShare looks them up by path), but linuxdeploy still has to pull
+# in what they link — ffmpeg, opencv, ... — and patch their rpath. Passing them
+# with --library instead would move them into usr/lib, where RS never looks.
+DEPS_ONLY=()
+[ -d "$PLUGINDIR" ] && DEPS_ONLY=( --deploy-deps-only "$PLUGINDIR" )
 
 cd "$OUTDIR"
 "$LD" --appdir "$APPDIR" \
     --executable "$APPDIR/usr/bin/retroshare-gui" \
     --desktop-file "$DESKTOP" \
     --icon-file "$ROOT/data/128x128/apps/retroshare.png" --icon-filename retroshare \
+    ${DEPS_ONLY[@]+"${DEPS_ONLY[@]}"} \
     --plugin qt \
     --output appimage
 


### PR DESCRIPTION
## What

Adds a maintained way to produce a RetroShare **GUI AppImage** from the CMake
build, using `linuxdeploy` + `linuxdeploy-plugin-qt`. Two entry points:

| Script | Compiles? | Result runs on |
|---|---|---|
| `build-appimage-local.sh` | no — packages the local `Build-cmake` binary | distros with glibc ≥ the build host |
| `build-appimage-docker.sh` | yes — inside a Debian 11 container | **any distro with glibc ≥ 2.31** (MX 21, Slackware 15, Debian 11+, Ubuntu 20.04+, Fedora 34+…) |

Both lay out a clean FHS `AppDir` by hand (the project's own `install()` rules
put the `.desktop` under `prefix/data/` with `RS_SERVICE_DESKTOP` off, which is
not AppImage-friendly) and bundle Qt + non-system libs.

## Files

- `build-appimage-local.sh` — package the local build (host glibc).
- `build-appimage-docker.sh` — host driver: build the toolchain image, run the container build.
- `Dockerfile.bullseye` — Debian 11 (glibc 2.31) toolchain + Qt5 deps + AppImage tools.
- `_appimage-inside.sh` — runs inside the container: cmake → AppDir → linuxdeploy.
- `BUILD.md` — full guide (glibc table, versioning gotcha, troubleshooting).
- `TESTERS.txt` — ships alongside the `.AppImage` for end users.

## Notes

- Uses **`linuxdeploy`**, not `probonopd/linuxdeployqt`: the latter's
  "continuous" build 107 fails silently right after the icon stage on this
  toolchain. `APPIMAGE_EXTRACT_AND_RUN=1` is set (Ubuntu 24.04 / containers lack
  libfuse2).
- **The glibc 2.31 (Docker) build requires the `RS_NO_LTO` opt-out**
  (libretroshare **PR #316**): Debian 11's GCC 10 ICEs (`lto1`) when linking
  libretroshare with LTO on. Documented in `BUILD.md`. The `local` build is
  unaffected.
- The pre-existing probonopd Qt4/trusty `Recipe` + `*.yml` + `makeAppImage*.sh`
  are left untouched (obsolete; flagged as such in `BUILD.md`), to keep this
  change purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
