### PR TITLE
Fix "Accept friend request" button persisting after SSL-only friend added

### DIFF
--- a/retroshare-gui/src/gui/feeds/SecurityItem.cpp
+++ b/retroshare-gui/src/gui/feeds/SecurityItem.cpp
@@ -300,7 +300,12 @@ void SecurityItem::updateItem()
 			chatButton->hide();
 		}
 
-		if (details.accept_connection)
+		// accept_connection is a PGP-keyring flag, only set when we own the peer's
+		// PGP key. An SSL-only friend (accepted unknown peer / short invite) has no
+		// PGP key, so it is flagged by skip_pgp_signature_validation instead. Treat
+		// both as accepted, otherwise the "Accept friend request" button keeps being
+		// shown after an SSL-only friend has already been added.
+		if (details.accept_connection || details.skip_pgp_signature_validation)
 		{
 			friendRequesttoolButton->hide();
 			requestLabel->hide();


### PR DESCRIPTION
Fix "Accept friend request" button persisting after SSL-only friend added

In the Activity feed, accepting an unknown peer (no PGP key in keyring) adds it as an SSL-only friend via addSslOnlyFriend(), which sets skip_pgp_signature_validation instead of the PGP-keyring accept_connection flag. SecurityItem::updateItem() only tested details.accept_connection to decide button visibility, so for an accepted SSL-only friend the condition stayed false and the "Accept friend request" button kept being shown (and "Remove friend" stayed hidden), even though the peer was already a friend.

Treat skip_pgp_signature_validation == true as accepted too, since that flag is only set for a peer already present in the friend list.