### PR TITLE
Fix dead supportlibs/jni.hpp submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 	url = https://github.com/i2p/libsam3.git
 [submodule "supportlibs/jni.hpp"]
 	path = supportlibs/jni.hpp
-	url = https://github.com/RetroShare/jni.hpp.git
+	url = https://github.com/RetroShare/jni-hpp.git
 [submodule "openpgpsdk"]
 	path = openpgpsdk
 	url = https://github.com/RetroShare/OpenPGP-SDK.git


### PR DESCRIPTION
## Summary
`supportlibs/jni.hpp` is pinned to commit `b1f3de8ec650b1d232b284da5b231d7355d73a53`, but that commit no longer exists in `RetroShare/jni.hpp` (the dotted-name repo) — it only exists in `RetroShare/jni-hpp` (hyphenated), which appears to be a rename/recreation of the original repo. This makes the submodule link 404 and causes strict fetchers (e.g. Gentoo Portage's `git-r3`) to fail with `remote error: upload-pack: not our ref ...`.

The CMake build already migrated to `RetroShare/jni-hpp` via `FetchContent` (`libretroshare/CMakeLists.txt`), so the qmake-era submodule reference was simply never updated to match.

This repoints `.gitmodules` at the same pinned commit under the correct (hyphenated) URL — verified locally that the submodule now clones and checks out cleanly.

Fixes #3259

## Test plan
- [x] `git submodule sync -- supportlibs/jni.hpp && git submodule update --init supportlibs/jni.hpp` clones successfully and checks out `b1f3de8ec650b1d232b284da5b231d7355d73a53`
- [x] Confirmed via `git ls-remote` that `RetroShare/jni-hpp.git` (not `jni.hpp.git`) contains this commit as its `master`/`HEAD`