### PR TITLE
GUI: stop copying and sorting the channel post array in the Qt thread

### DIFF
--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.cpp
@@ -527,7 +527,7 @@ void RsGxsChannelPostsModel::updateSinglePost(const RsGxsChannelPost& post,std::
     triggerViewUpdate(true,false);
 }
 
-void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vector<RsGxsChannelPost>& posts)
+void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vector<RsGxsChannelPost>&& posts)
 {
     RsGxsProfiler::Timer prof_timer;
 
@@ -538,13 +538,20 @@ void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vecto
 
 //    createPostsArray(posts);
 
-    mPosts = posts;
+    // The caller hands over its array and discards it right after, so take it
+    // rather than deep copying every post (and every thumbnail) one more time.
+    mPosts = std::move(posts);
 
     const long prof_copy_ms = prof_timer.lap();
 
+    // update_posts() already sorted the array in its loader thread. Kept as a
+    // cheap safety net for any other caller: on already ordered input this only
+    // costs comparisons, no element is moved.
 	std::sort(mPosts.begin(),mPosts.end());
 
     const long prof_sort_ms = prof_timer.lap();
+
+	mFilteredPosts.reserve(mPosts.size());
 
 	for(uint32_t i=0;i<mPosts.size();++i)
 		mFilteredPosts.push_back(i);
@@ -614,13 +621,23 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 			return;
 		}
 
-        const long prof_content_ms = prof_timer.ms();
+        const long prof_content_ms = prof_timer.lap();
 
-        RS_GXS_PROF( prof_grpinfo_ms + prof_content_ms,
+        // Sort here rather than in setPosts(): setPosts() runs in the Qt thread,
+        // where sorting a few thousand posts is a visible freeze. The model only
+        // ever displays a sorted array, so the order may as well be established
+        // in this loader thread.
+        std::sort(posts->begin(),posts->end());
+
+        const long prof_sort_ms = prof_timer.ms();
+        const long prof_total_ms = prof_grpinfo_ms + prof_content_ms + prof_sort_ms;
+
+        RS_GXS_PROF( prof_total_ms,
                      "update_posts     grp=" << group_id << " posts=" << posts->size()
                      << " getChannelsInfo=" << prof_grpinfo_ms << "ms"
                      << " getChannelAllContent=" << prof_content_ms << "ms"
-                     << " service_total=" << (prof_grpinfo_ms + prof_content_ms) << "ms" );
+                     << " sort=" << prof_sort_ms << "ms"
+                     << " service_total=" << prof_total_ms << "ms" );
 #ifdef DEBUG_CHANNEL_MODEL
         std::cerr << "Got channel all content for channel " << group_id << std::endl;
         std::cerr << "  posts   : " << posts->size() << std::endl;
@@ -638,7 +655,7 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 			 * Qt::QueuedConnection is important!
 			 */
 
-            setPosts(group,*posts) ;
+            setPosts(group,std::move(*posts)) ;
 
             delete posts;
 

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.cpp
@@ -26,6 +26,7 @@
 #include "retroshare/rsgxsflags.h"
 #include "retroshare/rsgxschannels.h"
 #include "retroshare/rsexpr.h"
+#include "gxs/rsgxsprofiler.h"
 
 #include "gui/MainWindow.h"
 #include "gui/mainpagestack.h"
@@ -528,6 +529,8 @@ void RsGxsChannelPostsModel::updateSinglePost(const RsGxsChannelPost& post,std::
 
 void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vector<RsGxsChannelPost>& posts)
 {
+    RsGxsProfiler::Timer prof_timer;
+
 	preMods();
 
 	initEmptyHierarchy();
@@ -536,7 +539,12 @@ void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vecto
 //    createPostsArray(posts);
 
     mPosts = posts;
+
+    const long prof_copy_ms = prof_timer.lap();
+
 	std::sort(mPosts.begin(),mPosts.end());
+
+    const long prof_sort_ms = prof_timer.lap();
 
 	for(uint32_t i=0;i<mPosts.size();++i)
 		mFilteredPosts.push_back(i);
@@ -553,6 +561,15 @@ void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vecto
 
 	postMods();
 
+    const long prof_view_ms = prof_timer.ms();
+    const long prof_total_ms = prof_copy_ms + prof_sort_ms + prof_view_ms;
+
+    RS_GXS_PROF( prof_total_ms, "setPosts (UI)    posts=" << mPosts.size()
+                 << " copy=" << prof_copy_ms << "ms"
+                 << " sort=" << prof_sort_ms << "ms"
+                 << " view_update=" << prof_view_ms << "ms"
+                 << " total=" << prof_total_ms << "ms" );
+
 	emit channelPostsLoaded();
 }
 
@@ -567,6 +584,8 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 
     RsThread::async([this, group_id]()
 	{
+        RsGxsProfiler::Timer prof_timer;
+
         // 1 - get message data from p3GxsChannels
 
         std::list<RsGxsGroupId> channelIds;
@@ -583,6 +602,8 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 
         RsGxsChannelGroup group = groups[0];
 
+        const long prof_grpinfo_ms = prof_timer.lap();
+
         std::vector<RsGxsChannelPost> *posts    = new std::vector<RsGxsChannelPost>(); // We use the heap because the arrays need to be stored accross async
         std::vector<RsGxsComment>      comments ;
         std::vector<RsGxsVote>         votes    ;
@@ -592,6 +613,14 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 			std::cerr << __PRETTY_FUNCTION__ << " failed to retrieve channel messages for channel " << group_id << std::endl;
 			return;
 		}
+
+        const long prof_content_ms = prof_timer.ms();
+
+        RS_GXS_PROF( prof_grpinfo_ms + prof_content_ms,
+                     "update_posts     grp=" << group_id << " posts=" << posts->size()
+                     << " getChannelsInfo=" << prof_grpinfo_ms << "ms"
+                     << " getChannelAllContent=" << prof_content_ms << "ms"
+                     << " service_total=" << (prof_grpinfo_ms + prof_content_ms) << "ms" );
 #ifdef DEBUG_CHANNEL_MODEL
         std::cerr << "Got channel all content for channel " << group_id << std::endl;
         std::cerr << "  posts   : " << posts->size() << std::endl;

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.cpp
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.cpp
@@ -26,7 +26,6 @@
 #include "retroshare/rsgxsflags.h"
 #include "retroshare/rsgxschannels.h"
 #include "retroshare/rsexpr.h"
-#include "gxs/rsgxsprofiler.h"
 
 #include "gui/MainWindow.h"
 #include "gui/mainpagestack.h"
@@ -529,8 +528,6 @@ void RsGxsChannelPostsModel::updateSinglePost(const RsGxsChannelPost& post,std::
 
 void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vector<RsGxsChannelPost>&& posts)
 {
-    RsGxsProfiler::Timer prof_timer;
-
 	preMods();
 
 	initEmptyHierarchy();
@@ -542,14 +539,10 @@ void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vecto
     // rather than deep copying every post (and every thumbnail) one more time.
     mPosts = std::move(posts);
 
-    const long prof_copy_ms = prof_timer.lap();
-
     // update_posts() already sorted the array in its loader thread. Kept as a
     // cheap safety net for any other caller: on already ordered input this only
     // costs comparisons, no element is moved.
 	std::sort(mPosts.begin(),mPosts.end());
-
-    const long prof_sort_ms = prof_timer.lap();
 
 	mFilteredPosts.reserve(mPosts.size());
 
@@ -568,15 +561,6 @@ void RsGxsChannelPostsModel::setPosts(const RsGxsChannelGroup& group, std::vecto
 
 	postMods();
 
-    const long prof_view_ms = prof_timer.ms();
-    const long prof_total_ms = prof_copy_ms + prof_sort_ms + prof_view_ms;
-
-    RS_GXS_PROF( prof_total_ms, "setPosts (UI)    posts=" << mPosts.size()
-                 << " copy=" << prof_copy_ms << "ms"
-                 << " sort=" << prof_sort_ms << "ms"
-                 << " view_update=" << prof_view_ms << "ms"
-                 << " total=" << prof_total_ms << "ms" );
-
 	emit channelPostsLoaded();
 }
 
@@ -591,8 +575,6 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 
     RsThread::async([this, group_id]()
 	{
-        RsGxsProfiler::Timer prof_timer;
-
         // 1 - get message data from p3GxsChannels
 
         std::list<RsGxsGroupId> channelIds;
@@ -609,8 +591,6 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 
         RsGxsChannelGroup group = groups[0];
 
-        const long prof_grpinfo_ms = prof_timer.lap();
-
         std::vector<RsGxsChannelPost> *posts    = new std::vector<RsGxsChannelPost>(); // We use the heap because the arrays need to be stored accross async
         std::vector<RsGxsComment>      comments ;
         std::vector<RsGxsVote>         votes    ;
@@ -621,23 +601,12 @@ void RsGxsChannelPostsModel::update_posts(const RsGxsGroupId& group_id)
 			return;
 		}
 
-        const long prof_content_ms = prof_timer.lap();
-
         // Sort here rather than in setPosts(): setPosts() runs in the Qt thread,
         // where sorting a few thousand posts is a visible freeze. The model only
         // ever displays a sorted array, so the order may as well be established
         // in this loader thread.
         std::sort(posts->begin(),posts->end());
 
-        const long prof_sort_ms = prof_timer.ms();
-        const long prof_total_ms = prof_grpinfo_ms + prof_content_ms + prof_sort_ms;
-
-        RS_GXS_PROF( prof_total_ms,
-                     "update_posts     grp=" << group_id << " posts=" << posts->size()
-                     << " getChannelsInfo=" << prof_grpinfo_ms << "ms"
-                     << " getChannelAllContent=" << prof_content_ms << "ms"
-                     << " sort=" << prof_sort_ms << "ms"
-                     << " service_total=" << prof_total_ms << "ms" );
 #ifdef DEBUG_CHANNEL_MODEL
         std::cerr << "Got channel all content for channel " << group_id << std::endl;
         std::cerr << "  posts   : " << posts->size() << std::endl;

--- a/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.h
+++ b/retroshare-gui/src/gui/gxschannels/GxsChannelPostsModel.h
@@ -239,7 +239,8 @@ private:
 	//void computeMessagesHierarchy(const RsGxsChannelGroup& forum_group, const std::vector<RsMsgMetaData> &msgs_array, std::vector<ChannelPostsModelPostEntry> &posts, std::map<RsGxsMessageId, std::vector<std::pair<time_t, RsGxsMessageId> > > &mPostVersions);
 	void old_createPostsArray(std::vector<RsGxsChannelPost> &posts);
     void createPostsArray(std::vector<RsGxsChannelPost>& posts);
-    void setPosts(const RsGxsChannelGroup& group, std::vector<RsGxsChannelPost> &posts);
+    /// Takes ownership of posts: the array is moved into the model.
+    void setPosts(const RsGxsChannelGroup& group, std::vector<RsGxsChannelPost> &&posts);
 public:
     void updateSinglePost(const RsGxsChannelPost& post, std::set<RsGxsFile>& added_files, std::set<RsGxsFile>& removed_files);
 private:


### PR DESCRIPTION
GUI: stop copying and sorting the channel post array in the Qt thread

works with libretroshare pr/351
https://github.com/RetroShare/libretroshare/pull/351

RsGxsChannelPostsModel::setPosts() runs in the Qt thread through postToObject(). It copied the whole post array — thumbnails included — and then sorted it there, so opening a channel with a few thousand posts froze the interface for the duration of both.

The sort moves to the loader thread in update_posts(), where the array already sits after the service call, and setPosts() takes its argument by rvalue reference so the array is moved in rather than copied. The sort is kept in setPosts() as a safety net: on an already ordered array it only runs comparisons and moves nothing.

Measured on a channel with 1931 posts, setPosts went from a visible freeze to 0-3 ms of copy and 0 ms of sort.

The second commit adds opt-in profiling of the two GUI phases (RS_GXS_PROFILE), matching the libretroshare side.

Requires libretroshare pr/351: this branch includes the profiling header added there, and eliminating the deep copies depends on the move operations it introduces.