### PR TITLE
gui(gxs): fix the group statistics storm that delayed unread counters at startup

### DIFF
--- a/retroshare-gui/src/gui/NewsFeed.cpp
+++ b/retroshare-gui/src/gui/NewsFeed.cpp
@@ -21,6 +21,7 @@
 #include <QDateTime>
 
 #include "NewsFeed.h"
+#include "gui/gxs/GxsPerfProbe.h"
 #include "ui_NewsFeed.h"
 
 #include <retroshare/rsbanlist.h>
@@ -274,6 +275,11 @@ void NewsFeed::handleForumEvent(std::shared_ptr<const RsEvent> event)
 {
 	const RsGxsForumEvent *pe = dynamic_cast<const RsGxsForumEvent*>(event.get());
 	if(!pe) return;
+
+	// Runs on the GUI thread and builds one full widget per incoming message,
+	// so a sync burst turns into a burst of widget construction here.
+	RsGuiPerf::Probe prof("newsFeed::handleForumEvent");
+	prof.detail(QString("code=%1").arg(static_cast<int>(pe->mForumEventCode)));
 
 	switch(pe->mForumEventCode)
 	{

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
@@ -38,6 +38,7 @@
 #include "retroshare/rsgxsifacetypes.h"
 #include "GxsCommentDialog.h"
 #include "util/DateTime.h"
+#include "gui/gxs/GxsPerfProbe.h"
 
 //#define DEBUG_GROUPFRAMEDIALOG
 
@@ -982,6 +983,9 @@ void GxsGroupFrameDialog::insertGroupsData(const std::list<RsGxsGenericGroupData
 		return;
 	}
 
+	RsGuiPerf::Probe prof("insertGroupsData");
+	prof.detail(QString("groups=%1").arg(groupList.size()));
+
 	mInFill = true;
 
 	QList<GroupItemInfo> adminList;
@@ -1110,6 +1114,8 @@ void GxsGroupFrameDialog::updateMessageSummaryListReal(RsGxsGroupId groupId)
 		return;
 	}
 
+	RsGuiPerf::Probe prof("updateMessageSummaryListReal");
+
 	if (groupId.isNull())
 	{
 		QTreeWidgetItem *items[2] = { mYourGroups, mSubscribedGroups };
@@ -1157,6 +1163,8 @@ void GxsGroupFrameDialog::updateGroupSummary()
 
 		RsQThreadUtils::postToObject( [this,groupInfo]()
 		{
+			RsGuiPerf::Probe prof("groupSummary(UI apply)");
+
 			/* Here it goes any code you want to be executed on the Qt Gui
 			 * thread, for example to update the data model with new information
 			 * after a blocking call to RetroShare API complete, note that
@@ -1325,13 +1333,24 @@ void GxsGroupFrameDialog::startOneStatisticsJob(const RsGxsGroupId &groupId)
     RsThread::async([this,groupId]()
     {
         GxsGroupStatistic stats;
-        const bool ok = getGroupStatistics(groupId, stats);
+        bool ok = false;
+
+        {
+            // Runs off the GUI thread, but holds the GXS engine for its whole
+            // duration, so it delays everything the interface waits for.
+            RsGuiPerf::Probe prof("getGroupStatistics");
+            prof.detail(QString::fromStdString(groupId.toStdString()));
+
+            ok = getGroupStatistics(groupId, stats);
+        }
 
         if(!ok)
             std::cerr << __PRETTY_FUNCTION__ << " failed to collect group statistics for group " << groupId << std::endl;
 
         RsQThreadUtils::postToObject( [this,stats,groupId,ok]()
         {
+            RsGuiPerf::Probe prof("groupStatistics(UI apply)");
+
             /* Here it goes any code you want to be executed on the Qt Gui
              * thread, for example to update the data model with new information
              * after a blocking call to RetroShare API complete, note that

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
@@ -1037,11 +1037,59 @@ void GxsGroupFrameDialog::insertGroupsData(const std::list<RsGxsGenericGroupData
 
 	mInFill = false;
 
+	restoreCachedGroupCounts();
+
 	/* Re-fill group */
 	if (!ui->groupTreeWidget->activateId(QString::fromStdString(mGroupId.toStdString()), true))
 		mGroupId.clear();
 
 	updateMessageSummaryList(RsGxsGroupId());
+}
+
+void GxsGroupFrameDialog::restoreCachedGroupCounts()
+{
+	// Two different things write the post count column: fillGroupItems() above
+	// puts there the number of posts the *network* advertises for the group
+	// (mVisibleMsgCount), and setCounts() puts there the number of posts we
+	// actually hold locally. Last writer wins, so a tree refill silently
+	// replaces the local figure by the neighbours' one -- 800 instead of 8259
+	// observed on a forum whose neighbours keep a much shorter history.
+	//
+	// It used to be papered over: every network statistics event ran a full
+	// local recomputation, which wrote the local figure back a moment later.
+	// That recomputation was ruinous and is gone, so re-apply what is already
+	// known instead. This costs nothing, the numbers come from the cache.
+
+	if(mCachedGroupStats.empty())
+		return;
+
+	QTreeWidgetItem *categories[2] = { mYourGroups, mSubscribedGroups };
+
+	for(int c = 0; c < 2; ++c)
+	{
+		if(!categories[c])
+			continue;
+
+		const int childCount = categories[c]->childCount();
+
+		for(int child = 0; child < childCount; ++child)
+		{
+			QTreeWidgetItem *item = categories[c]->child(child);
+			const QString childId = ui->groupTreeWidget->itemId(item);
+
+			if(childId.isEmpty())
+				continue;
+
+			auto it = mCachedGroupStats.find(RsGxsGroupId(childId.toStdString()));
+
+			if(it == mCachedGroupStats.end())
+				continue;
+
+			const GxsGroupStatistic& stats(it->second);
+
+			ui->groupTreeWidget->setCounts(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread, stats.mNumMsgs);
+		}
+	}
 }
 
 void GxsGroupFrameDialog::updateMessageSummaryList(RsGxsGroupId groupId)

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
@@ -81,6 +81,7 @@ GxsGroupFrameDialog::GxsGroupFrameDialog(RsGxsIfaceHelper *ifaceImpl,const QStri
 	mShouldUpdateMessageSummaryList = true;
 	mShouldUpdateGroupStatistics = false;
     mLastGroupStatisticsUpdateTs=0;
+    mStatisticsJobsInFlight = 0;
 	mInitialized = false;
 	mDistSyncAllowed = allow_dist_sync;
 	mInFill = false;
@@ -1252,17 +1253,36 @@ void GxsGroupFrameDialog::updateGroupStatistics(const RsGxsGroupId &groupId)
 
 void GxsGroupFrameDialog::updateGroupStatisticsReal(const RsGxsGroupId &groupId)
 {
+    // Queue rather than start: see startStatisticsJobs() for why the number of
+    // concurrent requests has to stay bounded.
+    mStatisticsQueue.insert(groupId);
+
+    startStatisticsJobs();
+}
+
+void GxsGroupFrameDialog::startStatisticsJobs()
+{
+    while(mStatisticsJobsInFlight < MAX_CONCURRENT_STATISTICS_JOBS && !mStatisticsQueue.empty())
+    {
+        const RsGxsGroupId groupId = *mStatisticsQueue.begin();
+        mStatisticsQueue.erase(mStatisticsQueue.begin());
+
+        ++mStatisticsJobsInFlight;
+        startOneStatisticsJob(groupId);
+    }
+}
+
+void GxsGroupFrameDialog::startOneStatisticsJob(const RsGxsGroupId &groupId)
+{
     RsThread::async([this,groupId]()
     {
         GxsGroupStatistic stats;
+        const bool ok = getGroupStatistics(groupId, stats);
 
-        if(! getGroupStatistics(groupId, stats))
-        {
+        if(!ok)
             std::cerr << __PRETTY_FUNCTION__ << " failed to collect group statistics for group " << groupId << std::endl;
-            return;
-        }
 
-        RsQThreadUtils::postToObject( [this,stats, groupId]()
+        RsQThreadUtils::postToObject( [this,stats,groupId,ok]()
         {
             /* Here it goes any code you want to be executed on the Qt Gui
              * thread, for example to update the data model with new information
@@ -1270,15 +1290,22 @@ void GxsGroupFrameDialog::updateGroupStatisticsReal(const RsGxsGroupId &groupId)
              * Qt::QueuedConnection is important!
              */
 
-            QTreeWidgetItem *item = ui->groupTreeWidget->getItemFromId(QString::fromStdString(stats.mGrpId.toStdString()));
+            if(ok)
+            {
+                QTreeWidgetItem *item = ui->groupTreeWidget->getItemFromId(QString::fromStdString(stats.mGrpId.toStdString()));
 
-            if (item)
-                // ui->groupTreeWidget->setUnreadCount(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread);
-				ui->groupTreeWidget->setCounts(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread, stats.mNumMsgs);
+                if (item)
+                    // ui->groupTreeWidget->setUnreadCount(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread);
+                    ui->groupTreeWidget->setCounts(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread, stats.mNumMsgs);
 
-            mCachedGroupStats[groupId] = stats;
+                mCachedGroupStats[groupId] = stats;
 
-            getUserNotify()->updateIcon();
+                getUserNotify()->updateIcon();
+            }
+
+            // Free the slot and refill the window.
+            --mStatisticsJobsInFlight;
+            startStatisticsJobs();
 
         }, this );
     });

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.cpp
@@ -82,7 +82,6 @@ GxsGroupFrameDialog::GxsGroupFrameDialog(RsGxsIfaceHelper *ifaceImpl,const QStri
 	mShouldUpdateMessageSummaryList = true;
 	mShouldUpdateGroupStatistics = false;
     mLastGroupStatisticsUpdateTs=0;
-    mStatisticsJobsInFlight = 0;
 	mInitialized = false;
 	mDistSyncAllowed = allow_dist_sync;
 	mInFill = false;
@@ -1309,27 +1308,6 @@ void GxsGroupFrameDialog::updateGroupStatistics(const RsGxsGroupId &groupId)
 
 void GxsGroupFrameDialog::updateGroupStatisticsReal(const RsGxsGroupId &groupId)
 {
-    // Queue rather than start: see startStatisticsJobs() for why the number of
-    // concurrent requests has to stay bounded.
-    mStatisticsQueue.insert(groupId);
-
-    startStatisticsJobs();
-}
-
-void GxsGroupFrameDialog::startStatisticsJobs()
-{
-    while(mStatisticsJobsInFlight < MAX_CONCURRENT_STATISTICS_JOBS && !mStatisticsQueue.empty())
-    {
-        const RsGxsGroupId groupId = *mStatisticsQueue.begin();
-        mStatisticsQueue.erase(mStatisticsQueue.begin());
-
-        ++mStatisticsJobsInFlight;
-        startOneStatisticsJob(groupId);
-    }
-}
-
-void GxsGroupFrameDialog::startOneStatisticsJob(const RsGxsGroupId &groupId)
-{
     RsThread::async([this,groupId]()
     {
         GxsGroupStatistic stats;
@@ -1345,9 +1323,12 @@ void GxsGroupFrameDialog::startOneStatisticsJob(const RsGxsGroupId &groupId)
         }
 
         if(!ok)
+        {
             std::cerr << __PRETTY_FUNCTION__ << " failed to collect group statistics for group " << groupId << std::endl;
+            return;
+        }
 
-        RsQThreadUtils::postToObject( [this,stats,groupId,ok]()
+        RsQThreadUtils::postToObject( [this,stats,groupId]()
         {
             RsGuiPerf::Probe prof("groupStatistics(UI apply)");
 
@@ -1357,22 +1338,15 @@ void GxsGroupFrameDialog::startOneStatisticsJob(const RsGxsGroupId &groupId)
              * Qt::QueuedConnection is important!
              */
 
-            if(ok)
-            {
-                QTreeWidgetItem *item = ui->groupTreeWidget->getItemFromId(QString::fromStdString(stats.mGrpId.toStdString()));
+            QTreeWidgetItem *item = ui->groupTreeWidget->getItemFromId(QString::fromStdString(stats.mGrpId.toStdString()));
 
-                if (item)
-                    // ui->groupTreeWidget->setUnreadCount(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread);
-                    ui->groupTreeWidget->setCounts(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread, stats.mNumMsgs);
+            if (item)
+                // ui->groupTreeWidget->setUnreadCount(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread);
+                ui->groupTreeWidget->setCounts(item, mCountChildMsgs ? (stats.mNumThreadMsgsUnread + stats.mNumChildMsgsUnread) : stats.mNumThreadMsgsUnread, stats.mNumMsgs);
 
-                mCachedGroupStats[groupId] = stats;
+            mCachedGroupStats[groupId] = stats;
 
-                getUserNotify()->updateIcon();
-            }
-
-            // Free the slot and refill the window.
-            --mStatisticsJobsInFlight;
-            startStatisticsJobs();
+            getUserNotify()->updateIcon();
 
         }, this );
     });

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
@@ -195,37 +195,9 @@ protected:
     virtual void updateGroupStatisticsReal(const RsGxsGroupId &groupId);
 
 private:
-    /*!
-     * rief Runs the queued group statistics with a bounded number in flight.
-     *
-     * Computing the statistics of one group is a blocking GXS request served by
-     * a single engine thread that sleeps 100 ms between passes, so most of a
-     * job's duration is waiting, not work: median 100 ms per group, which is
-     * exactly the tick quantum. Two extremes are both wrong.
-     *
-     * One detached thread per group: 839 jobs completing in the same second,
-     * and because each gives up after 5 s (waitToken cap) the ones at the back
-     * time out, are cancelled, and their counter never appears -- 104 of them
-     * measured.
-     *
-     * Strictly one at a time: no failures, but the 100 ms of latency is paid
-     * once per group in sequence -- 630 groups took 172 s before every counter
-     * showed up, and one slow group (a cold-cache forum taking 28 s) blocked
-     * all the others behind it.
-     *
-     * A small window keeps several requests waiting on the same tick pass, so
-     * they are served together, while staying far from the failure threshold.
-     */
-    void startStatisticsJobs();
-    void startOneStatisticsJob(const RsGxsGroupId &groupId);
-
     /*! Re-apply the known local post/unread counts after a group tree refill. */
     void restoreCachedGroupCounts();
 
-    static const int MAX_CONCURRENT_STATISTICS_JOBS = 8;
-
-    std::set<RsGxsGroupId> mStatisticsQueue;
-    int mStatisticsJobsInFlight;
 
 protected:
 

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
@@ -219,6 +219,9 @@ private:
     void startStatisticsJobs();
     void startOneStatisticsJob(const RsGxsGroupId &groupId);
 
+    /*! Re-apply the known local post/unread counts after a group tree refill. */
+    void restoreCachedGroupCounts();
+
     static const int MAX_CONCURRENT_STATISTICS_JOBS = 8;
 
     std::set<RsGxsGroupId> mStatisticsQueue;

--- a/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
+++ b/retroshare-gui/src/gui/gxs/GxsGroupFrameDialog.h
@@ -194,6 +194,38 @@ protected:
     virtual void updateGroupStatistics(const RsGxsGroupId &groupId);
     virtual void updateGroupStatisticsReal(const RsGxsGroupId &groupId);
 
+private:
+    /*!
+     * rief Runs the queued group statistics with a bounded number in flight.
+     *
+     * Computing the statistics of one group is a blocking GXS request served by
+     * a single engine thread that sleeps 100 ms between passes, so most of a
+     * job's duration is waiting, not work: median 100 ms per group, which is
+     * exactly the tick quantum. Two extremes are both wrong.
+     *
+     * One detached thread per group: 839 jobs completing in the same second,
+     * and because each gives up after 5 s (waitToken cap) the ones at the back
+     * time out, are cancelled, and their counter never appears -- 104 of them
+     * measured.
+     *
+     * Strictly one at a time: no failures, but the 100 ms of latency is paid
+     * once per group in sequence -- 630 groups took 172 s before every counter
+     * showed up, and one slow group (a cold-cache forum taking 28 s) blocked
+     * all the others behind it.
+     *
+     * A small window keeps several requests waiting on the same tick pass, so
+     * they are served together, while staying far from the failure threshold.
+     */
+    void startStatisticsJobs();
+    void startOneStatisticsJob(const RsGxsGroupId &groupId);
+
+    static const int MAX_CONCURRENT_STATISTICS_JOBS = 8;
+
+    std::set<RsGxsGroupId> mStatisticsQueue;
+    int mStatisticsJobsInFlight;
+
+protected:
+
     // This needs to be overloaded by subclasses, possibly calling the blocking API, since it is used asynchronously.
     virtual bool getGroupStatistics(const RsGxsGroupId& groupId, GxsGroupStatistic& stat) = 0;
 

--- a/retroshare-gui/src/gui/gxs/GxsPerfProbe.h
+++ b/retroshare-gui/src/gui/gxs/GxsPerfProbe.h
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * retroshare-gui/src/gui/gxs/GxsPerfProbe.h                                   *
+ *                                                                             *
+ * Copyright 2026 by Retroshare Team     <retroshare.project@gmail.com>        *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Affero General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Affero General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Affero General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+#pragma once
+
+// Opt-in latency probes, off unless RS_GUI_PROFILE is set in the environment.
+// Its value is a reporting threshold in milliseconds, 0 reports everything:
+//
+//     RS_GUI_PROFILE=0 ./retroshare
+//
+// Output goes through RsDbg(), i.e. stderr: launch from a terminal or the lines
+// go nowhere.
+
+#include <QString>
+#include <QTimer>
+#include <QCoreApplication>
+
+#include <chrono>
+#include <cstdlib>
+
+#include "util/rsdebug.h"
+
+namespace RsGuiPerf {
+
+inline double threshold()
+{
+	// <0 means disabled. Read once, the environment does not change at runtime.
+	static const double t = []() -> double {
+		const char *v = getenv("RS_GUI_PROFILE");
+		if(!v)
+			v = getenv("RS_FORUM_PROFILE"); // legacy name of the first investigation
+		return v ? atof(v) : -1.0;
+	}();
+
+	return t;
+}
+
+inline bool enabled() { return threshold() >= 0; }
+
+/* Breadcrumb of the last operation a probe measured on the current thread. The
+ * stall watchdog prints it, so a stall can be attributed even when the probe
+ * that covered it stayed below the reporting threshold. */
+inline const char *& lastOp()   { static thread_local const char *s = "none"; return s; }
+inline double&       lastOpMs() { static thread_local double d = 0;           return d; }
+
+/*!
+ * \brief RAII timer around one operation.
+ *
+ * Report a probe placed on the GUI thread as time the interface stayed frozen.
+ */
+class Probe
+{
+public:
+	explicit Probe(const char *what)
+	    : mWhat(what), mStart(std::chrono::steady_clock::now()) {}
+
+	~Probe()
+	{
+		if(!enabled())
+			return;
+
+		const double ms = std::chrono::duration<double,std::milli>(
+		            std::chrono::steady_clock::now() - mStart ).count();
+
+		lastOp()   = mWhat;
+		lastOpMs() = ms;
+
+		if(ms >= threshold())
+			RsDbg() << "GUI-PROF " << mWhat << " " << mDetails.toStdString()
+			        << " in " << ms << "ms";
+	}
+
+	void detail(const QString& s) { mDetails = s; }
+
+private:
+	const char *mWhat;
+	QString mDetails;
+	std::chrono::steady_clock::time_point mStart;
+};
+
+/*!
+ * \brief Watchdog for the GUI thread itself.
+ *
+ * The probes above only measure the code they wrap, so they cannot see a stall
+ * that happens anywhere else. This timer runs on the GUI thread and reports
+ * whenever the event loop failed to come back on time, whatever the reason and
+ * wherever the blocking code lives. It also names the last operation a probe
+ * measured, which points at the culprit when one covers it.
+ *
+ * Safe to call several times, only the first call installs anything.
+ */
+inline void installGuiStallWatchdog()
+{
+	static bool installed = false;
+
+	if(installed || !enabled())
+		return;
+
+	installed = true;
+
+	static const int TICK_MS = 50;
+
+	QTimer *timer = new QTimer(QCoreApplication::instance());
+	auto *last = new std::chrono::steady_clock::time_point(
+	            std::chrono::steady_clock::now() );
+
+	QObject::connect(timer, &QTimer::timeout, QCoreApplication::instance(), [last]()
+	{
+		const auto now = std::chrono::steady_clock::now();
+		const double ms = std::chrono::duration<double,std::milli>(now - *last).count();
+		*last = now;
+
+		// Anything above the tick plus a comfortable margin means the event loop
+		// was busy or blocked for that long.
+		if(ms > TICK_MS + 150)
+			RsDbg() << "GUI-PROF GUI-THREAD-STALL " << (ms - TICK_MS)
+			        << "ms  last_probe=" << lastOp() << " (" << lastOpMs() << "ms)";
+	});
+
+	timer->start(TICK_MS);
+}
+
+} // namespace RsGuiPerf

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
@@ -19,6 +19,7 @@
  *******************************************************************************/
 
 #include "GxsForumsDialog.h"
+#include "gui/gxs/GxsPerfProbe.h"
 #include "GxsForumGroupDialog.h"
 #include "GxsForumThreadWidget.h"
 #include "CreateGxsForumMsg.h"
@@ -66,6 +67,8 @@ void GxsForumsDialog::flushPendingStatistics()
 
 void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
 {
+    RsGuiPerf::Probe prof("forumsDialog::handleEvent");
+
     if(event->mType == RsEventType::GXS_FORUMS)
     {
         const RsGxsForumEvent *e = dynamic_cast<const RsGxsForumEvent*>(event.get());

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
@@ -51,18 +51,6 @@ GxsForumsDialog::GxsForumsDialog(QWidget *parent) :
     mUpdateTimer = new QTimer(this);
     mUpdateTimer->setSingleShot(true);
     connect(mUpdateTimer, SIGNAL(timeout()), this, SLOT(timerUpdate()));
-
-    mStatisticsDebounceTimer = new QTimer(this);
-    mStatisticsDebounceTimer->setSingleShot(true);
-    connect(mStatisticsDebounceTimer, SIGNAL(timeout()), this, SLOT(flushPendingStatistics()));
-}
-
-void GxsForumsDialog::flushPendingStatistics()
-{
-    for(const RsGxsGroupId& groupId: mStatisticsPending)
-        updateGroupStatisticsReal(groupId);
-
-    mStatisticsPending.clear();
 }
 
 void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
@@ -81,14 +69,7 @@ void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> eve
 		case RsForumEventCode::NEW_MESSAGE:
 		case RsForumEventCode::UPDATED_MESSAGE:        // [[fallthrough]];
 		case RsForumEventCode::READ_STATUS_CHANGED:
-			// Debounced rather than immediate: one recomputation costs a full
-			// rebuild of the forum's post hierarchy, and marking posts read or
-			// unread produces one event each. 700 ms still reads as instant.
-			// The timer is not restarted by later events, so a long burst (a
-			// sync delivering messages) cannot postpone the update forever.
-			mStatisticsPending.insert(e->mForumGroupId);
-			if(!mStatisticsDebounceTimer->isActive())
-				mStatisticsDebounceTimer->start(700);
+			updateGroupStatisticsReal(e->mForumGroupId); // update the list immediately
             break;
 
         case RsForumEventCode::NEW_FORUM:           // [[fallthrough]];

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
@@ -50,6 +50,18 @@ GxsForumsDialog::GxsForumsDialog(QWidget *parent) :
     mUpdateTimer = new QTimer(this);
     mUpdateTimer->setSingleShot(true);
     connect(mUpdateTimer, SIGNAL(timeout()), this, SLOT(timerUpdate()));
+
+    mStatisticsDebounceTimer = new QTimer(this);
+    mStatisticsDebounceTimer->setSingleShot(true);
+    connect(mStatisticsDebounceTimer, SIGNAL(timeout()), this, SLOT(flushPendingStatistics()));
+}
+
+void GxsForumsDialog::flushPendingStatistics()
+{
+    for(const RsGxsGroupId& groupId: mStatisticsPending)
+        updateGroupStatisticsReal(groupId);
+
+    mStatisticsPending.clear();
 }
 
 void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
@@ -66,7 +78,14 @@ void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> eve
 		case RsForumEventCode::NEW_MESSAGE:
 		case RsForumEventCode::UPDATED_MESSAGE:        // [[fallthrough]];
 		case RsForumEventCode::READ_STATUS_CHANGED:
-			updateGroupStatisticsReal(e->mForumGroupId); // update the list immediately
+			// Debounced rather than immediate: one recomputation costs a full
+			// rebuild of the forum's post hierarchy, and marking posts read or
+			// unread produces one event each. 700 ms still reads as instant.
+			// The timer is not restarted by later events, so a long burst (a
+			// sync delivering messages) cannot postpone the update forever.
+			mStatisticsPending.insert(e->mForumGroupId);
+			if(!mStatisticsDebounceTimer->isActive())
+				mStatisticsDebounceTimer->start(700);
             break;
 
         case RsForumEventCode::NEW_FORUM:           // [[fallthrough]];

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.cpp
@@ -77,8 +77,19 @@ void GxsForumsDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> eve
             break;
 
         case RsForumEventCode::STATISTICS_CHANGED:
+            // This event means a *peer* reported new statistics for a forum (how
+            // many messages it holds, how many suppliers). It says nothing about
+            // our own database, so the local message and unread counts cannot
+            // have changed and there is nothing to recompute here. The group
+            // summary refresh below already picks up the network side.
+            //
+            // Recomputing them anyway was ruinous: during a sync the node gets
+            // one such event per known forum, and each one rebuilt that forum's
+            // whole post hierarchy in its own detached thread. Measured on a node
+            // knowing ~1300 forums: 839 statistics jobs finishing in the same
+            // second and 104 requests dying on the 5 s waitToken cap, which is
+            // why the unread counters took forever to show up at startup.
             if(!mUpdateTimer->isActive()) mUpdateTimer->start(1000);
-            updateGroupStatisticsReal(e->mForumGroupId);
             break;
 
         default:

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.h
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.h
@@ -23,8 +23,6 @@
 
 #include "gui/gxs/GxsGroupFrameDialog.h"
 
-#include <set>
-
 #define IMAGE_GXSFORUMS         ":/icons/png/forums.png"
 
 class GxsForumsDialog : public GxsGroupFrameDialog
@@ -70,16 +68,8 @@ private:
 
     QTimer *mUpdateTimer;
 
-    // Read/unread events are debounced: recomputing a forum's statistics means
-    // rebuilding its whole post hierarchy (see p3GxsForums::getForumStatistics),
-    // so doing it on every single post marked read makes navigation crawl on a
-    // large forum. Bursts collapse into one recomputation per forum.
-    QTimer *mStatisticsDebounceTimer;
-    std::set<RsGxsGroupId> mStatisticsPending;
-
 private slots:
     void timerUpdate() { updateDisplay(true); }
-    void flushPendingStatistics();
 };
 
 #endif

--- a/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.h
+++ b/retroshare-gui/src/gui/gxsforums/GxsForumsDialog.h
@@ -23,6 +23,8 @@
 
 #include "gui/gxs/GxsGroupFrameDialog.h"
 
+#include <set>
+
 #define IMAGE_GXSFORUMS         ":/icons/png/forums.png"
 
 class GxsForumsDialog : public GxsGroupFrameDialog
@@ -68,8 +70,16 @@ private:
 
     QTimer *mUpdateTimer;
 
+    // Read/unread events are debounced: recomputing a forum's statistics means
+    // rebuilding its whole post hierarchy (see p3GxsForums::getForumStatistics),
+    // so doing it on every single post marked read makes navigation crawl on a
+    // large forum. Bursts collapse into one recomputation per forum.
+    QTimer *mStatisticsDebounceTimer;
+    std::set<RsGxsGroupId> mStatisticsPending;
+
 private slots:
     void timerUpdate() { updateDisplay(true); }
+    void flushPendingStatistics();
 };
 
 #endif


### PR DESCRIPTION
GUI only, no libretroshare change needed.

## Problem

On a node knowing many forums (~1300 here), the unread counters of the group list took a long time to settle at startup, and every sync burst made the interface sluggish.

## Cause, measured with the opt-in probes included

Every network `STATISTICS_CHANGED` event — one per known forum during a sync — triggered a full recomputation of that forum's *local* statistics: a complete rebuild of its post hierarchy, with a reputation lookup per post, in its own detached thread. Measured: 839 such jobs completing within the same second, and 104 dying on the 5 s `waitToken` cap, so their counters never appeared.

The event only reports what a peer advertises for the group. It says nothing about our own database, so there is nothing local to recompute.

## Fix

- `STATISTICS_CHANGED` no longer recomputes local statistics. The existing 1 s group summary refresh already propagates the network-side figures.
- The post-count column no longer gets silently overwritten by the network-advertised count after a group tree refill (a forum holding 8259 posts showed 800): the two writers of that column disagreed, and the cached local counts are now re-applied after the refill.

Last commit adds the opt-in latency probes (`RS_GUI_PROFILE`, inert when unset) used to measure the above; it shares an identical instrumentation header with #3274, so both merge cleanly in either order. Happy to drop that commit if you would rather not carry it.

## Note on what this PR deliberately does *not* do

An earlier revision throttled the statistics requests (a bounded concurrency window, and a debounce on read-status events). Both were reverted after measuring on a real profile: they made the counters *slower*. The bottleneck is not concurrency but a single query — reading a forum's statistics visits every message row of the group, which on a large forum with a cold cache holds the single-threaded GXS engine for tens of seconds (26 s on a 9573-message forum). Throttling the submission side only delays the cheap requests behind a request that blocks the engine anyway. Making that query cheap is a separate matter, not addressed here.
