### PR TITLE
FeedReader: add "Mark all as unread" alongside "Mark all as read"

### DIFF
--- a/plugins/FeedReader/gui/FeedReaderMessageWidget.cpp
+++ b/plugins/FeedReader/gui/FeedReaderMessageWidget.cpp
@@ -364,6 +364,9 @@ void FeedReaderMessageWidget::msgTreeCustomPopupMenu(QPoint /*point*/)
 	action = contextMnu.addAction(QIcon(""), tr("Mark all as read"), this, SLOT(markAllAsReadMsg()));
 	action->setEnabled(mFeedId);
 
+	action = contextMnu.addAction(QIcon(""), tr("Mark all as unread"), this, SLOT(markAllAsUnreadMsg()));
+	action->setEnabled(mFeedId);
+
 	contextMnu.addSeparator();
 
 	action = contextMnu.addAction(QIcon(""), tr("Copy link"), this, SLOT(copySelectedLinksMsg()));
@@ -821,6 +824,16 @@ void FeedReaderMessageWidget::markAsUnreadMsg()
 
 void FeedReaderMessageWidget::markAllAsReadMsg()
 {
+	setAllMsgAsReadUnread(true);
+}
+
+void FeedReaderMessageWidget::markAllAsUnreadMsg()
+{
+	setAllMsgAsReadUnread(false);
+}
+
+void FeedReaderMessageWidget::setAllMsgAsReadUnread(bool read)
+{
 	QList<QTreeWidgetItem*> items;
 
 	QTreeWidgetItemIterator it(ui->msgTreeWidget);
@@ -831,7 +844,7 @@ void FeedReaderMessageWidget::markAllAsReadMsg()
 		}
 		++it;
 	}
-	setMsgAsReadUnread(items, true);
+	setMsgAsReadUnread(items, read);
 }
 
 void FeedReaderMessageWidget::copySelectedLinksMsg()

--- a/plugins/FeedReader/gui/FeedReaderMessageWidget.h
+++ b/plugins/FeedReader/gui/FeedReaderMessageWidget.h
@@ -68,6 +68,7 @@ private slots:
 	void markAsReadMsg();
 	void markAsUnreadMsg();
 	void markAllAsReadMsg();
+	void markAllAsUnreadMsg();
 	void copySelectedLinksMsg();
 	void removeMsg();
 	void processFeed();
@@ -91,6 +92,7 @@ private:
 	void calculateMsgIconsAndFonts(QTreeWidgetItem *item);
 	void updateMsgItem(QTreeWidgetItem *item, FeedMsgInfo &info);
 	void setMsgAsReadUnread(QList<QTreeWidgetItem*> &rows, bool read);
+	void setAllMsgAsReadUnread(bool read);
 	void filterItem(QTreeWidgetItem *item, const QString &text, int filterColumn);
 	void filterItem(QTreeWidgetItem *item);
 	void toggleMsgText_internal();


### PR DESCRIPTION
Adds a **Mark all as unread** action to the FeedReader message list context menu, alongside the existing **Mark all as read**.

Symmetric to the existing action and using the same code path; useful to revisit a feed after having cleared it.
