### PR TITLE
GUI: relaunch focuses existing instance, add -n/--new-instance

### DIFF
--- a/retroshare-gui/src/gui/MainWindow.cpp
+++ b/retroshare-gui/src/gui/MainWindow.cpp
@@ -1296,6 +1296,14 @@ void MainWindow::receiveNewArgs(QStringList args)
 {
     RsInfo() << "Received new arguments from operating system call.";
 
+    if (args.isEmpty())
+    {
+        /* No arguments were passed: another instance just asked us to show the main window. */
+        RsInfo() << "No arguments received, showing the main window.";
+        raiseWindow();
+        return;
+    }
+
     std::string argstring = RsApplication::applicationFilePath().toStdString() ;
 
     for(auto l:args)

--- a/retroshare-gui/src/main.cpp
+++ b/retroshare-gui/src/main.cpp
@@ -363,6 +363,7 @@ feenableexcept(FE_INVALID | FE_DIVBYZERO);
     as      >> option(   's',"stderr"             ,conf.outStderr                ,"output to stderr instead of log file "                                                      )
             >> option(   'u',"udp"                ,conf.udpListenerOnly          ,"Only listen to UDP "                                                                        )
             >> option(   'R',"reset"              ,conf.optResetParams           ,"reset retroshare parameters "                                                               )
+            >> option(   'n',"new-instance"       ,conf.newInstance              ,"start a new instance even if one is already running"                                          )
             >> parameter('c',"base-dir"           ,conf.optBaseDir               ,"directory"                             ,"Set base directory "                                  ,false)
             >> parameter('l',"log-file"           ,logfilename                   ,"logfile"                               ,"Set Log filename "                                    ,false)
             >> parameter('d',"debug-level"        ,loglevel                      ,"level (debug,info,notice,warn,error,off)","Set debug level "                                   ,false)
@@ -406,12 +407,16 @@ feenableexcept(FE_INVALID | FE_DIVBYZERO);
         showHelp(as);
         return 0;
     }
-    // Look for parameters to be transmitted to running server
+    // Look for parameters to be transmitted to running server.
+    // If a retroshare instance is already running, hand over the arguments to it
+    // (or simply ask it to show its main window when there are none) instead of
+    // starting a second instance, unless the user explicitly requested one with
+    // -n/--new-instance or pointed to a different base directory with -c.
 
-    if((!rslink.empty() || !rsfile.empty() || !links_and_files.empty() || !conf.opModeStr.empty()) && notifyRunningInstance())
+    if(!conf.newInstance && conf.optBaseDir.empty() && notifyRunningInstance())
     {
         QStringList args;
-        RsErr() << "Sending rscollection files, retroshare links and opmode parameters to the runnning retroshare server." ;
+        RsErr() << "RetroShare is already running. Sending arguments to the running instance and exiting." ;
 
         if(!rslink.empty()) { args.push_back("-l"); args.push_back(QString::fromUtf8(rslink.c_str())); }
         if(!rsfile.empty()) { args.push_back("-f"); args.push_back(QString::fromUtf8(rsfile.c_str())); }

--- a/retroshare-gui/src/rshare.h
+++ b/retroshare-gui/src/rshare.h
@@ -50,10 +50,11 @@
 struct RsGUIConfigOptions: public RsConfigOptions
 {
     RsGUIConfigOptions()
-        : optResetParams(false), logLevel("Off"), argc(0)
+        : optResetParams(false), newInstance(false), logLevel("Off"), argc(0)
     {}
 
     bool optResetParams;		// reset all GUI parameters
+    bool newInstance;           // start a new instance even if one is already running
 
     QString dateformat;         // The format for dates in feed items etc.
     QString language;           // The current language.


### PR DESCRIPTION
When a RetroShare instance is already running, running the retroshare command again now hands the arguments over to that instance - or, when no arguments are given, simply asks it to show its main window - and then exits, instead of silently doing nothing.

A new -n/--new-instance command line option forces the start of a separate instance. Passing a different base directory with -c <dir> also still starts a separate instance for that profile.

Fixes #1225