### PR TITLE
fix(webui): make the front ends find the web UI files they ship with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,35 @@ endif()
 # 1. First add the core library (libretroshare)
 add_subdirectory(libretroshare)
 
-# 2. Then add the dependent executables
+# 2. The Web UI is data served by any front end, so it is built as soon as
+# RS_WEBUI is enabled. It used to be built as a side effect of adding
+# retroshare-service, which left a GUI only build (RS_SERVICE=OFF, the AppImage
+# configuration) with no web files generated at all. retroshare-service keeps
+# its own copy of this logic for standalone builds, guarded on the target not
+# existing yet.
+if(RS_WEBUI)
+	set(RS_WEBUI_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/retroshare-webui")
+
+	if(EXISTS "${RS_WEBUI_DEVEL_DIR}/CMakeLists.txt")
+		message(
+			STATUS
+			"RetroShare WebUI source found at ${RS_WEBUI_DEVEL_DIR} using it" )
+		add_subdirectory("${RS_WEBUI_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/webui")
+	endif()
+
+	# On Windows the WebUI CMakeLists defines no target, so drive the build
+	# script through a shell (MSYS2/MinGW) here.
+	if(NOT TARGET retroshare-webui)
+		add_custom_target(
+			retroshare-webui ALL
+			COMMAND sh ./build.sh
+			WORKING_DIRECTORY "${RS_WEBUI_DEVEL_DIR}/webui-src/make-src"
+			COMMENT "Compiling RetroShare WebUI"
+			SOURCES "${RS_WEBUI_DEVEL_DIR}/webui-src" )
+	endif()
+endif(RS_WEBUI)
+
+# 3. Then add the dependent executables
 if(RS_GUI)
 	add_subdirectory(retroshare-gui)
 	if(RS_PLUGINS)

--- a/build_scripts/OSX/deploy-macos.sh
+++ b/build_scripts/OSX/deploy-macos.sh
@@ -143,9 +143,15 @@ if [ -d "retroshare-gui/src/translations" ]; then
     find "retroshare-gui/src/translations" -name "*.qm" -exec cp {} "$APP_RESOURCES/translations/" \; 2>/dev/null || true
 fi
 
-if [ -d "retroshare-webui/src" ]; then
-    cp -r retroshare-webui/src/* "$APP_RESOURCES/webui/" 2>/dev/null || true
+# The generated web files live in retroshare-webui/webui (retroshare-webui/src
+# never existed, so this copy silently did nothing and shipped an empty webui
+# folder). Contents/Resources/webui is where libretroshare looks for them.
+if [ -d "retroshare-webui/webui" ]; then
+    cp -r retroshare-webui/webui/. "$APP_RESOURCES/webui/"
     echo "  WebUI copied to app resources."
+else
+    echo "  WARNING: retroshare-webui/webui not found, the bundle will ship no web interface."
+    echo "           Configure the build with -DRS_WEBUI=ON to generate it."
 fi
 
 # 6. Mise à jour du Info.plist

--- a/build_scripts/Windows-msys2/deploy-windows.sh
+++ b/build_scripts/Windows-msys2/deploy-windows.sh
@@ -340,12 +340,16 @@ fi
 
 # 10. Déploiement de la WebUI (si présente)
 echo ">>> Deploying WebUI static assets..."
-if [ -d "retroshare-webui/src" ]; then
+# The generated web files live in retroshare-webui/webui (retroshare-webui/src
+# never existed, so this copy silently did nothing). RetroShare looks for them
+# in ./webui relative to the executable, which is exactly $DEPLOY_DIR/webui.
+if [ -d "retroshare-webui/webui" ]; then
     mkdir -p "$DEPLOY_DIR/webui"
-    cp -r retroshare-webui/src/* "$DEPLOY_DIR/webui/" 2>/dev/null || true
+    cp -r retroshare-webui/webui/. "$DEPLOY_DIR/webui/"
     echo "  WebUI copied to deployment folder."
 else
-    echo "  WebUI source folder not found. Skipping WebUI packaging."
+    echo "  WARNING: retroshare-webui/webui not found, the archive will ship no web interface."
+    echo "           Configure the build with -DRS_WEBUI=ON to generate it."
 fi
 
 # 11. Création de l'archive finale (7z en priorité, zip en fallback)

--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -324,6 +324,13 @@ endif(RS_JSON_API)
 
 if(RS_WEBUI)
 	target_compile_definitions(${PROJECT_NAME} PRIVATE RS_WEBUI)
+
+	# The GUI serves the web files too, so it must wait for them to be generated
+	# (the target is created by the root CMakeLists, or by retroshare-service in
+	# a standalone build).
+	if(TARGET retroshare-webui)
+		add_dependencies(${PROJECT_NAME} retroshare-webui)
+	endif()
 endif(RS_WEBUI)
 
 ################################# CMark ########################################

--- a/retroshare-gui/src/gui/settings/rsharesettings.cpp
+++ b/retroshare-gui/src/gui/settings/rsharesettings.cpp
@@ -38,6 +38,7 @@
 #endif
 
 #include <retroshare/rspeers.h>
+#include <retroshare/rsinit.h>
 
 #ifdef Q_OS_WIN
 #	include <util/retroshareWin32.h>
@@ -1187,11 +1188,16 @@ void RshareSettings::setWebinterfaceEnabled(bool enabled)
 
 QString RshareSettings::getWebinterfaceFilesDirectory()
 {
-#ifdef WINDOWS_SYS
-	return valueFromGroup("Webinterface","directory","./webui/").toString();
-#else
-    return valueFromGroup("Webinterface","directory","/usr/share/retroshare/webui/").toString();
-#endif
+	/* The web UI files are shipped in the RetroShare data directory, which
+	 * libretroshare already locates per platform: the bundle Resources on
+	 * macOS, the executable directory on Windows, the install prefix (or the
+	 * relocated tree of an AppImage) on Linux. Hardcoding a path here instead
+	 * used to make the GUI look outside its own bundle. */
+	const QString defaultDirectory =
+	        QString::fromStdString(RsAccounts::systemDataDirectory(false))
+	        + "/webui/";
+
+	return valueFromGroup("Webinterface","directory",defaultDirectory).toString();
 }
 
 void RshareSettings::setWebinterfaceFilesDirectory(const QString& s)

--- a/retroshare-service/CMakeLists.txt
+++ b/retroshare-service/CMakeLists.txt
@@ -173,7 +173,9 @@ if(RS_SERVICE_TERMINAL_LOGIN)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_SERVICE_TERMINAL_LOGIN)
 endif(RS_SERVICE_TERMINAL_LOGIN)
 
-if(RS_WEBUI)
+if(RS_WEBUI AND NOT TARGET retroshare-webui)
+	# Only reached when retroshare-service is built standalone: in a super
+	# project build the root CMakeLists already created the target.
 	set(RS_WEBUI_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../retroshare-webui/")
 	get_filename_component(RS_WEBUI_DEVEL_DIR "${RS_WEBUI_DEVEL_DIR}" ABSOLUTE)
 	if(EXISTS "${RS_WEBUI_DEVEL_DIR}/CMakeLists.txt" )
@@ -206,7 +208,9 @@ if(RS_WEBUI)
 			SOURCES "${RS_WEBUI_DEVEL_DIR}/webui-src"
 		)
 	endif()
+endif()
 
+if(RS_WEBUI)
 	add_dependencies(${PROJECT_NAME} retroshare-webui)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_WEBUI)
 endif(RS_WEBUI)


### PR DESCRIPTION
Three defects made the web interface unreachable in packaged builds.

- The GUI overrode libretroshare's per-platform lookup at every startup with a hardcoded `/usr/share/retroshare/webui/` (`./webui/` on Windows), so a macOS bundle looked outside itself. The default now derives from `RsAccounts::systemDataDirectory()`, which already resolves `Contents/Resources` on macOS and the executable directory on Windows.

- The WebUI target was created by `retroshare-service/CMakeLists.txt`, so a GUI-only build (`RS_SERVICE=OFF`) generated no web files at all. It now lives in the root CMakeLists under `if(RS_WEBUI)` and both front ends depend on it. `retroshare-service` keeps its copy behind `NOT TARGET retroshare-webui` for standalone builds.

- `deploy-macos.sh` and `deploy-windows.sh` copied `retroshare-webui/src`, a path that never existed — the generated files are in `retroshare-webui/webui`. Errors went to `/dev/null`, so the macOS bundle silently shipped an empty `webui` folder.

Built and linked against unmodified libretroshare master (Linux, Qt5, Ninja). Standalone `retroshare-service` configure still produces the WebUI target.

Existing profiles keep the directory stored in their `RetroShare.conf`; the new default only applies to fresh ones.
