### PR TITLE
Chat rooms: fix unread message tracking and show the counters in the tree

### DIFF
--- a/retroshare-gui/src/gui/ChatLobbyWidget.cpp
+++ b/retroshare-gui/src/gui/ChatLobbyWidget.cpp
@@ -330,6 +330,29 @@ void ChatLobbyWidget::updateNotify(ChatLobbyId id, unsigned int count)
  * when it has unread messages, so that a collapsed branch still tells that something
  * is waiting inside.
  */
+/*!
+ * \brief Put an item of the room tree in bold, or back to normal.
+ *
+ * The tree itself carries the font size taken from the settings (see FontSizeHandler),
+ * but QTreeWidgetItem::font() returns a default constructed font when the item has no
+ * Qt::FontRole yet, and RSElidedItemDelegate paints the item with the model font as is,
+ * without merging it into the font of the view. Deriving the bold font from the item
+ * would therefore shrink the whole list down to the application font. So derive it from
+ * the tree, and remove the role altogether when the item is not bold, so that it keeps
+ * following the font size of the settings.
+ */
+static void setItemBold(QTreeWidget *treeWidget, QTreeWidgetItem *item, bool bold)
+{
+	if(bold)
+	{
+		QFont font = treeWidget->font();
+		font.setBold(true);
+		item->setFont(COLUMN_NAME, font);
+	}
+	else
+		item->setData(COLUMN_NAME, Qt::FontRole, QVariant());
+}
+
 void ChatLobbyWidget::updateUnreadCounters()
 {
 	QTreeWidgetItem *branches[4] = { privateSubLobbyItem, publicSubLobbyItem, privateLobbyItem, publicLobbyItem };
@@ -366,9 +389,7 @@ void ChatLobbyWidget::updateUnreadCounters()
 
 			item->setText(COLUMN_NAME, unread ? QString("%1 [%2]").arg(name).arg(unread) : name);
 
-			QFont font = item->font(COLUMN_NAME);
-			font.setBold(unread > 0);
-			item->setFont(COLUMN_NAME, font);
+			setItemBold(ui.lobbyTreeWidget, item, unread > 0);
 		}
 
 		QString label = branch->data(COLUMN_NAME, ROLE_BASE_NAME).toString();
@@ -382,9 +403,7 @@ void ChatLobbyWidget::updateUnreadCounters()
 		branch->setText(COLUMN_NAME, label);
 		branch->setToolTip(COLUMN_NAME, branch_unread ? tr("%n unread message(s)", "", branch_unread) : QString());
 
-		QFont font = branch->font(COLUMN_NAME);
-		font.setBold(branch_unread > 0);
-		branch->setFont(COLUMN_NAME, font);
+		setItemBold(ui.lobbyTreeWidget, branch, branch_unread > 0);
 	}
 }
 

--- a/retroshare-gui/src/gui/ChatLobbyWidget.cpp
+++ b/retroshare-gui/src/gui/ChatLobbyWidget.cpp
@@ -69,6 +69,7 @@
 #define ROLE_PRIVACYLEVEL  Qt::UserRole + 3
 #define ROLE_AUTOSUBSCRIBE Qt::UserRole + 4
 #define ROLE_FLAGS         Qt::UserRole + 5
+#define ROLE_BASE_NAME     Qt::UserRole + 6	// name without the counters appended for display
 
 
 #define TYPE_FOLDER       0
@@ -173,6 +174,7 @@ ChatLobbyWidget::ChatLobbyWidget(QWidget *parent, Qt::WindowFlags flags)
 
     privateSubLobbyItem = new RSTreeWidgetItem(compareRole, TYPE_FOLDER);
     privateSubLobbyItem->setText(COLUMN_NAME, tr("Private Subscribed"));
+	privateSubLobbyItem->setData(COLUMN_NAME, ROLE_BASE_NAME, tr("Private Subscribed"));
 	privateSubLobbyItem->setData(COLUMN_NAME, ROLE_SORT, "1");
 	//	privateLobbyItem->setIcon(COLUMN_NAME, QIcon(IMAGE_PRIVATE));
     privateSubLobbyItem->setData(COLUMN_DATA, ROLE_PRIVACYLEVEL, CHAT_LOBBY_PRIVACY_LEVEL_PRIVATE);
@@ -180,6 +182,7 @@ ChatLobbyWidget::ChatLobbyWidget(QWidget *parent, Qt::WindowFlags flags)
 
 	publicSubLobbyItem = new RSTreeWidgetItem(compareRole, TYPE_FOLDER);
 	publicSubLobbyItem->setText(COLUMN_NAME, tr("Public Subscribed"));
+	publicSubLobbyItem->setData(COLUMN_NAME, ROLE_BASE_NAME, tr("Public Subscribed"));
 	publicSubLobbyItem->setData(COLUMN_NAME, ROLE_SORT, "2");
 	//	publicLobbyItem->setIcon(COLUMN_NAME, QIcon(IMAGE_PUBLIC));
     publicSubLobbyItem->setData(COLUMN_DATA, ROLE_PRIVACYLEVEL, CHAT_LOBBY_PRIVACY_LEVEL_PUBLIC);
@@ -187,6 +190,7 @@ ChatLobbyWidget::ChatLobbyWidget(QWidget *parent, Qt::WindowFlags flags)
 
 	privateLobbyItem = new RSTreeWidgetItem(compareRole, TYPE_FOLDER);
 	privateLobbyItem->setText(COLUMN_NAME, tr("Private"));
+	privateLobbyItem->setData(COLUMN_NAME, ROLE_BASE_NAME, tr("Private"));
 	privateLobbyItem->setData(COLUMN_NAME, ROLE_SORT, "3");
 	//	privateLobbyItem->setIcon(COLUMN_NAME, QIcon(IMAGE_PRIVATE));
     privateLobbyItem->setData(COLUMN_DATA, ROLE_PRIVACYLEVEL, CHAT_LOBBY_PRIVACY_LEVEL_PRIVATE);
@@ -194,6 +198,7 @@ ChatLobbyWidget::ChatLobbyWidget(QWidget *parent, Qt::WindowFlags flags)
 
 	publicLobbyItem = new RSTreeWidgetItem(compareRole, TYPE_FOLDER);
 	publicLobbyItem->setText(COLUMN_NAME, tr("Public"));
+	publicLobbyItem->setData(COLUMN_NAME, ROLE_BASE_NAME, tr("Public"));
 	publicLobbyItem->setData(COLUMN_NAME, ROLE_SORT, "4");
 	//	publicLobbyItem->setIcon(COLUMN_NAME, QIcon(IMAGE_PUBLIC));
     publicLobbyItem->setData(COLUMN_DATA, ROLE_PRIVACYLEVEL, CHAT_LOBBY_PRIVACY_LEVEL_PUBLIC);
@@ -291,6 +296,15 @@ UserNotify *ChatLobbyWidget::createUserNotify(QObject *parent)
 
 void ChatLobbyWidget::updateNotify(ChatLobbyId id, unsigned int count)
 {
+	// Keep the per room unread count, so that the tree can show it on the room and
+	// on its parent branch. Do this before any early return below.
+	if (count)
+		_unread_counts[id] = count;
+	else
+		_unread_counts.erase(id);
+
+	updateUnreadCounters();
+
 	ChatLobbyDialog *dialog=NULL;
 	dialog=_lobby_infos[id].dialog;
 	if(!dialog) return;
@@ -304,6 +318,73 @@ void ChatLobbyWidget::updateNotify(ChatLobbyId id, unsigned int count)
 		notifyButton->setToolTip(QString("(%1)").arg(count));
 	} else {
 		notifyButton->setVisible(false);
+	}
+}
+
+/*!
+ * \brief Refresh the counters displayed in the room tree.
+ *
+ * Each room shows "[n]" when it holds n unread messages, and each branch shows the
+ * number of rooms it contains "(n)" plus the total of unread messages of its rooms
+ * "[n]". Counters that would be zero are simply omitted, and the item is put in bold
+ * when it has unread messages, so that a collapsed branch still tells that something
+ * is waiting inside.
+ */
+void ChatLobbyWidget::updateUnreadCounters()
+{
+	QTreeWidgetItem *branches[4] = { privateSubLobbyItem, publicSubLobbyItem, privateLobbyItem, publicLobbyItem };
+
+	for(int b=0; b<4; ++b)
+	{
+		QTreeWidgetItem *branch = branches[b];
+
+		if(branch == NULL)
+			continue;
+
+		unsigned int branch_unread = 0;
+		int room_count = 0;
+
+		for(int c=0; c<branch->childCount(); ++c)
+		{
+			QTreeWidgetItem *item = branch->child(c);
+
+			if(item->type() != TYPE_LOBBY)
+				continue;
+
+			++room_count;
+
+			ChatLobbyId id = item->data(COLUMN_DATA, ROLE_ID).toULongLong();
+			std::map<ChatLobbyId,unsigned int>::const_iterator it = _unread_counts.find(id);
+			unsigned int unread = (it == _unread_counts.end()) ? 0 : it->second;
+
+			branch_unread += unread;
+
+			QString name = item->data(COLUMN_NAME, ROLE_BASE_NAME).toString();
+
+			if(name.isEmpty())	// item not filled by updateItem() yet
+				continue;
+
+			item->setText(COLUMN_NAME, unread ? QString("%1 [%2]").arg(name).arg(unread) : name);
+
+			QFont font = item->font(COLUMN_NAME);
+			font.setBold(unread > 0);
+			item->setFont(COLUMN_NAME, font);
+		}
+
+		QString label = branch->data(COLUMN_NAME, ROLE_BASE_NAME).toString();
+
+		if(room_count > 0)
+			label += QString(" (%1)").arg(room_count);
+
+		if(branch_unread > 0)
+			label += QString(" [%1]").arg(branch_unread);
+
+		branch->setText(COLUMN_NAME, label);
+		branch->setToolTip(COLUMN_NAME, branch_unread ? tr("%n unread message(s)", "", branch_unread) : QString());
+
+		QFont font = branch->font(COLUMN_NAME);
+		font.setBold(branch_unread > 0);
+		branch->setFont(COLUMN_NAME, font);
 	}
 }
 
@@ -418,6 +499,9 @@ static void updateItem(QTreeWidget *treeWidget, QTreeWidgetItem *item, ChatLobby
 {
 	item->setText(COLUMN_NAME, QString::fromUtf8(name.c_str()));
 	item->setData(COLUMN_NAME, ROLE_SORT, QString::fromUtf8(name.c_str()));
+	// Keep the bare name aside: the displayed text gets an unread counter appended by
+	// ChatLobbyWidget::updateUnreadCounters(), which needs to rebuild it from scratch.
+	item->setData(COLUMN_NAME, ROLE_BASE_NAME, QString::fromUtf8(name.c_str()));
 
 	if(topic.empty())
 	{
@@ -760,9 +844,10 @@ void ChatLobbyWidget::updateDisplay()
         }
 	}
 	publicSubLobbyItem->setHidden(publicSubLobbyItem->childCount()==0);
-	publicSubLobbyItem->setText(COLUMN_NAME, tr("Public Subscribed")+ QString(" (") + QString::number(publicSubLobbyItem->childCount())+QString(")"));
 	privateSubLobbyItem->setHidden(privateSubLobbyItem->childCount()==0);
-	publicLobbyItem->setText(COLUMN_NAME, tr("Public")+ " (" + QString::number(publicLobbyItem->childCount())+QString(")"));
+
+	// re-append the counters, since updateItem() above has reset the room names
+	updateUnreadCounters();
 }
 
 void ChatLobbyWidget::createChatLobby()
@@ -1002,7 +1087,7 @@ void ChatLobbyWidget::copyItemLink()
 	}
 
 	ChatLobbyId id = item->data(COLUMN_DATA, ROLE_ID).toULongLong();
-	QString name = item->text(COLUMN_NAME);
+	QString name = item->data(COLUMN_NAME, ROLE_BASE_NAME).toString();	// without the unread counter
 
 	RetroShareLink link = RetroShareLink::createChatRoom(ChatId(id),name);
 	if (link.valid()) {

--- a/retroshare-gui/src/gui/ChatLobbyWidget.h
+++ b/retroshare-gui/src/gui/ChatLobbyWidget.h
@@ -121,6 +121,8 @@ private:
 
 	bool filterItem(QTreeWidgetItem *item, const QString &text, int filterColumn);
 
+	void updateUnreadCounters();
+
 	RSTreeWidgetItemCompareRole *compareRole;
 	QTreeWidgetItem *privateLobbyItem;
 	QTreeWidgetItem *publicLobbyItem;
@@ -131,6 +133,8 @@ private:
 	ChatTabWidget *tabWidget ;
 
 	std::map<ChatLobbyId,ChatLobbyInfoStruct> _lobby_infos ;
+
+	std::map<ChatLobbyId,unsigned int> _unread_counts ;	// unread messages per room, for the tree counters
 
 	std::map<QTreeWidgetItem*,time_t> _icon_changed_map ;
 

--- a/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
@@ -28,6 +28,7 @@
 
 #include "gui/ChatLobbyWidget.h"
 #include "gui/MainWindow.h"
+#include "util/rsdebug.h"
 #include "gui/SoundManager.h"
 #include "gui/settings/rsharesettings.h"
 #include "util/DateTime.h"
@@ -140,7 +141,7 @@ QString ChatLobbyUserNotify::getTrayMessage(bool plural)
 
 QString ChatLobbyUserNotify::getNotifyMessage(bool plural)
 {
-	return plural ? tr("%1 mentions") : tr("%1 mention");
+	return plural ? tr("%1 messages") : tr("%1 message");
 }
 
 void ChatLobbyUserNotify::iconClicked()
@@ -303,12 +304,13 @@ void ChatLobbyUserNotify::chatLobbyNewMessage(ChatLobbyId lobby_id, QDateTime ti
 		}
 
 	if ((bGetNickName || bFoundTextToNotify || _bCountUnRead)){
-		QString strAnchor = DateTime::formatDateTime(time);
+		QString strAnchor = DateTime::formatDate(time.date()) + " " + time.time().toString("HH:mm:ss");
 		MsgData msgData;
 		msgData.text=RsHtml::plainText(senderName) + ": " + msg;
 		msgData.unread=!(bGetNickName || bFoundTextToNotify);
 
 		_listMsg[lobby_id][strAnchor]=msgData;
+		RsDbg() << "CHATCOUNT: Incrementing count for lobby=" << lobby_id << " author='" << senderName.toStdString() << "' anchor='" << strAnchor.toStdString() << "' count=" << _listMsg[lobby_id].size() << std::endl;
 		emit countChanged(lobby_id, _listMsg[lobby_id].size());
 		updateIcon();
 		SoundManager::play(SOUND_NEW_LOBBY_MESSAGE);
@@ -339,12 +341,22 @@ void ChatLobbyUserNotify::chatLobbyCleared(ChatLobbyId lobby_id, QString anchor,
 	lobby_map::iterator itCL=_listMsg.find(lobby_id);
 	if (itCL!=_listMsg.end()) {
 		if (!anchor.isEmpty()) {
+			RsDbg() << "CHATCOUNT: Received clear request for anchor='" << anchor.toStdString() << "' from lobby=" << lobby_id << std::endl;
 			msg_map::iterator itMsg=itCL->second.find(anchor);
 			if (itMsg!=itCL->second.end()) {
 				MsgData msgData = itMsg->second;
 				if(!onlyUnread || msgData.unread) {
 					itCL->second.erase(itMsg);
+					RsDbg() << "CHATCOUNT: Successfully erased anchor from map. New count=" << itCL->second.size() << std::endl;
 					changed=true;
+				}
+			} else {
+				// Help debug non-cleared messages by revealing that the search key did not match stored keys.
+				// We skip printing for non-date anchors like "PERSONID:" to avoid spam.
+				if (!anchor.startsWith("PERSONID:")) {
+					RsDbg() << "CHATCOUNT: Failed to find anchor='" << anchor.toStdString() << "' in list. List keys: ";
+					for(auto const& item : itCL->second) RsDbg() << "'" << item.first.toStdString() << "', ";
+					RsDbg() << std::endl;
 				}
 			}
 			count = itCL->second.size();

--- a/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
+++ b/retroshare-gui/src/gui/chat/ChatLobbyUserNotify.cpp
@@ -29,6 +29,15 @@
 #include "gui/ChatLobbyWidget.h"
 #include "gui/MainWindow.h"
 #include "util/rsdebug.h"
+
+// Set to 1 to trace chat unread-count bookkeeping to stderr (development diagnostics).
+#define DEBUG_CHAT_UNREAD_COUNT 0
+#if DEBUG_CHAT_UNREAD_COUNT
+#  define CHATCOUNT_DBG RsDbg()
+#else
+#  define CHATCOUNT_DBG while(false) RsDbg()
+#endif
+
 #include "gui/SoundManager.h"
 #include "gui/settings/rsharesettings.h"
 #include "util/DateTime.h"
@@ -310,7 +319,7 @@ void ChatLobbyUserNotify::chatLobbyNewMessage(ChatLobbyId lobby_id, QDateTime ti
 		msgData.unread=!(bGetNickName || bFoundTextToNotify);
 
 		_listMsg[lobby_id][strAnchor]=msgData;
-		RsDbg() << "CHATCOUNT: Incrementing count for lobby=" << lobby_id << " author='" << senderName.toStdString() << "' anchor='" << strAnchor.toStdString() << "' count=" << _listMsg[lobby_id].size() << std::endl;
+		CHATCOUNT_DBG << "CHATCOUNT: Incrementing count for lobby=" << lobby_id << " author='" << senderName.toStdString() << "' anchor='" << strAnchor.toStdString() << "' count=" << _listMsg[lobby_id].size() << std::endl;
 		emit countChanged(lobby_id, _listMsg[lobby_id].size());
 		updateIcon();
 		SoundManager::play(SOUND_NEW_LOBBY_MESSAGE);
@@ -341,22 +350,22 @@ void ChatLobbyUserNotify::chatLobbyCleared(ChatLobbyId lobby_id, QString anchor,
 	lobby_map::iterator itCL=_listMsg.find(lobby_id);
 	if (itCL!=_listMsg.end()) {
 		if (!anchor.isEmpty()) {
-			RsDbg() << "CHATCOUNT: Received clear request for anchor='" << anchor.toStdString() << "' from lobby=" << lobby_id << std::endl;
+			CHATCOUNT_DBG << "CHATCOUNT: Received clear request for anchor='" << anchor.toStdString() << "' from lobby=" << lobby_id << std::endl;
 			msg_map::iterator itMsg=itCL->second.find(anchor);
 			if (itMsg!=itCL->second.end()) {
 				MsgData msgData = itMsg->second;
 				if(!onlyUnread || msgData.unread) {
 					itCL->second.erase(itMsg);
-					RsDbg() << "CHATCOUNT: Successfully erased anchor from map. New count=" << itCL->second.size() << std::endl;
+					CHATCOUNT_DBG << "CHATCOUNT: Successfully erased anchor from map. New count=" << itCL->second.size() << std::endl;
 					changed=true;
 				}
 			} else {
 				// Help debug non-cleared messages by revealing that the search key did not match stored keys.
 				// We skip printing for non-date anchors like "PERSONID:" to avoid spam.
 				if (!anchor.startsWith("PERSONID:")) {
-					RsDbg() << "CHATCOUNT: Failed to find anchor='" << anchor.toStdString() << "' in list. List keys: ";
-					for(auto const& item : itCL->second) RsDbg() << "'" << item.first.toStdString() << "', ";
-					RsDbg() << std::endl;
+					CHATCOUNT_DBG << "CHATCOUNT: Failed to find anchor='" << anchor.toStdString() << "' in list. List keys: ";
+					for(auto const& item : itCL->second) CHATCOUNT_DBG << "'" << item.first.toStdString() << "', ";
+					CHATCOUNT_DBG << std::endl;
 				}
 			}
 			count = itCL->second.size();

--- a/retroshare-gui/src/gui/chat/ChatStyle.cpp
+++ b/retroshare-gui/src/gui/chat/ChatStyle.cpp
@@ -375,7 +375,7 @@ QString ChatStyle::formatMessage(enumFormatMessage type
 
 	QString strName = RsHtml::plainText(name).prepend(QString("<a name=\"name\">")).append(QString("</a>"));
 	QString strDate = DateTime::formatDate(timestamp.date()).prepend(QString("<a name=\"date\">")).append(QString("</a>"));
-	QString strTime = DateTime::formatTime(timestamp.time()).prepend(QString("<a name=\"time\">")).append(QString("</a>"));
+	QString strTime = timestamp.time().toString("HH:mm:ss").prepend(QString("<a name=\"time\">")).append(QString("</a>"));
 
 	int bi = name.lastIndexOf(QRegularExpression(" \\(.*\\)")); //trim location from the end
 	QString strShortName = RsHtml::plainText(name.left(bi)).prepend(QString("<a name=\"name\">")).append(QString("</a>"));

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -38,6 +38,7 @@
 #include "util/HandleRichText.h"
 #include "gui/chat/ChatUserNotify.h"//For BradCast
 #include "util/DateTime.h"
+#include "util/rsdebug.h"
 #include "util/imageutil.h"
 #include "util/qtthreadsutils.h"
 #include "gui/im_history/ImHistoryBrowser.h"
@@ -57,7 +58,11 @@
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QStringListModel>
+#include <QAbstractTextDocumentLayout>
 #include <QTextCodec>
+#include <QTextDocument>
+#include <QTextBlock>
+#include <QTextFragment>
 #include <QTextDocumentFragment>
 #include <QTextStream>
 #include <QTimer>
@@ -158,6 +163,7 @@ ChatWidget::ChatWidget(QWidget *parent)
 	connect(ui->attachPictureButton, SIGNAL(clicked()), this, SLOT(addExtraPicture()));
 	connect(ui->addFileButton, SIGNAL(clicked()), this , SLOT(addExtraFile()));
 	connect(ui->sendButton, SIGNAL(clicked()), this, SLOT(sendChat()));
+	connect(ui->textBrowser->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(checkVisibleAnchors()), Qt::QueuedConnection);
 
 	connect(ui->actionSaveChatHistory, SIGNAL(triggered()), this, SLOT(fileSaveAs()));
 	connect(ui->actionClearChatHistory, SIGNAL(triggered()), this, SLOT(clearChatHistory()));
@@ -578,39 +584,6 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 			}
 		}
 
-		if (notify && chatType() == CHATTYPE_LOBBY) {
-			if ((event->type() == QEvent::KeyPress)
-			    || (event->type() == QEvent::MouseMove)
-			    || (event->type() == QEvent::Enter)
-			    || (event->type() == QEvent::Leave)
-			    || (event->type() == QEvent::Wheel)
-			    || (event->type() == QEvent::ToolTip) ) {
-
-				QTextCursor cursor = ui->textBrowser->cursorForPosition(QPoint(0, 0));
-				QPoint bottom_right(ui->textBrowser->viewport()->width() - 1, ui->textBrowser->viewport()->height() - 1);
-				int end_pos = ui->textBrowser->cursorForPosition(bottom_right).position();
-				cursor.setPosition(end_pos, QTextCursor::KeepAnchor);
-				if ((cursor.position() != lastUpdateCursorPos || cursor.selectionEnd() != lastUpdateCursorEnd) &&
-				   !cursor.selectedText().isEmpty()) {
-					lastUpdateCursorPos = cursor.position();
-					lastUpdateCursorEnd = cursor.selectionEnd();
-					QRegExp rx("<a name=\"(.*)\"",Qt::CaseSensitive, QRegExp::RegExp2);
-					rx.setMinimal(true);
-					QString sel=cursor.selection().toHtml();
-					QStringList anchors;
-					int pos=0;
-					while ((pos = rx.indexIn(sel,pos)) != -1) {
-						anchors << rx.cap(1);
-						pos += rx.matchedLength();
-					}
-					if (!anchors.isEmpty()){
-						for (QStringList::iterator it=anchors.begin();it!=anchors.end();++it) {
-							notify->chatLobbyCleared(chatId.toLobbyId(), *it);
-						}
-					}
-				}
-			}
-		}
 	}
 
     if (obj == ui->textBrowser) {
@@ -793,6 +766,67 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 	return QWidget::eventFilter(obj, event);
 }
 
+void ChatWidget::checkVisibleAnchors()
+{
+	RsDbg() << "CHATCOUNT: Scroll Event Fired. ActiveWindow=" << isActive() << " ScrollValue=" << ui->textBrowser->verticalScrollBar()->value() << std::endl;
+	if (notify && chatType() == CHATTYPE_LOBBY && isActive()) {
+		QTextDocument *doc = ui->textBrowser->document();
+		if (!doc || doc->isEmpty()) return;
+		
+		// RACE CONDITION SHIELD: If layout engine is not initialized or reports zero height, 
+		// everything will erroneously appear to fit on screen. Force abort and wait for next cycle.
+		qreal totalH = doc->documentLayout()->documentSize().height();
+		if (totalH <= 0) return;
+
+		int viewH = ui->textBrowser->viewport()->height();
+		int vScroll = ui->textBrowser->verticalScrollBar()->value();
+		QStringList visibleAnchors;
+
+		QRegExp rx("<a name=\"(.*)\"", Qt::CaseSensitive, QRegExp::RegExp2);
+		rx.setMinimal(true);
+
+		for (QTextBlock block = doc->begin(); block.isValid(); block = block.next()) {
+			// Acquire absolute document geometry coordinates, 100% race-free and stable!
+			QRectF blockRect = doc->documentLayout()->blockBoundingRect(block);
+			
+			// Project raw document coordinates into physical visual viewport coordinates
+			qreal vTop = blockRect.top() - vScroll;
+			qreal vBottom = blockRect.bottom() - vScroll;
+			
+			if (vTop > viewH) {
+				break; // Block is physically below visible horizon. Halt search!
+			}
+			
+			if (vBottom < 0) {
+				continue; // Block is physically above visible horizon. Skip!
+			}
+			
+			// THIS BLOCK IS PHYSICALLY VISIBLE! Extract anchor using PROVEN Regex parser!
+			QTextCursor bCursor(block);
+			bCursor.select(QTextCursor::BlockUnderCursor);
+			QString blockHtml = bCursor.selection().toHtml();
+
+			int pos = 0;
+			while ((pos = rx.indexIn(blockHtml, pos)) != -1) {
+				QString name = rx.cap(1);
+				if (!name.isEmpty()) {
+					visibleAnchors << name;
+				}
+				pos += rx.matchedLength();
+			}
+		}
+		
+		visibleAnchors.removeDuplicates();
+		
+		if (!visibleAnchors.isEmpty()){
+			RsDbg() << "CHATCOUNT: Success! Found " << visibleAnchors.size() << " visible anchors in the active viewport." << std::endl;
+			for (const QString &anchor : visibleAnchors) {
+				notify->chatLobbyCleared(chatId.toLobbyId(), anchor);
+			}
+		}
+	}
+}
+
 /**
  * @brief Utility function for completeNickname.
  */
@@ -964,6 +998,7 @@ void ChatWidget::showEvent(QShowEvent */*event*/)
 		QScrollBar *scrollbar2 = ui->textBrowser->verticalScrollBar();
 		scrollbar2->setValue(scrollbar2->maximum());
 	}
+	QTimer::singleShot(0, this, SLOT(checkVisibleAnchors()));
 }
 
 void ChatWidget::resizeEvent(QResizeEvent */*event*/)
@@ -976,6 +1011,7 @@ void ChatWidget::resizeEvent(QResizeEvent */*event*/)
 	// Workaround: now the scroll position is correct calculated
 	QScrollBar *scrollbar = ui->textBrowser->verticalScrollBar();
 	scrollbar->setValue(scrollbar->maximum());
+	QTimer::singleShot(0, this, SLOT(checkVisibleAnchors()));
 }
 
 void ChatWidget::addToParent(QWidget *newParent)
@@ -1105,7 +1141,7 @@ void ChatWidget::addChatMsg(bool incoming, const QString &name, const RsGxsId gx
 	QString formattedMessage = RsHtml().formatText(ui->textBrowser->document(), message, formatTextFlag, backgroundColor, desiredContrast, desiredMinimumFontSize);
 	QDateTime dtTimestamp=incoming ? sendTime : recvTime;
 	QString formatMsg = chatStyle.formatMessage(type, name, dtTimestamp, formattedMessage, formatFlag, backgroundColor);
-	QString timeStamp = DateTime::formatDateTime(dtTimestamp);
+	QString timeStamp = DateTime::formatDate(dtTimestamp.date()) + " " + dtTimestamp.time().toString("HH:mm:ss");
 
 	//replace Date and Time anchors
 	formatMsg.replace(QString("<a name=\"date\">"),QString("<a name=\"%1\">").arg(timeStamp));

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -775,15 +775,22 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 	return QWidget::eventFilter(obj, event);
 }
 
+/**
+ * @brief Clear the unread status of the messages currently displayed.
+ *
+ * Each message carries an anchor holding its timestamp. The blocks of the document
+ * are walked and their geometry compared to the viewport, so that only the messages
+ * really shown to the user are reported as read. Called on scroll, show and resize.
+ */
 void ChatWidget::checkVisibleAnchors()
 {
-	CHATCOUNT_DBG << "CHATCOUNT: Scroll Event Fired. ActiveWindow=" << isActive() << " ScrollValue=" << ui->textBrowser->verticalScrollBar()->value() << std::endl;
+	CHATCOUNT_DBG << "CHATCOUNT: check requested, active=" << isActive() << " scroll=" << ui->textBrowser->verticalScrollBar()->value() << std::endl;
 	if (notify && chatType() == CHATTYPE_LOBBY && isActive()) {
 		QTextDocument *doc = ui->textBrowser->document();
 		if (!doc || doc->isEmpty()) return;
-		
-		// RACE CONDITION SHIELD: If layout engine is not initialized or reports zero height, 
-		// everything will erroneously appear to fit on screen. Force abort and wait for next cycle.
+
+		// The layout may not be computed yet, in which case every block reports a null
+		// geometry and would look visible. Give up and wait for the next call.
 		qreal totalH = doc->documentLayout()->documentSize().height();
 		if (totalH <= 0) return;
 
@@ -795,22 +802,21 @@ void ChatWidget::checkVisibleAnchors()
 		rx.setMinimal(true);
 
 		for (QTextBlock block = doc->begin(); block.isValid(); block = block.next()) {
-			// Acquire absolute document geometry coordinates, 100% race-free and stable!
 			QRectF blockRect = doc->documentLayout()->blockBoundingRect(block);
-			
-			// Project raw document coordinates into physical visual viewport coordinates
+
+			// document coordinates -> viewport coordinates
 			qreal vTop = blockRect.top() - vScroll;
 			qreal vBottom = blockRect.bottom() - vScroll;
-			
+
 			if (vTop > viewH) {
-				break; // Block is physically below visible horizon. Halt search!
+				break;		// below the viewport: the next blocks are lower, stop here
 			}
-			
+
 			if (vBottom < 0) {
-				continue; // Block is physically above visible horizon. Skip!
+				continue;	// above the viewport
 			}
-			
-			// THIS BLOCK IS PHYSICALLY VISIBLE! Extract anchor using PROVEN Regex parser!
+
+			// visible block: collect the anchors it contains
 			QTextCursor bCursor(block);
 			bCursor.select(QTextCursor::BlockUnderCursor);
 			QString blockHtml = bCursor.selection().toHtml();
@@ -824,11 +830,11 @@ void ChatWidget::checkVisibleAnchors()
 				pos += rx.matchedLength();
 			}
 		}
-		
+
 		visibleAnchors.removeDuplicates();
-		
+
 		if (!visibleAnchors.isEmpty()){
-			CHATCOUNT_DBG << "CHATCOUNT: Success! Found " << visibleAnchors.size() << " visible anchors in the active viewport." << std::endl;
+			CHATCOUNT_DBG << "CHATCOUNT: " << visibleAnchors.size() << " anchors visible in the viewport" << std::endl;
 			for (const QString &anchor : visibleAnchors) {
 				notify->chatLobbyCleared(chatId.toLobbyId(), anchor);
 			}

--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -39,6 +39,15 @@
 #include "gui/chat/ChatUserNotify.h"//For BradCast
 #include "util/DateTime.h"
 #include "util/rsdebug.h"
+
+// Set to 1 to trace chat unread-count bookkeeping to stderr (development diagnostics).
+#define DEBUG_CHAT_UNREAD_COUNT 0
+#if DEBUG_CHAT_UNREAD_COUNT
+#  define CHATCOUNT_DBG RsDbg()
+#else
+#  define CHATCOUNT_DBG while(false) RsDbg()
+#endif
+
 #include "util/imageutil.h"
 #include "util/qtthreadsutils.h"
 #include "gui/im_history/ImHistoryBrowser.h"
@@ -768,7 +777,7 @@ bool ChatWidget::eventFilter(QObject *obj, QEvent *event)
 
 void ChatWidget::checkVisibleAnchors()
 {
-	RsDbg() << "CHATCOUNT: Scroll Event Fired. ActiveWindow=" << isActive() << " ScrollValue=" << ui->textBrowser->verticalScrollBar()->value() << std::endl;
+	CHATCOUNT_DBG << "CHATCOUNT: Scroll Event Fired. ActiveWindow=" << isActive() << " ScrollValue=" << ui->textBrowser->verticalScrollBar()->value() << std::endl;
 	if (notify && chatType() == CHATTYPE_LOBBY && isActive()) {
 		QTextDocument *doc = ui->textBrowser->document();
 		if (!doc || doc->isEmpty()) return;
@@ -819,7 +828,7 @@ void ChatWidget::checkVisibleAnchors()
 		visibleAnchors.removeDuplicates();
 		
 		if (!visibleAnchors.isEmpty()){
-			RsDbg() << "CHATCOUNT: Success! Found " << visibleAnchors.size() << " visible anchors in the active viewport." << std::endl;
+			CHATCOUNT_DBG << "CHATCOUNT: Success! Found " << visibleAnchors.size() << " visible anchors in the active viewport." << std::endl;
 			for (const QString &anchor : visibleAnchors) {
 				notify->chatLobbyCleared(chatId.toLobbyId(), anchor);
 			}

--- a/retroshare-gui/src/gui/chat/ChatWidget.h
+++ b/retroshare-gui/src/gui/chat/ChatWidget.h
@@ -209,6 +209,7 @@ private slots:
 	void quote();
 	void dropPlacemark();
 	void saveSticker();
+	void checkVisibleAnchors();
 
 private:
 	bool findText(const QString& qsStringToFind);


### PR DESCRIPTION
Unread messages of chat rooms were badly tracked and barely visible.

Defects

- Messages were cleared as "read" from a text cursor selection rebuilt on key/mouse/wheel/tooltip events in `eventFilter()`. The selection often covered the wrong range (or nothing), so counters stayed up while the messages had been on screen for a long time.
- Anchors identifying a message are its formatted timestamp, which had a one minute resolution: several messages sent in the same minute shared a single key, and only one of them could ever be cleared.
- The room tree only signalled unread messages with a changed icon, the count itself being buried in the tooltip of the notify button inside the room. Branch labels were inconsistent: only "Public Subscribed" and "Public" carried a room count, the two private ones carried none.

Changes

- `ChatWidget`: replace the event-filter cursor heuristic by `checkVisibleAnchors()`, which walks the document blocks and compares `blockBoundingRect()` with the viewport rectangle to know what is actually displayed. It runs on `verticalScrollBar::valueChanged`, on show and on resize, and only when the chat window is active.
- Give the timestamps used as anchors a seconds precision (`ChatStyle::formatMessage`, `ChatWidget::addChatMsg`, `ChatLobbyUserNotify::chatLobbyNewMessage`) so that each message owns a distinct key.
- `ChatLobbyWidget`: rooms now display `[n]` when they hold n unread messages, and each branch displays the number of rooms it holds `(n)` followed by the total of unread messages of its rooms `[n]`. Zero counters are omitted and items with unread messages go bold, so that a collapsed branch still shows what waits inside. The bare room name is kept in a new `ROLE_BASE_NAME` data role, since `updateDisplay()` rebuilds the name text every 5 seconds; `copyItemLink()` reads that role too, so the counter never leaks into a `retroshare://` chat room link.
- `ChatLobbyUserNotify::getNotifyMessage()`: "%1 mentions" -> "%1 messages", the counter counts messages, not only mentions.
- The CHATCOUNT development traces are kept but gated behind `DEBUG_CHAT_UNREAD_COUNT`, off by default.

GUI only, no protocol or library change.
