### PR TITLE
gui: let RSElidedItemDelegate inherit the view font from the model font

### DIFF
--- a/retroshare-gui/src/gui/common/RSElidedItemDelegate.cpp
+++ b/retroshare-gui/src/gui/common/RSElidedItemDelegate.cpp
@@ -137,9 +137,13 @@ void RSElidedItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 		td.setHtml(ownOption.text);
 		ownOption.text = td.toPlainText();
 	}
-	// Get Font as option.font is not accurate
+	// Get Font as option.font is not accurate. Merge it into the font of the view instead
+	// of replacing it: a font stored in the model usually only sets a couple of attributes
+	// (bold, italic) and expects the rest (family, size) to be inherited from the view.
+	// QFont::resolve() keeps exactly what the model really set and takes the rest from the
+	// view, which is what QStyledItemDelegate::initStyleOption() does as well.
 	if (index.data(Qt::FontRole).type() == QVariant::Font) {
-		QFont font = index.data(Qt::FontRole).value<QFont>();
+		QFont font = index.data(Qt::FontRole).value<QFont>().resolve(ownOption.font);
 		ownOption.font = font;
 		ownOption.fontMetrics = QFontMetrics(font);
 #ifdef DEBUG_EID_PAINT
@@ -421,9 +425,9 @@ bool RSElidedItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
 							td.setHtml(ownOption.text);
 							ownOption.text = td.toPlainText();
 						}
-						//Get Font as option.font is not accurate
+						//Get Font as option.font is not accurate, merged into the one of the view (see paint())
 						if (index.data(Qt::FontRole).type() == QVariant::Font) {
-							QFont font = index.data(Qt::FontRole).value<QFont>();
+							QFont font = index.data(Qt::FontRole).value<QFont>().resolve(ownOption.font);
 							ownOption.font = font;
 							ownOption.fontMetrics = QFontMetrics(font);
 						}


### PR DESCRIPTION
`RSElidedItemDelegate` took the `Qt::FontRole` of the model and **assigned** it to the style option, replacing the font of the view instead of merging into it.

A font stored in a model usually carries only the attribute the caller wanted to change — most of the time bold — and expects family and size to keep coming from the view. Assigning it whole drops those items back to the **application font**, ignoring the font size configured in the settings, which `FontSizeHandler` puts on the view.

This is easy to trigger, since `QTreeWidgetItem::font()` returns a default constructed font when the item has no `Qt::FontRole` yet: the usual "read the font, set it bold, write it back" turns the whole list into the application font. Measured on a remote X display where the desktop font is 9pt while the RetroShare font size is 11pt, the affected list visibly shrank:

```
QApplication::font           = 9pt
view font (settings)         = 11pt
item->font(col), no FontRole = 9pt      <- the trap
initStyleOption()            = 11pt bold   (what Qt does)
delegate before this patch   = 9pt bold    (what was painted)
delegate after this patch    = 11pt bold
```

The fix merges with `QFont::resolve()`, which keeps only the attributes the model really set and takes the rest from the view — the same merge `QStyledItemDelegate::initStyleOption()` already performs a few lines above. The comment "option.font is not accurate" dates back to 2016, when the code started from the raw view option; since `initStyleOption()` was introduced in 2020 the manual assignment only undoes that merge.

Same change in the tooltip path of `editorEvent()`, which recomputes the elision with that font. `sizeHint()` was already using the merged font from `initStyleOption()`, so rows were measured with one font and painted with another.

`QFont::resolve(const QFont&)` exists identically in Qt5 and Qt6.

Views using this delegate: chat rooms, identities, group tree (forums/channels/boards), friend list, forum threads, messages, comments, `RSComboBox`, settings. Note that `GroupTreeWidget` currently re-stamps the point size on every item when the font size setting changes — a workaround for this very bug, which becomes unnecessary (left untouched here).