### PR TITLE
Add hint when sending stickers

### DIFF
--- a/retroshare-gui/src/gui/chat/ChatWidget.cpp
+++ b/retroshare-gui/src/gui/chat/ChatWidget.cpp
@@ -1673,7 +1673,7 @@ void ChatWidget::sendSticker()
 	if(sendingBlocked) return;
 	QString sticker = qobject_cast<QPushButton*>(sender())->statusTip();
 	QString encodedImage;
-	if (RsHtml::makeEmbeddedImage(sticker, encodedImage, 640*480, maxMessageSize() - 200)) {		//-200 for the html stuff
+	if (RsHtml::makeEmbeddedImage(sticker, encodedImage, 640*480, maxMessageSize() - 200, "sticker")) {		//-200 for the html stuff
 		RsHtml::optimizeHtml(encodedImage, 0);
 		std::string msg = encodedImage.toUtf8().constData();
         rsChats->sendChat(chatId, msg);

--- a/retroshare-gui/src/util/HandleRichText.cpp
+++ b/retroshare-gui/src/util/HandleRichText.cpp
@@ -1211,7 +1211,7 @@ QString RsHtml::toHtml(QString text, bool realHtml)
 }
 
 /** Loads image and converts image to embedded image HTML fragment **/
-bool RsHtml::makeEmbeddedImage(const QString &fileName, QString &embeddedImage, const int maxPixels, const int maxBytes)
+bool RsHtml::makeEmbeddedImage(const QString &fileName, QString &embeddedImage, const int maxPixels, const int maxBytes, const QString &cssClass)
 {
 	QImage image;
 
@@ -1219,15 +1219,15 @@ bool RsHtml::makeEmbeddedImage(const QString &fileName, QString &embeddedImage, 
 		fprintf (stderr, "RsHtml::makeEmbeddedImage() - image \"%s\" can't be load\n", fileName.toLatin1().constData());
 		return false;
 	}
-    return RsHtml::makeEmbeddedImage(image, embeddedImage, maxPixels, maxBytes);
+    return RsHtml::makeEmbeddedImage(image, embeddedImage, maxPixels, maxBytes, cssClass);
 }
 
 /** Converts image to embedded image HTML fragment **/
-bool RsHtml::makeEmbeddedImage(const QImage &originalImage, QString &embeddedImage, const int maxPixels, const int maxBytes)
+bool RsHtml::makeEmbeddedImage(const QImage &originalImage, QString &embeddedImage, const int maxPixels, const int maxBytes, const QString &cssClass)
 {
 	rstime::RsScopeTimer s("Embed image");
 	QImage opt;
-    return ImageUtil::optimizeSizeHtml(embeddedImage, originalImage, opt, maxPixels, maxBytes);
+    return ImageUtil::optimizeSizeHtml(embeddedImage, originalImage, opt, maxPixels, maxBytes, cssClass);
 }
 
 QString RsHtml::plainText(const QString &text)

--- a/retroshare-gui/src/util/HandleRichText.h
+++ b/retroshare-gui/src/util/HandleRichText.h
@@ -69,9 +69,9 @@ public:
 	static void    optimizeHtml(QTextEdit *textEdit, QString &text, unsigned int flag = 0);
 	static void    optimizeHtml(QString &text, unsigned int flag = 0, const QColor &backgroundColor = Qt::white, qreal desiredContrast = 1.0, int desiredMinimumFontSize = 10);
 	static QString toHtml(QString text, bool realHtml = true);
+	static bool    makeEmbeddedImage(const QString &fileName, QString &embeddedImage, const int maxPixels, const int maxBytes = -1, const QString &cssClass = QString());
 
-	static bool    makeEmbeddedImage(const QString &fileName, QString &embeddedImage, const int maxPixels, const int maxBytes = -1);
-    static bool    makeEmbeddedImage(const QImage &originalImage, QString &embeddedImage, const int maxPixels, const int maxBytes = -1);
+    static bool    makeEmbeddedImage(const QImage &originalImage, QString &embeddedImage, const int maxPixels, const int maxBytes = -1, const QString &cssClass = QString());
 
 	static QString plainText(const QString &text);
 	static QString plainText(const std::string &text);

--- a/retroshare-gui/src/util/imageutil.cpp
+++ b/retroshare-gui/src/util/imageutil.cpp
@@ -260,7 +260,7 @@ bool ImageUtil::hasAlphaContent(const QImage& image)
     std::cerr << "Image of size " << image.width() << " x " << image.height() << ": No transparency content detected." << std::endl;
     return false;
 }
-bool ImageUtil::optimizeSizeHtml(QString &html, const QImage& original, QImage &optimized, int maxPixels, int maxBytes)
+bool ImageUtil::optimizeSizeHtml(QString &html, const QImage& original, QImage &optimized, int maxPixels, int maxBytes, const QString &cssClass)
 {
 	QByteArray bytearray;
 	if(maxBytes > 0){
@@ -274,7 +274,10 @@ bool ImageUtil::optimizeSizeHtml(QString &html, const QImage& original, QImage &
     if(optimizeSizeBytes(bytearray, original, optimized,has_transparency?"PNG":"JPG",maxPixels, maxBytes))
 	{
 		QByteArray encodedByteArray = bytearray.toBase64();
-		html = "<img src=\"data:image/";
+		html = "<img";
+		if (!cssClass.isEmpty())
+			html += " class=\"" + cssClass + "\"";
+		html += " src=\"data:image/";
 		html.append(has_transparency ? "png" : "jpeg");
 		html.append(";base64,");
 		html.append(encodedByteArray);

--- a/retroshare-gui/src/util/imageutil.h
+++ b/retroshare-gui/src/util/imageutil.h
@@ -38,7 +38,7 @@ public:
 	static void extractImage(QWidget *window, QTextCursor cursor, QString file = "");
 	static void copyImage(QWidget *window, QTextCursor cursor);
 	static bool saveImage(QWidget *window, const QImage &image, QString file = "");
-    static bool optimizeSizeHtml(QString &html, const QImage& original, QImage &optimized, int maxPixels = -1, int maxBytes = -1);
+    static bool optimizeSizeHtml(QString &html, const QImage& original, QImage &optimized, int maxPixels = -1, int maxBytes = -1, const QString &cssClass = QString());
     static bool optimizeSizeBytes(QByteArray &bytearray, const QImage &original, QImage &optimized, const char *format, int maxPixels, int maxBytes);
     static bool hasAlphaContent(const QImage& image);
 


### PR DESCRIPTION
When sending a sticker with a chat message, hint that the image is actually a sticker and not a normal image, so that it's possible to optimize the resizing on screen with different DPIs.

The receiving end just checks that the class contains "sticker" and can scale accordingly.