### PR TITLE
FeedReader: warn when the SOCKS proxy scheme resolves hostnames locally

### DIFF
--- a/plugins/FeedReader/gui/ProxyWidget.cpp
+++ b/plugins/FeedReader/gui/ProxyWidget.cpp
@@ -17,14 +17,19 @@ ProxyWidget::ProxyWidget(QWidget *parent)
 	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("HTTP Proxy."), Qt::ToolTipRole);
 	ui->schemeComboBox->addItem("HTTPS", "https://");
 	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("HTTPS Proxy."), Qt::ToolTipRole);
-	ui->schemeComboBox->addItem("SOCKS4", "socks4://");
-	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS4 Proxy."), Qt::ToolTipRole);
-	ui->schemeComboBox->addItem("SOCKS4a", "socks4a://");
-	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS4a Proxy. Proxy resolves URL hostname."), Qt::ToolTipRole);
-	ui->schemeComboBox->addItem("SOCKS5", "socks5://");
-	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS5 Proxy."), Qt::ToolTipRole);
-	ui->schemeComboBox->addItem("SOCKS5h", "socks5h://");
-	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS5 Proxy. Proxy resolves URL hostname."), Qt::ToolTipRole);
+	ui->schemeComboBox->addItem(tr("SOCKS4 (local DNS)"), "socks4://");
+	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS4 Proxy. Hostnames are resolved locally and leak to your DNS resolver."), Qt::ToolTipRole);
+	ui->schemeComboBox->addItem(tr("SOCKS4a (remote DNS)"), "socks4a://");
+	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS4a Proxy. Hostnames are resolved by the proxy."), Qt::ToolTipRole);
+	ui->schemeComboBox->addItem(tr("SOCKS5 (local DNS)"), "socks5://");
+	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS5 Proxy. Hostnames are resolved locally and leak to your DNS resolver."), Qt::ToolTipRole);
+	ui->schemeComboBox->addItem(tr("SOCKS5h (remote DNS, use with Tor)"), "socks5h://");
+	ui->schemeComboBox->setItemData(ui->schemeComboBox->count() - 1, tr("SOCKS5 Proxy. Hostnames are resolved by the proxy. Recommended with Tor."), Qt::ToolTipRole);
+
+	/* The warning only reflects the selected scheme, so it does not need to be
+	 * disconnected while the widget updates itself (unlike the "changed" signal). */
+	connect(ui->schemeComboBox, (void(QComboBox::*)(int))&QComboBox::currentIndexChanged, this, &ProxyWidget::updateWarning);
+	updateWarning();
 }
 
 ProxyWidget::~ProxyWidget()
@@ -91,6 +96,19 @@ int ProxyWidget::port()
 void ProxyWidget::setPort(int value)
 {
 	ui->portSpinBox->setValue(value);
+}
+
+void ProxyWidget::updateWarning()
+{
+	QString scheme = ui->schemeComboBox->currentData().toString();
+
+	if (scheme == "socks4://" || scheme == "socks5://") {
+		ui->warningLabel->setText(tr("Hostnames of the feeds will be resolved locally and leak to your DNS resolver. With Tor, use SOCKS5h (or SOCKS4a) instead."));
+		ui->warningLabel->show();
+	} else {
+		ui->warningLabel->clear();
+		ui->warningLabel->hide();
+	}
 }
 
 void ProxyWidget::addressChanged(const QString &value)

--- a/plugins/FeedReader/gui/ProxyWidget.h
+++ b/plugins/FeedReader/gui/ProxyWidget.h
@@ -26,6 +26,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
 	void addressChanged(const QString &value);
+	void updateWarning();
 
 private:
 	void connectUi(bool doConnect);

--- a/plugins/FeedReader/gui/ProxyWidget.ui
+++ b/plugins/FeedReader/gui/ProxyWidget.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>22</height>
+    <height>44</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true"/>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -27,22 +27,51 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QComboBox" name="schemeComboBox"/>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="addressLineEdit"/>
-   </item>
-   <item>
-    <widget class="QLabel" name="portLabel">
-     <property name="text">
-      <string notr="true">:</string>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>0</number>
      </property>
-    </widget>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QComboBox" name="schemeComboBox"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="addressLineEdit"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="portLabel">
+       <property name="text">
+        <string notr="true">:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="portSpinBox">
+       <property name="maximum">
+        <number>65535</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
-    <widget class="QSpinBox" name="portSpinBox">
-     <property name="maximum">
-      <number>65535</number>
+    <widget class="QLabel" name="warningLabel">
+     <property name="styleSheet">
+      <string notr="true">color: #b35a00;</string>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Problem

A tester configured the FeedReader proxy as `SOCKS5` pointing at Tor and got this on every fetch:

```
[warn] Your application (using socks5 to port 443) is giving Tor only an IP address.
Applications that do DNS resolves themselves may leak information.
Consider using Socks4A (e.g. via privoxy or socat) instead.
```

FeedReader hands the proxy string straight to libcurl (`CURLOPT_PROXY`). With a plain `socks4://` or `socks5://` scheme libcurl resolves the feed hostname itself through the system resolver and only sends the IP to the proxy, so every feed hostname leaks to clearnet DNS. Only `socks4a://` and `socks5h://` let the proxy (Tor) resolve the name.

The proxy code is correct; the problem is that nothing in the UI tells the user that "SOCKS5" is the leaky variant and "SOCKS5h" is the one to use with Tor (only a tooltip hinted at it).

## Fix (UI only, no behaviour change)

- Scheme combo entries renamed to say where the resolution happens: `SOCKS4 (local DNS)`, `SOCKS4a (remote DNS)`, `SOCKS5 (local DNS)`, `SOCKS5h (remote DNS, use with Tor)`, with matching tooltips.
- `ProxyWidget` now shows a warning line under the field whenever a local-DNS SOCKS scheme is selected: *Hostnames of the feeds will be resolved locally and leak to your DNS resolver. With Tor, use SOCKS5h (or SOCKS4a) instead.* The same widget is used by the FeedReader settings page and by the add-feed dialog, so both get it.
- The default (empty scheme = HTTP) is unchanged, and plain SOCKS4/SOCKS5 stay available for LAN proxies.

Built with CMake on Linux (Qt5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
