### PR TITLE
gui/main: fix non-Windows build, applicationFilePath declared under WINDOWS_SYS only

### DIFF
--- a/retroshare-gui/src/main.cpp
+++ b/retroshare-gui/src/main.cpp
@@ -299,6 +299,9 @@ QString filedialog_existing_directory_hook(QWidget *parent, const QString &capti
 
 int main(int argc, char *argv[])
 {
+    /* On Windows argv[0] does not always contain the full path, so the real
+       one is fetched below through QCoreApplication::applicationFilePath(). */
+    QString applicationFilePath = QString::fromLocal8Bit(argv[0]);
 #ifdef WINDOWS_SYS
     // The current directory of the application is changed when using the native dialog on Windows
     // This is a quick fix until libretroshare is using a absolute path in the portable Version
@@ -326,7 +329,6 @@ int main(int argc, char *argv[])
     qt_use_native_dialogs = false;
 #endif
 
-    QString applicationFilePath;
     {
         /* Set the current directory to the application dir,
            because the start dir with autostart from the registry run key is not the exe dir */


### PR DESCRIPTION
Since e63584843 ("Use QCoreApplication::applicationFilePath instead of argv[0]...", merged with #3281), `QString applicationFilePath;` is declared inside the `#ifdef WINDOWS_SYS` block at the top of `main()`, but is used unconditionally further down to fill `conf.main_executable_path`:

```
retroshare-gui/src/main.cpp:432:33: error: 'applicationFilePath' was not declared in this scope
```

So every Linux/macOS GUI build currently fails, while Windows builds are unaffected.

This moves the declaration to function scope, seeded from `argv[0]` (the previous non-Windows behaviour); Windows still overrides it with `QCoreApplication::applicationFilePath()` as e63584843 intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)