### PR TITLE
gui/cmake: skip the librnp static-deps link workaround with RS_SYSTEM_LIBRNP

### DIFF
--- a/retroshare-gui/CMakeLists.txt
+++ b/retroshare-gui/CMakeLists.txt
@@ -669,18 +669,25 @@ endif(RS_GXSCIRCLES)
 # because the statically-linked librnp does not propagate them. Ideally librnp
 # (or libretroshare) should export these as link-interface deps so consumers don't
 # have to repeat them; that belongs to libretroshare and is left as a follow-up.
-find_library(BOTAN_LIBRARY NAMES botan botan-3 botan-2 libbotan-3 libbotan-2 REQUIRED)
-
-if(WIN32)
-    # Robust resolution including RNP and sexpp inside the link group for Windows MinGW
-    target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,--start-group retroshare librnp sexpp z bz2 json-c ${BOTAN_LIBRARY} -Wl,--end-group)
-elseif(APPLE)
-    # macOS specific behavior: skip Linux-specific linker flags
-    target_link_libraries(${PROJECT_NAME} PRIVATE retroshare z bz2 json-c ${BOTAN_LIBRARY})
-else()
-    # Default behavior for Linux
+# When RS_SYSTEM_LIBRNP is ON (distribution builds, e.g. Debian) the system
+# librnp is a shared library that carries its own dependencies, so none of this
+# is needed — and botan development files may legitimately be absent.
+if(RS_SYSTEM_LIBRNP)
     target_link_libraries(${PROJECT_NAME} PRIVATE retroshare)
-    target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,--no-as-needed z bz2 json-c ${BOTAN_LIBRARY} -Wl,--as-needed)
+else()
+    find_library(BOTAN_LIBRARY NAMES botan botan-3 botan-2 libbotan-3 libbotan-2 REQUIRED)
+
+    if(WIN32)
+        # Robust resolution including RNP and sexpp inside the link group for Windows MinGW
+        target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,--start-group retroshare librnp sexpp z bz2 json-c ${BOTAN_LIBRARY} -Wl,--end-group)
+    elseif(APPLE)
+        # macOS specific behavior: skip Linux-specific linker flags
+        target_link_libraries(${PROJECT_NAME} PRIVATE retroshare z bz2 json-c ${BOTAN_LIBRARY})
+    else()
+        # Default behavior for Linux
+        target_link_libraries(${PROJECT_NAME} PRIVATE retroshare)
+        target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,--no-as-needed z bz2 json-c ${BOTAN_LIBRARY} -Wl,--as-needed)
+    endif()
 endif()
 
 if(RS_PLUGINS AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)


### PR DESCRIPTION
Super-project half of RetroShare/libretroshare#386.

The GUI manually re-links botan/json-c/z/bz2 because the vendored *static* librnp does not propagate its dependencies — and `find_library(BOTAN_LIBRARY ... REQUIRED)` makes botan development files mandatory even though the GUI never uses botan directly.

With `RS_SYSTEM_LIBRNP=ON` (the new option from libretroshare#386) the system librnp is a *shared* library carrying its own dependencies, so this workaround is skipped entirely. Found by building the Debian package in a clean sid container, where the configure aborted on the botan probe (no botan dev files installed — legitimately, since nothing needs them there).

Inert when the option is OFF (the default): the existing link logic is byte-for-byte unchanged.

Part of the groundwork for Debian packaging (Debian bug #659069).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
