### PR TITLE
🐞Fix: to use available screen geometry for toasters and fix stack spacing

### DIFF
--- a/retroshare-gui/src/gui/RsGUIEventManager.cpp
+++ b/retroshare-gui/src/gui/RsGUIEventManager.cpp
@@ -586,7 +586,7 @@ void RsGUIEventManager::startWaitingToasters()
 		/* Calculate positions */
 		QSize size = toaster->widget->size();
 
-		QRect desktopGeometry = RsApplication::primaryScreenGeometry();
+		QRect desktopGeometry = RsApplication::availablePrimaryScreenGeometry();
 
 		switch (toaster->position) {
 		case RshareSettings::TOASTERPOS_TOPLEFT:
@@ -681,7 +681,15 @@ void RsGUIEventManager::runningTick()
 		}
 
 		toaster->widget->move(newPos + diff);
-		diff += newPos - toaster->startPos;
+
+		int totalTravel = qAbs(toaster->endPos.y() - toaster->startPos.y());
+		if (totalTravel > 0) {
+			static const int TOASTER_SPACING = 10;
+			int currentTravel = qAbs(newPos.y() - toaster->startPos.y());
+			int pushDist = toaster->widget->height() + TOASTER_SPACING;
+			int direction = (toaster->endPos.y() < toaster->startPos.y()) ? -1 : 1;
+			diff.setY(diff.y() + direction * (currentTravel * pushDist / totalTravel));
+		}
 
 		QRect mask = QRect(0, 0, toaster->widget->width(), qAbs(toaster->startPos.y() - newPos.y()));
 		if (newPos.y() > toaster->startPos.y()) {

--- a/retroshare-gui/src/gui/settings/NotifyPage.ui
+++ b/retroshare-gui/src/gui/settings/NotifyPage.ui
@@ -371,7 +371,7 @@
                 </sizepolicy>
                </property>
                <property name="maximum">
-                <number>20</number>
+                <number>100</number>
                </property>
               </widget>
              </item>
@@ -384,7 +384,7 @@
                 </sizepolicy>
                </property>
                <property name="maximum">
-                <number>20</number>
+                <number>100</number>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
The bottom of the desktop is now the top of the taskbar, so even with the default value, the toaster sits cleanly above the taskbar.